### PR TITLE
docs(spec): 基本設計書 v1.4.3 — §4.2.6 audit_logs.action 標準値に LOGIN_FAILED 追加 (Issue #180)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -73,7 +73,7 @@ GitHub Actions (`cicd.yml`) runs `./gradlew check` on every push and PR, publish
 ### Design Versions
 
 - 要件定義書: v1.4.2
-- 基本設計書: **v1.4.2** ← Single Source of Truth
+- 基本設計書: **v1.4.3** ← Single Source of Truth
 - 開発計画書: v1.2
 - OpenAPI: **v1.4.3**(27 operations / 26 schemas)
 

--- a/docs/specs/基本設計書.md
+++ b/docs/specs/基本設計書.md
@@ -2,9 +2,9 @@
 
 タスク管理システム(マルチテナントSaaS)
 
-Version 1.4.2
+Version 1.4.3
 
-2026年5月16日
+2026年5月17日
 
 作成者: 開発チーム
 
@@ -23,6 +23,7 @@ Version 1.4.2
 | 1.4 | 2026-05-16 | Issue #159: SaaS Admin スコープ整理(2026-05-16 ブレスト)を反映。§3 画面 S-11〜S-14 を SaaS Admin / セルフサインアップ向けに再編、§4.2.2 tenants の status 列を ACTIVE/SUSPENDED に整理し例外テーブル化を明示、§4.2.6 audit_logs に actor_sub 追加と TENANT_* アクション種別、§5 API 一覧に GET /api/tenants/{id} / PATCH /api/tenants/{id}/status / GET /api/platform/metrics 追加 + A-05 を認証済みユーザー化、§6.2 認可モデルを 2 軸直交に書き換え、§6.2.1 に SaaS Admin の業務 API 呼び出し 403 明示 | 開発チーム |
 | 1.4.1 | 2026-05-16 | PR #165 レビュー指摘対応: §4.2 冒頭・§4.2.1 users を JIT 整合に修正(INSERT 可・UPDATE/DELETE 不可)、§5.1 API 一覧で A-25〜A-27 を末尾(A-24 後)に移動し採番方針を追記、A-06/A-26 の役割分担を備考に明記、§5.2 X-Tenant-Id 不要枠を API 番号で列挙、§6.2 兼務ユーザーの認可動作を明示(業務 API はテナント軸で評価)、§4.2.6 audit_logs に列順序と Flyway 実装時の留意点を補足 | 開発チーム |
 | 1.4.2 | 2026-05-16 | Issue #111: §4.2.3 user_tenants の `status` 列備考に「`DISABLED` への遷移 API は Phase 2、本フェーズは `INVITED` / `ACTIVE` のみ実装」を追記。要件定義書 v1.4.2 §6.2 への参照整合 | 開発チーム |
+| 1.4.3 | 2026-05-17 | Issue #180: §4.2.6 audit_logs の `action` 標準値に `LOGIN_FAILED` を追加(JWT 検証失敗・未認証アクセス試行を記録、`user_id` が NULL になるイベントの代表例)。`*_DENIED` 系認可違反の記録方針(§6.2.3)とも明示的に整合 | 開発チーム |
 
 ## 目次
 
@@ -414,7 +415,7 @@ Version 1.4.2
 | tenant_id | BIGINT |   |   | テナント分離(NULL=システム横断 / SaaS Admin 操作・テナント横断バッチ等) |
 | user_id | BIGINT |   |   | 操作ユーザー(認証失敗時はNULL) |
 | actor_sub | VARCHAR(255) |   |   | 操作主体の Keycloak `sub` クレーム(NULL=未認証 / システムバッチ)。SaaS Admin 操作の追跡に必須(設計規約 v1.1 §3.5 参照) |
-| action | VARCHAR(50) |   | ○ | `LOGIN` / `CREATE` / `UPDATE` / `DELETE` / `TENANT_CREATED` / `TENANT_SUSPENDED` / `TENANT_REACTIVATED` 等 |
+| action | VARCHAR(50) |   | ○ | `LOGIN` / `LOGIN_FAILED` / `CREATE` / `UPDATE` / `DELETE` / `TENANT_CREATED` / `TENANT_SUSPENDED` / `TENANT_REACTIVATED` 等。`LOGIN_FAILED` は JWT 検証失敗 / 未認証アクセス試行を記録(`user_id` が NULL になるイベントの代表例)。`*_DENIED`(認可違反)も §6.2.3 の方針に基づき記録 |
 | entity_type | VARCHAR(50) |   |   | 対象エンティティ種別 |
 | entity_id | BIGINT |   |   | 対象ID |
 | detail | JSON |   |   | 変更内容(差分) |


### PR DESCRIPTION
## 背景

PR #179(OpenAPI v1.4.4)のレビューで、**SSOT 原則の不整合**が指摘された:

- OpenAPI(`AuditLog.action`)に \`LOGIN_FAILED\` を独自追加していた
- 基本設計書 v1.4.2 §4.2.6 の \`action\` 標準値リストには未掲載
- CLAUDE.md で「基本設計書 = SSOT」と明示しているのに OpenAPI が先行する状態

本 PR は **PR #179 に先行**して基本設計書側を更新し、OpenAPI の独自追加を正式採用に切り替える。マージ後、PR #179 で OpenAPI の暫定注記(「#180 で確認予定」)を削除する。

## 変更内容

\`docs/specs/基本設計書.md\` v1.4.2 → **v1.4.3**:

- §4.2.6 audit_logs テーブル定義の \`action\` 列備考に \`LOGIN_FAILED\` を追加
- 同備考に説明追加: 「\`LOGIN_FAILED\` は JWT 検証失敗 / 未認証アクセス試行を記録(\`user_id\` が NULL になるイベントの代表例)。\`*_DENIED\`(認可違反)も §6.2.3 の方針に基づき記録」
- 改訂履歴に v1.4.3 行を追加
- ヘッダの Version / 日付を更新(2026-05-17)

\`.claude/CLAUDE.md\`:

- 基本設計書: v1.4.2 → **v1.4.3** に同期

## 影響範囲

- ドキュメントのみ。OpenAPI / コード変更なし
- 既存 \`action\` 値の意味・運用は変わらない(\`LOGIN_FAILED\` は元々 OpenAPI 側で記述済み、本 PR は設計書側を追随)

## マージ後のフォローアップ

- PR #179 で OpenAPI \`AuditLog.action\` description の暫定注記「設計書への正式取り込みは #180 で確認予定」を削除
- Issue #180 をクローズ(設計書側で確認完了として)

## 受け入れ条件

- [x] §4.2.6 表に \`LOGIN_FAILED\` 追記
- [x] 改訂履歴に v1.4.3 行追加
- [x] CLAUDE.md バージョン同期

## 関連

- Issue #180(本 PR でクローズ予定)
- PR #179(本 PR マージ後に description 確定化)
- 親 Issue: #120 [Sprint 0 Readiness]

Closes #180