### PR TITLE
api(openapi): v1.4.4 — info.description 共通レスポンス補完 + Conflict/NotFound description 具体化 + AuditLog 補強 (Issues #127 #128 #173 #174)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -75,7 +75,7 @@ GitHub Actions (`cicd.yml`) runs `./gradlew check` on every push and PR, publish
 - 要件定義書: v1.4.2
 - 基本設計書: **v1.4.2** ← Single Source of Truth
 - 開発計画書: v1.2
-- OpenAPI: **v1.4.3**(27 operations / 26 schemas)
+- OpenAPI: **v1.4.4**(27 operations / 26 schemas)
 
 ### Multi-Tenancy(絶対不変)
 

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -592,7 +592,7 @@ paths:
           $ref: "#/components/responses/NotFound"
           description: |-
             タスクが存在しないか、当該ユーザーが**参照権限**を持たない(可視性チェック不通過によりリソース存在を秘匿、HTTP Status Policy / NIST AC-4)。
-            なお**公開範囲変更権限**(所有者のみ、Tenant Admin は強制変更可)不足の場合は 403 を返す(基本設計書 §6.2.1)。
+            なお**公開範囲変更権限**(所有者のみ)不足の場合は 403 を返す(基本設計書 §6.2.1)。
         "401": { $ref: "#/components/responses/Unauthorized" }
 
   # --- 関係者 ---
@@ -645,7 +645,7 @@ paths:
           $ref: "#/components/responses/NotFound"
           description: |-
             タスクが存在しないか、当該ユーザーが**参照権限**を持たない(可視性チェック不通過によりリソース存在を秘匿、HTTP Status Policy / NIST AC-4)。
-            なお**関係者追加権限**(所有者のみ、Tenant Admin は強制操作可)不足の場合は 403 を返す(基本設計書 §6.2.1)。
+            なお**関係者追加権限**(所有者のみ)不足の場合は 403 を返す(基本設計書 §6.2.1)。
         "409":
           $ref: "#/components/responses/Conflict"
           description: 指定ユーザーが既に同タスクの関係者として登録済み(重複追加)。
@@ -666,7 +666,7 @@ paths:
           $ref: "#/components/responses/NotFound"
           description: |-
             タスクが存在しないか、当該ユーザーが**参照権限**を持たない(可視性チェック不通過によりリソース存在を秘匿、HTTP Status Policy / NIST AC-4)。または対象ユーザーが当該タスクの関係者として登録されていない。
-            なお**関係者削除権限**(所有者のみ、Tenant Admin は強制操作可)不足の場合は 403 を返す(基本設計書 §6.2.1)。
+            なお**関係者削除権限**(所有者のみ)不足の場合は 403 を返す(基本設計書 §6.2.1)。
 
   # --- ダッシュボード ---
   /api/dashboard/summary:
@@ -1149,11 +1149,12 @@ components:
             - システム起因のバッチ処理(ShedLock 経由のスケジューラ等、人間の操作主体が存在しないイベント)
         action:
           type: string
+          minLength: 2
           pattern: "^[A-Z][A-Z0-9_]*$"
           description: |-
             監査対象の業務操作種別。命名規約は大文字始まり、英数字・アンダースコアのみ(設計規約 §2.5)。
             本フェーズで定義されている標準値(基本設計書 v1.4.2 §4.2.6):
-            `LOGIN` / `LOGIN_FAILED` / `CREATE` / `UPDATE` / `DELETE` / `TENANT_CREATED` / `TENANT_SUSPENDED` / `TENANT_REACTIVATED`。
+            `LOGIN` / `CREATE` / `UPDATE` / `DELETE` / `TENANT_CREATED` / `TENANT_SUSPENDED` / `TENANT_REACTIVATED`。
             将来エンドポイント追加時に新しい action 値が増える可能性があるため、enum ではなく pattern で命名規約のみを制約する。
         entityType:
           type: [string, 'null']

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -733,7 +733,7 @@ paths:
         - name: action
           in: query
           description: "監査ログ action 値による完全一致フィルタ。`AuditLog.action` と同じ命名規約に従う(設計規約 §2.5)。"
-          schema: { type: string, minLength: 5, pattern: "^[A-Z][A-Z0-9_]*$" }
+          schema: { type: string, pattern: "^[A-Z][A-Z0-9_]*$" }
         - { name: page, in: query, schema: { type: integer, default: 0 } }
         - { name: size, in: query, schema: { type: integer, default: 50, maximum: 100 } }
       responses:
@@ -1128,7 +1128,7 @@ components:
 
     AuditLog:
       description: |
-        監査ログのレスポンス表現。`audit_logs` テーブル(基本設計書 v1.4.2 §4.2.6)に対応するが、
+        監査ログのレスポンス表現。`audit_logs` テーブル(基本設計書 v1.4.3 §4.2.6)に対応するが、
         **以下の DDL 列は API レスポンスに含めない**(内部分離キー / 内部実装 / 重複情報のため):
 
         - `tenant_id` — `/api/audit-logs` は Tenant Admin が自テナントの監査ログを参照する API であり、
@@ -1152,14 +1152,14 @@ components:
             - システム起因のバッチ処理(ShedLock 経由のスケジューラ等、人間の操作主体が存在しないイベント)
         action:
           type: string
-          minLength: 5
           pattern: "^[A-Z][A-Z0-9_]*$"
           description: |-
             監査対象の業務操作種別。命名規約は大文字始まり、英数字・アンダースコアのみ(設計規約 §2.5)。
-            `minLength: 5` は現状の標準値(下記)の最短が `LOGIN` (5 文字)であることに合わせた下限。将来 3〜4 文字の action 値を追加したくなった場合は本制約と命名規約を併せて見直す。
-            本フェーズで定義されている標準値(基本設計書 v1.4.2 §4.2.6 ベース。`LOGIN_FAILED` は認証失敗追跡用に OpenAPI 側で追記、設計書への正式取り込みは #180 で確認予定):
+            本フェーズで定義されている標準値(基本設計書 v1.4.3 §4.2.6):
             `LOGIN` / `LOGIN_FAILED` / `CREATE` / `UPDATE` / `DELETE` / `TENANT_CREATED` / `TENANT_SUSPENDED` / `TENANT_REACTIVATED`。
+            `LOGIN_FAILED` は JWT 検証失敗 / 未認証アクセス試行を記録(`userId` が NULL になるイベントの代表例)。`*_DENIED`(認可違反)も §6.2.3 の方針に基づき記録する。
             将来エンドポイント追加時に新しい action 値が増える可能性があるため、enum ではなく pattern で命名規約のみを制約する。
+            `minLength` は意図的に設定しない:現状の標準値の最短は `LOGIN`(5 文字)だが、将来 3〜4 文字の action 値(例: `VIEW`、`SEND`)が追加された場合のクライアント側破壊的変更を避けるため。
         entityType:
           type: [string, 'null']
         entityId:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -34,8 +34,10 @@ info:
     - `401 Unauthorized` — JWT欠落 / 署名不正 / 期限切れ
     - `403 Forbidden` — テナント越境、ロール権限不足、編集系で所有者でない 等
     - `404 Not Found` — リソース不在、または **参照系で参照権限不足**(リソース存在を漏らさない方針)
+    - `409 Conflict` — リソースの競合状態(詳細は基本設計書 §5.4.1。エンドポイント個別のシナリオはレスポンス description 参照)
+    - `422 Unprocessable Content` — 前提リソース未存在(招待時に Keycloak 未登録 等。詳細は基本設計書 §5.4.2)
     - `500 Internal Server Error` — サーバー内部エラー
-  version: "1.4.3"
+  version: "1.4.4"
   contact:
     name: 開発チーム
     email: dev@example.com
@@ -192,7 +194,9 @@ paths:
               schema: { $ref: "#/components/schemas/TenantCreatedResponse" }
         "400": { $ref: "#/components/responses/Validation" }
         "401": { $ref: "#/components/responses/Unauthorized" }
-        "409": { $ref: "#/components/responses/Conflict" }
+        "409":
+          $ref: "#/components/responses/Conflict"
+          description: テナント名から生成された `code` の一意制約違反(同名テナント存在時の連番付与リトライ後も解消できなかったレアケース)。
 
   /api/tenants/{id}:
     get:
@@ -216,7 +220,9 @@ paths:
             application/json:
               schema: { $ref: "#/components/schemas/Tenant" }
         "401": { $ref: "#/components/responses/Unauthorized" }
-        "404": { $ref: "#/components/responses/NotFound" }
+        "404":
+          $ref: "#/components/responses/NotFound"
+          description: 指定 ID のテナントが存在しない、または一般ユーザーが所属していないテナントを指定した(リソース存在秘匿)。
     put:
       tags: [Tenant]
       summary: テナント名更新 (SaaS Admin)
@@ -244,7 +250,9 @@ paths:
         "400": { $ref: "#/components/responses/Validation" }
         "401": { $ref: "#/components/responses/Unauthorized" }
         "403": { $ref: "#/components/responses/Forbidden" }
-        "404": { $ref: "#/components/responses/NotFound" }
+        "404":
+          $ref: "#/components/responses/NotFound"
+          description: 指定 ID のテナントが存在しない。
 
   /api/tenants/{id}/status:
     patch:
@@ -281,7 +289,9 @@ paths:
         "400": { $ref: "#/components/responses/Validation" }
         "401": { $ref: "#/components/responses/Unauthorized" }
         "403": { $ref: "#/components/responses/Forbidden" }
-        "404": { $ref: "#/components/responses/NotFound" }
+        "404":
+          $ref: "#/components/responses/NotFound"
+          description: 指定 ID のテナントが存在しない。
 
   # --- プラットフォーム監視 (SaaS Admin) ---
   /api/platform/metrics:
@@ -352,7 +362,9 @@ paths:
         "400": { $ref: "#/components/responses/Validation" }
         "401": { $ref: "#/components/responses/Unauthorized" }
         "403": { $ref: "#/components/responses/Forbidden" }
-        "409": { $ref: "#/components/responses/Conflict" }
+        "409":
+          $ref: "#/components/responses/Conflict"
+          description: 招待対象が既に `user_tenants` に登録済み(重複招待)。
         "422": { $ref: "#/components/responses/UnprocessableContent" }
 
   /api/tenant/users/{userId}/role:
@@ -468,7 +480,9 @@ paths:
           content:
             application/json:
               schema: { $ref: "#/components/schemas/TaskDetail" }
-        "404": { $ref: "#/components/responses/NotFound" }
+        "404":
+          $ref: "#/components/responses/NotFound"
+          description: タスクが存在しない、または参照権限なし(リソース存在秘匿)。
         "401": { $ref: "#/components/responses/Unauthorized" }
         "403": { $ref: "#/components/responses/Forbidden" }
     put:
@@ -490,7 +504,9 @@ paths:
             application/json:
               schema: { $ref: "#/components/schemas/Task" }
         "403": { $ref: "#/components/responses/Forbidden" }
-        "404": { $ref: "#/components/responses/NotFound" }
+        "404":
+          $ref: "#/components/responses/NotFound"
+          description: タスクが存在しない、または参照権限なし(リソース存在秘匿)。
         "401": { $ref: "#/components/responses/Unauthorized" }
     delete:
       tags: [Task]
@@ -502,7 +518,9 @@ paths:
       responses:
         "204": { description: No Content }
         "403": { $ref: "#/components/responses/Forbidden" }
-        "404": { $ref: "#/components/responses/NotFound" }
+        "404":
+          $ref: "#/components/responses/NotFound"
+          description: タスクが存在しない、または参照権限なし(リソース存在秘匿)。
         "401": { $ref: "#/components/responses/Unauthorized" }
 
   /api/tasks/{id}/status:
@@ -531,7 +549,9 @@ paths:
         "400": { $ref: "#/components/responses/Validation" }
         "401": { $ref: "#/components/responses/Unauthorized" }
         "403": { $ref: "#/components/responses/Forbidden" }
-        "404": { $ref: "#/components/responses/NotFound" }
+        "404":
+          $ref: "#/components/responses/NotFound"
+          description: タスクが存在しない、または参照権限なし(リソース存在秘匿)。
 
   /api/tasks/{id}/visibility:
     patch:
@@ -562,7 +582,9 @@ paths:
               schema: { $ref: "#/components/schemas/Task" }
         "400": { $ref: "#/components/responses/Validation" }
         "403": { $ref: "#/components/responses/Forbidden" }
-        "404": { $ref: "#/components/responses/NotFound" }
+        "404":
+          $ref: "#/components/responses/NotFound"
+          description: タスクが存在しない、または参照権限なし(リソース存在秘匿)。
         "401": { $ref: "#/components/responses/Unauthorized" }
 
   # --- 関係者 ---
@@ -584,7 +606,9 @@ paths:
                 items: { $ref: "#/components/schemas/Stakeholder" }
         "401": { $ref: "#/components/responses/Unauthorized" }
         "403": { $ref: "#/components/responses/Forbidden" }
-        "404": { $ref: "#/components/responses/NotFound" }
+        "404":
+          $ref: "#/components/responses/NotFound"
+          description: タスクが存在しない、または参照権限なし(リソース存在秘匿)。
     post:
       tags: [Stakeholder]
       summary: 関係者追加(所有者のみ)
@@ -609,8 +633,12 @@ paths:
         "400": { $ref: "#/components/responses/Validation" }
         "401": { $ref: "#/components/responses/Unauthorized" }
         "403": { $ref: "#/components/responses/Forbidden" }
-        "404": { $ref: "#/components/responses/NotFound" }
-        "409": { $ref: "#/components/responses/Conflict" }
+        "404":
+          $ref: "#/components/responses/NotFound"
+          description: タスクが存在しない、または参照権限なし(リソース存在秘匿)。
+        "409":
+          $ref: "#/components/responses/Conflict"
+          description: 指定ユーザーが既に同タスクの関係者として登録済み(重複追加)。
 
   /api/tasks/{taskId}/stakeholders/{userId}:
     delete:
@@ -624,7 +652,9 @@ paths:
         "204": { description: No Content }
         "401": { $ref: "#/components/responses/Unauthorized" }
         "403": { $ref: "#/components/responses/Forbidden" }
-        "404": { $ref: "#/components/responses/NotFound" }
+        "404":
+          $ref: "#/components/responses/NotFound"
+          description: タスクが存在しないか参照権限なし、または対象ユーザーが当該タスクの関係者として登録されていない。
 
   # --- ダッシュボード ---
   /api/dashboard/summary:
@@ -1083,7 +1113,7 @@ components:
 
     AuditLog:
       description: |
-        監査ログのレスポンス表現。`audit_logs` テーブル(基本設計書 v1.4.1 §4.2.6)に対応するが、
+        監査ログのレスポンス表現。`audit_logs` テーブル(基本設計書 v1.4.2 §4.2.6)に対応するが、
         **以下の DDL 列は API レスポンスに含めない**(内部分離キー / 内部実装 / 重複情報のため):
 
         - `tenant_id` — `/api/audit-logs` は Tenant Admin が自テナントの監査ログを参照する API であり、
@@ -1101,7 +1131,18 @@ components:
         userId:
           type: [integer, 'null']
           format: int64
-        action:     { type: string }
+          description: |-
+            操作ユーザーの `users.id`。以下のシナリオで `null` になる(Issue #173):
+            - 認証失敗イベント(JWT 検証失敗 / 未認証で保護リソースへのアクセス試行)
+            - システム起因のバッチ処理(ShedLock 経由のスケジューラ等、人間の操作主体が存在しないイベント)
+        action:
+          type: string
+          pattern: "^[A-Z][A-Z0-9_]*$"
+          description: |-
+            監査対象の業務操作種別。命名規約は大文字始まり、英数字・アンダースコアのみ(Issue #174、設計規約 §2.5)。
+            本フェーズで定義されている標準値(基本設計書 v1.4.2 §4.2.6):
+            `LOGIN` / `LOGIN_FAILED` / `CREATE` / `UPDATE` / `DELETE` / `TENANT_CREATED` / `TENANT_SUSPENDED` / `TENANT_REACTIVATED`。
+            将来エンドポイント追加時に新しい action 値が増える可能性があるため、enum ではなく pattern で命名規約のみを制約する。
         entityType:
           type: [string, 'null']
         entityId:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -482,9 +482,7 @@ paths:
               schema: { $ref: "#/components/schemas/TaskDetail" }
         "404":
           $ref: "#/components/responses/NotFound"
-          description: |-
-            タスクが存在しないか、当該ユーザーが**参照権限**を持たない(可視性チェック不通過によりリソース存在を秘匿、HTTP Status Policy / NIST AC-4)。
-            なお**編集権限**(所有者・担当者・Tenant Admin 等)不足の場合は 403 を返す。
+          description: タスクが存在しないか、当該ユーザーが**参照権限**を持たない(可視性チェック不通過によりリソース存在を秘匿、HTTP Status Policy / NIST AC-4)。
         "401": { $ref: "#/components/responses/Unauthorized" }
         "403": { $ref: "#/components/responses/Forbidden" }
     put:
@@ -618,9 +616,7 @@ paths:
         "403": { $ref: "#/components/responses/Forbidden" }
         "404":
           $ref: "#/components/responses/NotFound"
-          description: |-
-            タスクが存在しないか、当該ユーザーが**参照権限**を持たない(可視性チェック不通過によりリソース存在を秘匿、HTTP Status Policy / NIST AC-4)。
-            なお**編集権限**(所有者・担当者・Tenant Admin 等)不足の場合は 403 を返す。
+          description: タスクが存在しないか、当該ユーザーが**参照権限**を持たない(可視性チェック不通過によりリソース存在を秘匿、HTTP Status Policy / NIST AC-4)。
     post:
       tags: [Stakeholder]
       summary: 関係者追加(所有者のみ)
@@ -668,7 +664,9 @@ paths:
         "403": { $ref: "#/components/responses/Forbidden" }
         "404":
           $ref: "#/components/responses/NotFound"
-          description: タスクが存在しないか参照権限なし、または対象ユーザーが当該タスクの関係者として登録されていない。
+          description: |-
+            タスクが存在しないか、当該ユーザーが**参照権限**を持たない(可視性チェック不通過によりリソース存在を秘匿、HTTP Status Policy / NIST AC-4)。または対象ユーザーが当該タスクの関係者として登録されていない。
+            なお**編集権限**(所有者または Tenant Admin)不足の場合は 403 を返す。
 
   # --- ダッシュボード ---
   /api/dashboard/summary:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -733,7 +733,7 @@ paths:
         - name: action
           in: query
           description: "監査ログ action 値による完全一致フィルタ。`AuditLog.action` と同じ命名規約に従う(設計規約 §2.5)。"
-          schema: { type: string, minLength: 3, pattern: "^[A-Z][A-Z0-9_]*$" }
+          schema: { type: string, minLength: 5, pattern: "^[A-Z][A-Z0-9_]*$" }
         - { name: page, in: query, schema: { type: integer, default: 0 } }
         - { name: size, in: query, schema: { type: integer, default: 50, maximum: 100 } }
       responses:
@@ -1152,12 +1152,12 @@ components:
             - システム起因のバッチ処理(ShedLock 経由のスケジューラ等、人間の操作主体が存在しないイベント)
         action:
           type: string
-          minLength: 3
+          minLength: 5
           pattern: "^[A-Z][A-Z0-9_]*$"
           description: |-
             監査対象の業務操作種別。命名規約は大文字始まり、英数字・アンダースコアのみ(設計規約 §2.5)。
-            `minLength: 3` は現状の標準値(下記)の最短が `LOGIN` (5文字)であり、1〜2 文字の値は実用上想定されないため命名規約上の下限として設定。
-            本フェーズで定義されている標準値(基本設計書 v1.4.2 §4.2.6 ベース。`LOGIN_FAILED` は認証失敗追跡用に OpenAPI 側で追記、設計書への正式取り込みは別 Issue で確認予定):
+            `minLength: 5` は現状の標準値(下記)の最短が `LOGIN` (5 文字)であることに合わせた下限。将来 3〜4 文字の action 値を追加したくなった場合は本制約と命名規約を併せて見直す。
+            本フェーズで定義されている標準値(基本設計書 v1.4.2 §4.2.6 ベース。`LOGIN_FAILED` は認証失敗追跡用に OpenAPI 側で追記、設計書への正式取り込みは #180 で確認予定):
             `LOGIN` / `LOGIN_FAILED` / `CREATE` / `UPDATE` / `DELETE` / `TENANT_CREATED` / `TENANT_SUSPENDED` / `TENANT_REACTIVATED`。
             将来エンドポイント追加時に新しい action 値が増える可能性があるため、enum ではなく pattern で命名規約のみを制約する。
         entityType:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -482,7 +482,9 @@ paths:
               schema: { $ref: "#/components/schemas/TaskDetail" }
         "404":
           $ref: "#/components/responses/NotFound"
-          description: タスクが存在しない、または参照権限なし(リソース存在秘匿)。
+          description: |-
+            タスクが存在しないか、当該ユーザーが**参照権限**を持たない(可視性チェック不通過によりリソース存在を秘匿、HTTP Status Policy / NIST AC-4)。
+            なお**編集権限**(所有者・担当者・Tenant Admin 等)不足の場合は 403 を返す。
         "401": { $ref: "#/components/responses/Unauthorized" }
         "403": { $ref: "#/components/responses/Forbidden" }
     put:
@@ -506,7 +508,9 @@ paths:
         "403": { $ref: "#/components/responses/Forbidden" }
         "404":
           $ref: "#/components/responses/NotFound"
-          description: タスクが存在しない、または参照権限なし(リソース存在秘匿)。
+          description: |-
+            タスクが存在しないか、当該ユーザーが**参照権限**を持たない(可視性チェック不通過によりリソース存在を秘匿、HTTP Status Policy / NIST AC-4)。
+            なお**編集権限**(所有者・担当者・Tenant Admin 等)不足の場合は 403 を返す。
         "401": { $ref: "#/components/responses/Unauthorized" }
     delete:
       tags: [Task]
@@ -520,7 +524,9 @@ paths:
         "403": { $ref: "#/components/responses/Forbidden" }
         "404":
           $ref: "#/components/responses/NotFound"
-          description: タスクが存在しない、または参照権限なし(リソース存在秘匿)。
+          description: |-
+            タスクが存在しないか、当該ユーザーが**参照権限**を持たない(可視性チェック不通過によりリソース存在を秘匿、HTTP Status Policy / NIST AC-4)。
+            なお**編集権限**(所有者・担当者・Tenant Admin 等)不足の場合は 403 を返す。
         "401": { $ref: "#/components/responses/Unauthorized" }
 
   /api/tasks/{id}/status:
@@ -551,7 +557,9 @@ paths:
         "403": { $ref: "#/components/responses/Forbidden" }
         "404":
           $ref: "#/components/responses/NotFound"
-          description: タスクが存在しない、または参照権限なし(リソース存在秘匿)。
+          description: |-
+            タスクが存在しないか、当該ユーザーが**参照権限**を持たない(可視性チェック不通過によりリソース存在を秘匿、HTTP Status Policy / NIST AC-4)。
+            なお**編集権限**(所有者・担当者・Tenant Admin 等)不足の場合は 403 を返す。
 
   /api/tasks/{id}/visibility:
     patch:
@@ -584,7 +592,9 @@ paths:
         "403": { $ref: "#/components/responses/Forbidden" }
         "404":
           $ref: "#/components/responses/NotFound"
-          description: タスクが存在しない、または参照権限なし(リソース存在秘匿)。
+          description: |-
+            タスクが存在しないか、当該ユーザーが**参照権限**を持たない(可視性チェック不通過によりリソース存在を秘匿、HTTP Status Policy / NIST AC-4)。
+            なお**編集権限**(所有者・担当者・Tenant Admin 等)不足の場合は 403 を返す。
         "401": { $ref: "#/components/responses/Unauthorized" }
 
   # --- 関係者 ---
@@ -608,7 +618,9 @@ paths:
         "403": { $ref: "#/components/responses/Forbidden" }
         "404":
           $ref: "#/components/responses/NotFound"
-          description: タスクが存在しない、または参照権限なし(リソース存在秘匿)。
+          description: |-
+            タスクが存在しないか、当該ユーザーが**参照権限**を持たない(可視性チェック不通過によりリソース存在を秘匿、HTTP Status Policy / NIST AC-4)。
+            なお**編集権限**(所有者・担当者・Tenant Admin 等)不足の場合は 403 を返す。
     post:
       tags: [Stakeholder]
       summary: 関係者追加(所有者のみ)
@@ -635,7 +647,9 @@ paths:
         "403": { $ref: "#/components/responses/Forbidden" }
         "404":
           $ref: "#/components/responses/NotFound"
-          description: タスクが存在しない、または参照権限なし(リソース存在秘匿)。
+          description: |-
+            タスクが存在しないか、当該ユーザーが**参照権限**を持たない(可視性チェック不通過によりリソース存在を秘匿、HTTP Status Policy / NIST AC-4)。
+            なお**編集権限**(所有者・担当者・Tenant Admin 等)不足の場合は 403 を返す。
         "409":
           $ref: "#/components/responses/Conflict"
           description: 指定ユーザーが既に同タスクの関係者として登録済み(重複追加)。
@@ -1132,14 +1146,14 @@ components:
           type: [integer, 'null']
           format: int64
           description: |-
-            操作ユーザーの `users.id`。以下のシナリオで `null` になる(Issue #173):
+            操作ユーザーの `users.id`。以下のシナリオで `null` になる:
             - 認証失敗イベント(JWT 検証失敗 / 未認証で保護リソースへのアクセス試行)
             - システム起因のバッチ処理(ShedLock 経由のスケジューラ等、人間の操作主体が存在しないイベント)
         action:
           type: string
           pattern: "^[A-Z][A-Z0-9_]*$"
           description: |-
-            監査対象の業務操作種別。命名規約は大文字始まり、英数字・アンダースコアのみ(Issue #174、設計規約 §2.5)。
+            監査対象の業務操作種別。命名規約は大文字始まり、英数字・アンダースコアのみ(設計規約 §2.5)。
             本フェーズで定義されている標準値(基本設計書 v1.4.2 §4.2.6):
             `LOGIN` / `LOGIN_FAILED` / `CREATE` / `UPDATE` / `DELETE` / `TENANT_CREATED` / `TENANT_SUSPENDED` / `TENANT_REACTIVATED`。
             将来エンドポイント追加時に新しい action 値が増える可能性があるため、enum ではなく pattern で命名規約のみを制約する。

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -508,7 +508,7 @@ paths:
           $ref: "#/components/responses/NotFound"
           description: |-
             タスクが存在しないか、当該ユーザーが**参照権限**を持たない(可視性チェック不通過によりリソース存在を秘匿、HTTP Status Policy / NIST AC-4)。
-            なお**編集権限**(所有者・担当者・Tenant Admin 等)不足の場合は 403 を返す。
+            なお**更新権限**(所有者または Tenant Admin)不足の場合は 403 を返す(基本設計書 §6.2.1)。
         "401": { $ref: "#/components/responses/Unauthorized" }
     delete:
       tags: [Task]
@@ -524,7 +524,7 @@ paths:
           $ref: "#/components/responses/NotFound"
           description: |-
             タスクが存在しないか、当該ユーザーが**参照権限**を持たない(可視性チェック不通過によりリソース存在を秘匿、HTTP Status Policy / NIST AC-4)。
-            なお**編集権限**(所有者・担当者・Tenant Admin 等)不足の場合は 403 を返す。
+            なお**削除権限**(所有者または Tenant Admin)不足の場合は 403 を返す(基本設計書 §6.2.1)。
         "401": { $ref: "#/components/responses/Unauthorized" }
 
   /api/tasks/{id}/status:
@@ -557,7 +557,7 @@ paths:
           $ref: "#/components/responses/NotFound"
           description: |-
             タスクが存在しないか、当該ユーザーが**参照権限**を持たない(可視性チェック不通過によりリソース存在を秘匿、HTTP Status Policy / NIST AC-4)。
-            なお**編集権限**(所有者・担当者・Tenant Admin 等)不足の場合は 403 を返す。
+            なお**ステータス変更権限**(所有者・担当者・Tenant Admin)不足の場合は 403 を返す(基本設計書 §6.2.1)。
 
   /api/tasks/{id}/visibility:
     patch:
@@ -592,7 +592,7 @@ paths:
           $ref: "#/components/responses/NotFound"
           description: |-
             タスクが存在しないか、当該ユーザーが**参照権限**を持たない(可視性チェック不通過によりリソース存在を秘匿、HTTP Status Policy / NIST AC-4)。
-            なお**編集権限**(所有者・担当者・Tenant Admin 等)不足の場合は 403 を返す。
+            なお**公開範囲変更権限**(所有者のみ、Tenant Admin は強制変更可)不足の場合は 403 を返す(基本設計書 §6.2.1)。
         "401": { $ref: "#/components/responses/Unauthorized" }
 
   # --- 関係者 ---
@@ -645,7 +645,7 @@ paths:
           $ref: "#/components/responses/NotFound"
           description: |-
             タスクが存在しないか、当該ユーザーが**参照権限**を持たない(可視性チェック不通過によりリソース存在を秘匿、HTTP Status Policy / NIST AC-4)。
-            なお**編集権限**(所有者・担当者・Tenant Admin 等)不足の場合は 403 を返す。
+            なお**関係者追加権限**(所有者のみ、Tenant Admin は強制操作可)不足の場合は 403 を返す(基本設計書 §6.2.1)。
         "409":
           $ref: "#/components/responses/Conflict"
           description: 指定ユーザーが既に同タスクの関係者として登録済み(重複追加)。
@@ -666,7 +666,7 @@ paths:
           $ref: "#/components/responses/NotFound"
           description: |-
             タスクが存在しないか、当該ユーザーが**参照権限**を持たない(可視性チェック不通過によりリソース存在を秘匿、HTTP Status Policy / NIST AC-4)。または対象ユーザーが当該タスクの関係者として登録されていない。
-            なお**編集権限**(所有者または Tenant Admin)不足の場合は 403 を返す。
+            なお**関係者削除権限**(所有者のみ、Tenant Admin は強制操作可)不足の場合は 403 を返す(基本設計書 §6.2.1)。
 
   # --- ダッシュボード ---
   /api/dashboard/summary:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -730,7 +730,10 @@ paths:
       parameters:
         - { name: from, in: query, schema: { type: string, format: date-time } }
         - { name: to,   in: query, schema: { type: string, format: date-time } }
-        - { name: action, in: query, schema: { type: string } }
+        - name: action
+          in: query
+          description: "監査ログ action 値による完全一致フィルタ。`AuditLog.action` と同じ命名規約に従う(設計規約 §2.5)。"
+          schema: { type: string, minLength: 3, pattern: "^[A-Z][A-Z0-9_]*$" }
         - { name: page, in: query, schema: { type: integer, default: 0 } }
         - { name: size, in: query, schema: { type: integer, default: 50, maximum: 100 } }
       responses:
@@ -1149,12 +1152,13 @@ components:
             - システム起因のバッチ処理(ShedLock 経由のスケジューラ等、人間の操作主体が存在しないイベント)
         action:
           type: string
-          minLength: 2
+          minLength: 3
           pattern: "^[A-Z][A-Z0-9_]*$"
           description: |-
             監査対象の業務操作種別。命名規約は大文字始まり、英数字・アンダースコアのみ(設計規約 §2.5)。
-            本フェーズで定義されている標準値(基本設計書 v1.4.2 §4.2.6):
-            `LOGIN` / `CREATE` / `UPDATE` / `DELETE` / `TENANT_CREATED` / `TENANT_SUSPENDED` / `TENANT_REACTIVATED`。
+            `minLength: 3` は現状の標準値(下記)の最短が `LOGIN` (5文字)であり、1〜2 文字の値は実用上想定されないため命名規約上の下限として設定。
+            本フェーズで定義されている標準値(基本設計書 v1.4.2 §4.2.6 ベース。`LOGIN_FAILED` は認証失敗追跡用に OpenAPI 側で追記、設計書への正式取り込みは別 Issue で確認予定):
+            `LOGIN` / `LOGIN_FAILED` / `CREATE` / `UPDATE` / `DELETE` / `TENANT_CREATED` / `TENANT_SUSPENDED` / `TENANT_REACTIVATED`。
             将来エンドポイント追加時に新しい action 値が増える可能性があるため、enum ではなく pattern で命名規約のみを制約する。
         entityType:
           type: [string, 'null']


### PR DESCRIPTION
## 背景

Sprint 0 Readiness 配下 #120 の OpenAPI 補強系 4 Issue を一括対応する PR。レビューサイクルを経て、SSOT 原則(基本設計書 = Single Source of Truth)に整合させる形で確定化済み。

- **#127** [軽微] info.description の共通レスポンス一覧に 409 / 422 が未記載
- **#128** [軽微] Conflict レスポンスの description が汎用的 → Conflict + NotFound の `$ref` 使用箇所全てを具体化
- **#173** AuditLog.userId の nullable シナリオを description に追記
- **#174** AuditLog.action の enum 定義または pattern 制約を検討 → **pattern + description**(方針 B)を採用

## 変更内容

`api/openapi.yaml` v1.4.3 → **v1.4.4**:

### #127: info.description 共通レスポンス一覧
`401` / `403` / `404` / `500` のみだった列挙に `409 Conflict` と `422 Unprocessable Content` を追加(基本設計書 §5.4.1 / §5.4.2 への参照付き)。

### #128: Conflict / NotFound `$ref` description 上書き(全 14 箇所)
OpenAPI 3.1 では `$ref` と同階層に `description` を記述することで呼び出し元ごとに上書きできるため、各エンドポイントの 409 / 404 シナリオを具体化。

**Conflict(3 箇所)**: POST /api/tenants / POST /api/tenant/users/invite / POST /api/tasks/{id}/stakeholders

**NotFound(11 箇所)**: テナント系 3 + タスク系 8。
- GET 系は単純な「参照権限なし」記述
- 書き込み系は操作別の権限主体(更新権限・削除権限・ステータス変更権限・公開範囲変更権限・関係者追加権限・関係者削除権限)を明示し、403 との使い分けが読み取れる形に
- removeStakeholder は「関係者リストに登録されていない」も含む特殊シナリオ

### #173: AuditLog.userId description
null になるシナリオを明示(認証失敗イベント / システム起因バッチ処理)。

### #174: AuditLog.action pattern + description
`pattern: "^[A-Z][A-Z0-9_]*$"` を採用(方針 B)+ description で標準値リスト明示。`minLength` は意図的に設定しない(将来 3〜4 文字 action 値追加余地を残すため、レビュー指摘で 5→3→削除と推移)。

標準値(基本設計書 v1.4.3 §4.2.6 — `LOGIN_FAILED` は本 PR レビューを契機に PR #183 で設計書側に正式追加済):
`LOGIN` / `LOGIN_FAILED` / `CREATE` / `UPDATE` / `DELETE` / `TENANT_CREATED` / `TENANT_SUSPENDED` / `TENANT_REACTIVATED`

### 周辺整合
- AuditLog top description のバージョン参照: `基本設計書 v1.4.1` → **`v1.4.3`**(PR #176 で v1.4.2、PR #183 で v1.4.3 に到達)
- タスク書き込み系の 404 description に基本設計書 §6.2.1 への参照を追加し、権限主体を操作別に具体化
- `*_DENIED`(認可違反)も §6.2.3 の方針に基づき記録する旨を AuditLog.action description に明記(具体値定義はマージ後に別 Issue 起票)

### CLAUDE.md
- OpenAPI: `v1.4.3` → `v1.4.4`(operations 27 / schemas 26 は不変)

## 影響範囲
- ドキュメント・description / pattern 追加のみ。エンドポイント・schema フィールド構成・enum 値・既存 pattern に変更なし
- 既存クライアントへの破壊的変更なし

## 受け入れ条件チェック
- [x] #127 info.description に 409 / 422 を追記
- [x] #128 Conflict / NotFound 全使用箇所に具体的 description を上書き
- [x] #173 AuditLog.userId に null シナリオの description を追加
- [x] #174 AuditLog.action に pattern + description を追加(方針 B 採用、minLength なし)
- [x] CLAUDE.md バージョン同期

## マージ後のフォローアップ(本 PR の派生 Issue)
- [ ] **ツール互換性検証 Issue 起票**: Swagger UI / Redoc / openapi-generator 等で `$ref` + sibling description の上書き動作を実検証(Sprint 0 実装フェーズで対応)
- [ ] **`*_DENIED` 標準値定義 Issue 起票**: 設計書 §4.2.6 / §6.2.3 に `ACCESS_DENIED` / `EDIT_DENIED` 等の具体値を定義(設計書先行ルート)
- 既存 #182(レスポンスコード並び順統一)で本 PR で触れたエンドポイントも対象に含める

## 関連
- 親 Issue: #120 [Sprint 0 Readiness]
- 派生 Issue(本 PR レビュー由来): #180(LOGIN_FAILED 設計書取り込み、PR #183 マージ済) / #181(§6.2.1 Tenant Admin 例外確認) / #182(レスポンスコード並び順統一)
- 関連 PR: #183(基本設計書 v1.4.3、本 PR 用に SSOT 整合確保)
- 基本設計書 v1.4.3 §5.4.1 / §5.4.2 / §4.2.6 / §6.2.1 / §6.2.3 / §2.5 設計規約

Closes #127
Closes #128
Closes #173
Closes #174
