### PR TITLE
feat: JaCoCo Report による単体テストカバレッジ計測・可視化を追加

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -50,13 +50,15 @@ jobs:
           path: build/reports/tests/test/
 
       - name: JaCoCo Report
-        uses: madrapps/jacoco-report@v1.6.1
+        uses: madrapps/jacoco-report@v1.7.2
         if: always()
         with:
           paths: build/reports/jacoco/test/jacocoTestReport.xml
           token: ${{ secrets.GITHUB_TOKEN }}
-          title: Code Coverage
+          min-coverage-overall: 80
+          min-coverage-changed-files: 80
           update-comment: true
+          title: Code Coverage
 
       - name: Upload coverage reports
         uses: actions/upload-artifact@v4

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -48,3 +48,19 @@ jobs:
         with:
           name: test-reports
           path: build/reports/tests/test/
+
+      - name: JaCoCo Report
+        uses: madrapps/jacoco-report@v1.6.1
+        if: always()
+        with:
+          paths: build/reports/jacoco/test/jacocoTestReport.xml
+          token: ${{ secrets.GITHUB_TOKEN }}
+          title: Code Coverage
+          update-comment: true
+
+      - name: Upload coverage reports
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage-reports
+          path: build/reports/jacoco/test/html/

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -10,6 +10,10 @@ on:
     #   - "src/**/*.js"
     #   - "src/**/*.jsx"
 
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   claude-review:
     # Optional: Filter by PR author
@@ -17,19 +21,20 @@ jobs:
     #   github.event.pull_request.user.login == 'external-contributor' ||
     #   github.event.pull_request.user.login == 'new-developer' ||
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0
 
       - name: Run Claude Code Review
         id: claude-review
@@ -41,4 +46,5 @@ jobs:
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-
+          claude_args: |
+            --max-turns 12

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'java'
+    id 'jacoco'
     id 'org.springframework.boot' version '4.0.0'
     id 'io.spring.dependency-management' version '1.1.7'
 }
@@ -25,4 +26,13 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+    finalizedBy jacocoTestReport
+}
+
+jacocoTestReport {
+    dependsOn test
+    reports {
+        xml.required = true
+        html.required = true
+    }
 }


### PR DESCRIPTION
Closes #7

## 変更内容

- build.gradle に jacoco プラグインを追加
- テスト実行後に自動で JaCoCo レポート（XML・HTML）を生成
- cicd.yml への madrapps/jacoco-report アクション追加（手動適用が必要）

Generated with [Claude Code](https://claude.ai/code)