### PR TITLE
feat(openapi): GET /api/tasks の status クエリパラメータに enum 値を明示 (Issue #110)

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -28,7 +28,7 @@ info:
     - `403 Forbidden` — テナント越境、ロール権限不足、編集系で所有者でない 等
     - `404 Not Found` — リソース不在、または **参照系で参照権限不足**(リソース存在を漏らさない方針)
     - `500 Internal Server Error` — サーバー内部エラー
-  version: "1.3.1"
+  version: "1.3.2"
   contact:
     name: 開発チーム
     email: dev@example.com
@@ -264,7 +264,14 @@ paths:
       parameters:
         - { name: targetDate,     in: query, schema: { type: string, format: date }, description: "表示対象日(省略時は当日 TODAY)" }
         - { name: includeOverdue, in: query, schema: { type: boolean, default: true }, description: "期限切れ未完了タスクを含める" }
-        - { name: status,         in: query, schema: { type: string }, description: "カンマ区切りで複数指定可" }
+        - name: status
+          in: query
+          explode: false
+          description: "絞込ステータス(複数指定可、カンマ区切り: status=NOT_STARTED,IN_PROGRESS)"
+          schema:
+            type: array
+            items:
+              $ref: "#/components/schemas/TaskStatus"
         - { name: ownerId,        in: query, schema: { type: integer, format: int64 } }
         - { name: assigneeId,     in: query, schema: { type: integer, format: int64 } }
         - { name: priority,       in: query, schema: { type: string, enum: [HIGH, MEDIUM, LOW] } }

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -271,6 +271,7 @@ paths:
           description: "絞込ステータス(複数指定可、カンマ区切り: status=NOT_STARTED,IN_PROGRESS)"
           schema:
             type: array
+            minItems: 1
             items:
               $ref: "#/components/schemas/TaskStatus"
         - { name: ownerId,        in: query, schema: { type: integer, format: int64 } }

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -28,7 +28,7 @@ info:
     - `403 Forbidden` — テナント越境、ロール権限不足、編集系で所有者でない 等
     - `404 Not Found` — リソース不在、または **参照系で参照権限不足**(リソース存在を漏らさない方針)
     - `500 Internal Server Error` — サーバー内部エラー
-  version: "1.3.3"
+  version: "1.3.2"
   contact:
     name: 開発チーム
     email: dev@example.com

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -28,7 +28,7 @@ info:
     - `403 Forbidden` — テナント越境、ロール権限不足、編集系で所有者でない 等
     - `404 Not Found` — リソース不在、または **参照系で参照権限不足**(リソース存在を漏らさない方針)
     - `500 Internal Server Error` — サーバー内部エラー
-  version: "1.3.2"
+  version: "1.3.3"
   contact:
     name: 開発チーム
     email: dev@example.com
@@ -266,6 +266,7 @@ paths:
         - { name: includeOverdue, in: query, schema: { type: boolean, default: true }, description: "期限切れ未完了タスクを含める" }
         - name: status
           in: query
+          style: form
           explode: false
           description: "絞込ステータス(複数指定可、カンマ区切り: status=NOT_STARTED,IN_PROGRESS)"
           schema:
@@ -274,7 +275,7 @@ paths:
               $ref: "#/components/schemas/TaskStatus"
         - { name: ownerId,        in: query, schema: { type: integer, format: int64 } }
         - { name: assigneeId,     in: query, schema: { type: integer, format: int64 } }
-        - { name: priority,       in: query, schema: { type: string, enum: [HIGH, MEDIUM, LOW] } }
+        - { name: priority,       in: query, schema: { $ref: "#/components/schemas/Priority" } }
         - { name: visibility,     in: query, schema: { type: string, enum: [TENANT, STAKEHOLDERS, PRIVATE] } }
         - { name: keyword,        in: query, schema: { type: string }, description: "タイトル/説明部分一致" }
         - { name: page,           in: query, schema: { type: integer, default: 0 } }


### PR DESCRIPTION
Issue #110 の対応。

GET /api/tasks の status クエリパラメータを `type: string` から `type: array, items: $ref: TaskStatus` (`explode: false`) に変更。

Generated with [Claude Code](https://claude.ai/code)