### PR TITLE
feat: JaCoCoによる単体テストカバレッジ計測を追加

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -48,3 +48,10 @@ jobs:
         with:
           name: test-reports
           path: build/reports/tests/test/
+
+      - name: Upload coverage reports
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage-reports
+          path: build/reports/jacoco/test/html/

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -48,10 +48,3 @@ jobs:
         with:
           name: test-reports
           path: build/reports/tests/test/
-
-      - name: Upload coverage reports
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: coverage-reports
-          path: build/reports/jacoco/test/html/

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'java'
+    id 'jacoco'
     id 'org.springframework.boot' version '4.0.0'
     id 'io.spring.dependency-management' version '1.1.7'
 }
@@ -25,4 +26,13 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+    finalizedBy jacocoTestReport
+}
+
+jacocoTestReport {
+    dependsOn test
+    reports {
+        xml.required = true
+        html.required = true
+    }
 }


### PR DESCRIPTION
Closes #7

## 変更内容

- build.gradle に jacoco プラグインを追加
- テスト実行後に自動で JaCoCo レポート（XML・HTML）を生成
- cicd.yml へのアーティファクトアップロードステップは手動適用が必要

Generated with [Claude Code](https://claude.ai/code)