### PR TITLE
chore(ci): claude-code-action を JST タイムゾーンで実行

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -24,6 +24,8 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    env:
+      TZ: Asia/Tokyo
     permissions:
       contents: read
       pull-requests: write
@@ -47,6 +49,7 @@ jobs:
             Focus on: correctness, null safety, test coverage, and code quality.
             Post the review result as a GitHub PR comment.
             Write all review comments in Japanese.
+            Treat all dates and times as Japan Standard Time (JST, UTC+9).
           claude_args: |
             --max-turns 20
             --allowed-tools Bash(gh pr comment *) Bash(gh pr view *) Bash(gh pr diff *) Bash(git diff *) Read Glob Grep LS

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -18,6 +18,8 @@ jobs:
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
+    env:
+      TZ: Asia/Tokyo
     permissions:
       contents: write
       pull-requests: write
@@ -47,4 +49,6 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           # claude_args: '--allowed-tools Bash(gh pr *)'
-          claude_args: '--allowed-tools Bash(gh pr *) Bash(gh issue *) Edit Write Read Bash(git *)'
+          claude_args: |
+            --allowed-tools Bash(gh pr *) Bash(gh issue *) Edit Write Read Bash(git *)
+            --append-system-prompt "Treat all dates and times as Japan Standard Time (JST, UTC+9)."


### PR DESCRIPTION
claude-code-action のジョブを JST で稼働させる。\n\n- 各ジョブに env: TZ: Asia/Tokyo\n- prompt / --append-system-prompt に「すべての日時は JST (UTC+9) で扱う」と明示\n\n対象: .github/workflows/claude.yml, .github/workflows/claude-code-review.yml