### PR TITLE
Update CLAUDE code review workflow conditions

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,7 +21,7 @@ jobs:
     #   github.event.pull_request.user.login == 'external-contributor' ||
     #   github.event.pull_request.user.login == 'new-developer' ||
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-    if: github.event.pull_request.draft == false && github.event.pull_request.user.login != 'renovate[bot]'
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -41,6 +41,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: "claude[bot],renovate[bot]"
           prompt: |
             Please review this pull request and post your findings as a comment.
             Focus on: correctness, null safety, test coverage, and code quality.


### PR DESCRIPTION
Removed the check for 'renovate[bot]' in the condition for running the workflow and added allowed bots for the Claude review action.