### PR TITLE
fix(openapi): PATCH /api/tasks/{id}/visibility の 200 レスポンスに Task スキーマを追加

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -415,7 +415,11 @@ paths:
                   items: { type: integer, format: int64 }
                   description: "visibility=STAKEHOLDERS のとき指定。既存の関係者は置換される"
       responses:
-        "200": { description: OK }
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Task" }
         "400": { $ref: "#/components/responses/Validation" }
         "403": { $ref: "#/components/responses/Forbidden" }
         "404": { $ref: "#/components/responses/NotFound" }


### PR DESCRIPTION
closes #99

PATCH /api/tasks/{id}/visibility の 200 レスポンスボディが未定義だった問題を修正。`/status` と一貫性を保つため、更新後の Task オブジェクトを返すスキーマを追加。

Generated with [Claude Code](https://claude.ai/code)