### PR TITLE
feat: NullAway と jspecify を導入して null 安全性を静的検証

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'jacoco'
     id 'org.springframework.boot' version '4.0.0'
     id 'io.spring.dependency-management' version '1.1.7'
+    id 'net.ltgt.errorprone' version '4.0.1'
 }
 
 group = 'xyz.dgz48'
@@ -21,7 +22,24 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'org.jspecify:jspecify'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    errorprone 'com.google.errorprone:error_prone_core:2.28.0'
+    errorprone 'com.uber.nullaway:nullaway:0.12.3'
+}
+
+tasks.named('compileJava') {
+    options.errorprone {
+        error('NullAway')
+        option('NullAway:AnnotatedPackages', 'xyz.dgz48')
+        option('NullAway:JSpecifyMode', 'true')
+    }
+}
+
+tasks.named('compileTestJava') {
+    options.errorprone {
+        disable('NullAway')
+    }
 }
 
 tasks.named('test') {

--- a/src/main/java/xyz/dgz48/tasks/webapi/package-info.java
+++ b/src/main/java/xyz/dgz48/tasks/webapi/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package xyz.dgz48.tasks.webapi;
+
+import org.jspecify.annotations.NullMarked;


### PR DESCRIPTION
Closes #10

## 変更内容
- NullAway + jspecify を build.gradle に追加（jspecify はバージョン省略）
- package-info.java で @NullMarked を適用
- 既存 CI (./gradlew test) で NullAway が自動検証される

Generated with [Claude Code](https://claude.ai/code)