### PR TITLE
docs: Step 5 残作業 — docs/README.md と gap-analysis のバージョン同期

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,8 +10,8 @@
 
 | 文書 | パス | 内容 |
 |---|---|---|
-| 要件定義書 v1.2 | `specs/要件定義書.md` | 業務要件・機能要件・非機能要件・技術スタック |
-| 基本設計書 v1.2 | `specs/基本設計書.md` | アーキ・画面・DB・API・セキュリティ |
+| 要件定義書 v1.4.3 | `specs/要件定義書.md` | 業務要件・機能要件・非機能要件・技術スタック |
+| 基本設計書 v1.4.4 | `specs/基本設計書.md` | アーキ・画面・DB・API・セキュリティ |
 | 開発計画書 v1.2 | `specs/開発計画書.md` | 体制・スケジュール・リスク・GitHub運用マッピング |
 
 ### Flyway 初期スキーマ(本PRには未含、Sprint 0 で投入予定)
@@ -24,7 +24,7 @@
 
 | ファイル | 内容 |
 |---|---|
-| `../api/openapi.yaml` | OpenAPI 3.1。27エンドポイント・26スキーマ・認可ルール記述・エラーレスポンス共通定義 |
+| `../api/openapi.yaml` | OpenAPI 3.1(v1.4.5)。28エンドポイント・27スキーマ・認可ルール記述・エラーレスポンス共通定義 |
 
 ### クラス図 / シーケンス図(Mermaid)
 
@@ -37,7 +37,7 @@
 | `diagrams/sequence-02-task-create.mmd`      | タスク作成(認証→認可→ドメイン→永続化→監査) |
 | `diagrams/sequence-03-task-list-authz.mmd`  | 当日表示+期限切れ常時表示+visibilityフィルタ |
 | `diagrams/sequence-04-task-edit-authz.mmd`  | 所有者チェックと TaskOwnershipException |
-| `diagrams/sequence-05-stakeholder-add.mmd`  | 関係者追加(visibility自動昇格を含む) |
+| `diagrams/sequence-05-stakeholder-add.mmd`  | 関係者追加(所有者・担当者が実施、visibility 自動昇格なし、ADR-0005) |
 
 ## 利用方法
 
@@ -72,7 +72,7 @@ VS Code拡張: "Mermaid Preview"
 
 ## 整合性メモ
 
-- API操作数(基本設計書) と OpenAPI operations: ともに **24** (A-01〜A-24、A-23/A-24 は通知設定 v1.3.1 で追加)
+- API操作数(基本設計書) と OpenAPI operations: ともに **28**(A-01〜A-28)。A-23/A-24 は通知設定 v1.3.1 で追加、A-25/A-26/A-27 は SaaS Admin スコープで v1.4.1 で追加、A-28 は S-15 テナント運営者向けダッシュボードとして v1.4.5 で追加(ADR-0005)
 - DDLのテーブル数とER図上の業務テーブル数: ともに **5(+運用2)**
 - 認可ルールはシーケンス図(03/04/05)と OpenAPI の `description` で重複記述。実装時は `TaskAuthorizationDomainService` に1箇所で集約
 

--- a/docs/reviews/2026-05-10-scaffold-vs-design-gap-analysis.md
+++ b/docs/reviews/2026-05-10-scaffold-vs-design-gap-analysis.md
@@ -18,7 +18,7 @@
 | `application.yml` | 🟡 最小構成 | OAuth2 issuer / DataSource / Flyway 設定追加 |
 | クリーンアーキテクチャ4層構造 | 🔴 未実装(scaffold は標準Spring構成) | Domain / UseCase / Adapter リファクタ |
 | その他テーブル(tenants/user_tenants/task_stakeholders/audit_logs/user_notification_settings/shedlock) | 🔴 未実装 | 新規 migration + Entity |
-| API実装(27 endpoints) | 🔴 未実装 | Controller + UseCase + Repository |
+| API実装(28 endpoints) | 🔴 未実装 | Controller + UseCase + Repository |
 
 ---
 


### PR DESCRIPTION
## 概要

ADR-0005 §6 の step 5(CLAUDE.md / 派生ドキュメントの残バージョン参照同期)のうち、PR #191(OpenAPI v1.4.5)に同梱できなかった `docs/README.md` と `docs/reviews/2026-05-10-scaffold-vs-design-gap-analysis.md` の同期を行う最終 PR。

## 関連 ADR / PR

- ADR-0005 / PR #186 タスク認可 3 役割化(マージ済)
- PR #189 要件定義書 v1.4.3(マージ済)
- 基本設計書 v1.4.4 PR(マージ済)
- PR #191 OpenAPI v1.4.5 + CLAUDE.md(マージ済)

## 変更点

- docs/README.md:
  - 設計仕様書テーブル: 要件定義書 v1.2 → v1.4.3、基本設計書 v1.2 → v1.4.4
  - API 仕様欄: OpenAPI v1.4.5、28 エンドポイント、27 スキーマ
  - sequence-05 説明: ADR-0005 整合(自動昇格削除)
  - 整合性メモの API 操作数: 24 → 28(A-25〜A-28 追加経緯併記)
- docs/reviews/2026-05-10-scaffold-vs-design-gap-analysis.md:
  - エンドポイント数: 27 → 28

## チェックリスト(ADR-0005 §6 step 5)

- [x] CLAUDE.md バージョン同期(PR #191 で同梱済)
- [x] docs/README.md バージョン参照同期
- [x] gap-analysis エンドポイント数同期
- [x] README.md(リポジトリルート)— OpenAPI / バージョン記載なしのため変更不要を確認

## ADR-0005 §6 完了

本 PR マージで ADR-0005 §6 step 2〜5 がすべて完了します。
- step 2: 要件定義書 v1.4.3(PR #189、マージ済)
- step 3: 基本設計書 v1.4.4(マージ済)
- step 4: OpenAPI v1.4.5(PR #191、マージ済)
- step 5: CLAUDE.md(PR #191 同梱、マージ済)+ 本 PR(docs/README.md / gap-analysis)

## レビュー観点

- バージョン番号と件数の整合性のみ。設計判断を含まない単純追従 PR