### PR TITLE
fix(openapi): PUT /api/tenant/users/{userId}/role の 200 レスポンスに TenantUser スキーマを追加

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -238,7 +238,11 @@ paths:
               properties:
                 role: { type: string, enum: [TENANT_ADMIN, MEMBER] }
       responses:
-        "200": { description: OK }
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/TenantUser" }
         "403": { $ref: "#/components/responses/Forbidden" }
         "401": { $ref: "#/components/responses/Unauthorized" }
 


### PR DESCRIPTION
Closes #106

PUT /api/tenant/users/{userId}/role の 200 レスポンスに更新後の TenantUser スキーマを追加。PATCH /api/tasks/{id}/visibility (PR #115) と同じパターンで実装。

Generated with [Claude Code](https://claude.ai/code)