### PR TITLE
feat: add claude-automation shim workflows (Phase 2 Step 1)

### DIFF
--- a/.github/workflows/claude-auto-merge.yml
+++ b/.github/workflows/claude-auto-merge.yml
@@ -12,10 +12,21 @@ permissions:
   contents: write
   pull-requests: write
 
+concurrency:
+  group: claude-auto-merge-shim-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
 jobs:
   auto-merge:
+    # 起動条件:
+    # (1) approve された
+    # (2) approve した actor が claude-automation-review[bot](人や他 bot の approve では起動しない)
+    # (3) needs-human-decision ラベルが付いていない
     if: |
       github.event.review.state == 'approved' &&
+      github.event.review.user.login == 'claude-automation-review[bot]' &&
       !contains(github.event.pull_request.labels.*.name, 'needs-human-decision')
     uses: win2cot/claude-automation/.github/workflows/reusable-auto-merge.yml@v1
-    secrets: inherit
+    secrets:
+      CLAUDE_REVIEW_APP_ID: ${{ secrets.CLAUDE_REVIEW_APP_ID }}
+      CLAUDE_REVIEW_PRIVATE_KEY: ${{ secrets.CLAUDE_REVIEW_PRIVATE_KEY }}

--- a/.github/workflows/claude-auto-merge.yml
+++ b/.github/workflows/claude-auto-merge.yml
@@ -1,0 +1,21 @@
+# Claude Auto Merge shim
+# レビュワ Claude approve で auto-merge を有効化。
+# 本体は win2cot/claude-automation の reusable-auto-merge.yml@v1。
+
+name: Claude Auto Merge
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: |
+      github.event.review.state == 'approved' &&
+      !contains(github.event.pull_request.labels.*.name, 'needs-human-decision')
+    uses: win2cot/claude-automation/.github/workflows/reusable-auto-merge.yml@v1
+    secrets: inherit

--- a/.github/workflows/claude-auto-merge.yml
+++ b/.github/workflows/claude-auto-merge.yml
@@ -12,9 +12,11 @@ permissions:
   contents: write
   pull-requests: write
 
+# auto-merge 有効化は冪等(既に有効なら 2 回目は no-op)のため、キュー積み上がりを避けて
+# 直近のイベントだけを処理する設計にする(cancel-in-progress: true)
 concurrency:
   group: claude-auto-merge-shim-${{ github.event.pull_request.number }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   auto-merge:

--- a/.github/workflows/claude-impl-fix.yml
+++ b/.github/workflows/claude-impl-fix.yml
@@ -17,10 +17,20 @@ permissions:
   id-token: write
   actions: read
 
+concurrency:
+  group: claude-impl-fix-shim-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
 jobs:
   impl-fix:
+    # 起動条件:
+    # (1) review が changes_requested で submit された(人 or レビュワ bot どちらでも)
+    # (2) PR レビューコメントが投稿された かつ 投稿者が impl bot 自身でない(自己ループ防止)
     if: |
       (github.event_name == 'pull_request_review' && github.event.review.state == 'changes_requested') ||
-      github.event_name == 'pull_request_review_comment'
+      (github.event_name == 'pull_request_review_comment' && github.event.comment.user.login != 'claude-automation-impl[bot]')
     uses: win2cot/claude-automation/.github/workflows/reusable-impl-fix.yml@v1
-    secrets: inherit
+    secrets:
+      CLAUDE_IMPL_APP_ID: ${{ secrets.CLAUDE_IMPL_APP_ID }}
+      CLAUDE_IMPL_PRIVATE_KEY: ${{ secrets.CLAUDE_IMPL_PRIVATE_KEY }}
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/claude-impl-fix.yml
+++ b/.github/workflows/claude-impl-fix.yml
@@ -1,0 +1,26 @@
+# Claude Impl Fix shim
+# レビュー指摘を受けて実装 Claude が修正コミット + 対応完了レポート投稿。
+# 本体は win2cot/claude-automation の reusable-impl-fix.yml@v1。
+
+name: Claude Impl Fix
+
+on:
+  pull_request_review:
+    types: [submitted]
+  pull_request_review_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  id-token: write
+  actions: read
+
+jobs:
+  impl-fix:
+    if: |
+      (github.event_name == 'pull_request_review' && github.event.review.state == 'changes_requested') ||
+      github.event_name == 'pull_request_review_comment'
+    uses: win2cot/claude-automation/.github/workflows/reusable-impl-fix.yml@v1
+    secrets: inherit

--- a/.github/workflows/claude-impl.yml
+++ b/.github/workflows/claude-impl.yml
@@ -1,0 +1,22 @@
+# Claude Impl shim
+# claude:ready ラベル付与で実装 Claude を起動。
+# 本体は win2cot/claude-automation の reusable-impl.yml@v1。
+
+name: Claude Impl
+
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  id-token: write
+  actions: read
+
+jobs:
+  impl:
+    if: github.event.label.name == 'claude:ready'
+    uses: win2cot/claude-automation/.github/workflows/reusable-impl.yml@v1
+    secrets: inherit

--- a/.github/workflows/claude-impl.yml
+++ b/.github/workflows/claude-impl.yml
@@ -15,8 +15,18 @@ permissions:
   id-token: write
   actions: read
 
+# 同一 Issue への重複起動防止(claude-automation 側 reusable にも concurrency はあるが、
+# shim 側でも明示することで予測可能性を高める)
+concurrency:
+  group: claude-impl-shim-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
 jobs:
   impl:
     if: github.event.label.name == 'claude:ready'
     uses: win2cot/claude-automation/.github/workflows/reusable-impl.yml@v1
-    secrets: inherit
+    # secrets は必要なものだけ明示(secrets: inherit は外部リポジトリへの全 secrets 漏洩リスクのため不使用)
+    secrets:
+      CLAUDE_IMPL_APP_ID: ${{ secrets.CLAUDE_IMPL_APP_ID }}
+      CLAUDE_IMPL_PRIVATE_KEY: ${{ secrets.CLAUDE_IMPL_PRIVATE_KEY }}
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/claude-notify-human.yml
+++ b/.github/workflows/claude-notify-human.yml
@@ -1,0 +1,24 @@
+# Claude Notify Human shim
+# needs-human-decision ラベル付与で @win2cot メンション + auto-merge 保険無効化。
+# 本体は win2cot/claude-automation の reusable-notify-human.yml@v1。
+
+name: Claude Notify Human
+
+on:
+  issues:
+    types: [labeled]
+  pull_request:
+    types: [labeled]
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  notify:
+    if: github.event.label.name == 'needs-human-decision'
+    uses: win2cot/claude-automation/.github/workflows/reusable-notify-human.yml@v1
+    secrets: inherit
+    with:
+      mention: '@win2cot'

--- a/.github/workflows/claude-notify-human.yml
+++ b/.github/workflows/claude-notify-human.yml
@@ -10,15 +10,21 @@ on:
   pull_request:
     types: [labeled]
 
+# contents:write は不要(コメント投稿と auto-merge 無効化のみ。最小権限原則)
 permissions:
-  contents: write
   issues: write
   pull-requests: write
+
+concurrency:
+  group: claude-notify-shim-${{ github.event.issue.number || github.event.pull_request.number }}
+  cancel-in-progress: false
 
 jobs:
   notify:
     if: github.event.label.name == 'needs-human-decision'
     uses: win2cot/claude-automation/.github/workflows/reusable-notify-human.yml@v1
-    secrets: inherit
+    secrets:
+      CLAUDE_IMPL_APP_ID: ${{ secrets.CLAUDE_IMPL_APP_ID }}
+      CLAUDE_IMPL_PRIVATE_KEY: ${{ secrets.CLAUDE_IMPL_PRIVATE_KEY }}
     with:
       mention: '@win2cot'

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -23,9 +23,13 @@ concurrency:
 
 jobs:
   review:
+    # 起動条件:
+    # (1) PR が ready_for_review になった
+    # (2) issue_comment が PR に投稿された かつ 投稿者が claude-automation-impl[bot] かつ
+    #     本文に signal: claude-impl-done を含む(任意のユーザによる起動を防ぐため投稿者を限定)
     if: |
       github.event_name == 'pull_request' ||
-      (github.event_name == 'issue_comment' && github.event.issue.pull_request != null && contains(github.event.comment.body, 'signal: claude-impl-done'))
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request != null && github.event.comment.user.login == 'claude-automation-impl[bot]' && contains(github.event.comment.body, 'signal: claude-impl-done'))
     uses: win2cot/claude-automation/.github/workflows/reusable-review.yml@v1
     secrets:
       CLAUDE_REVIEW_APP_ID: ${{ secrets.CLAUDE_REVIEW_APP_ID }}

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -17,10 +17,17 @@ permissions:
   id-token: write
   actions: read
 
+concurrency:
+  group: claude-review-shim-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: false
+
 jobs:
   review:
     if: |
       github.event_name == 'pull_request' ||
       (github.event_name == 'issue_comment' && github.event.issue.pull_request != null && contains(github.event.comment.body, 'signal: claude-impl-done'))
     uses: win2cot/claude-automation/.github/workflows/reusable-review.yml@v1
-    secrets: inherit
+    secrets:
+      CLAUDE_REVIEW_APP_ID: ${{ secrets.CLAUDE_REVIEW_APP_ID }}
+      CLAUDE_REVIEW_PRIVATE_KEY: ${{ secrets.CLAUDE_REVIEW_PRIVATE_KEY }}
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,26 @@
+# Claude Review shim
+# PR ready 化・対応完了レポートコメントでレビュワ Claude を起動。
+# 本体は win2cot/claude-automation の reusable-review.yml@v1。
+
+name: Claude Review
+
+on:
+  pull_request:
+    types: [ready_for_review]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  id-token: write
+  actions: read
+
+jobs:
+  review:
+    if: |
+      github.event_name == 'pull_request' ||
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request != null && contains(github.event.comment.body, 'signal: claude-impl-done'))
+    uses: win2cot/claude-automation/.github/workflows/reusable-review.yml@v1
+    secrets: inherit


### PR DESCRIPTION
## 変更内容

claude-automation の reusable workflow 5 つを @v1 参照で呼ぶ shim。

| ファイル | 役割 |
|---|---|
| `claude-impl.yml` | Issue (claude:ready) → impl Claude 起動 |
| `claude-impl-fix.yml` | review changes_requested / comment → 修正 |
| `claude-review.yml` | PR ready / 対応完了レポート → review Claude 起動 |
| `claude-auto-merge.yml` | approve → auto-merge 有効化 |
| `claude-notify-human.yml` | needs-human-decision → メンション + auto-merge 無効化 |

すべて `uses: win2cot/claude-automation/.github/workflows/reusable-*.yml@v1` で本体を参照。

## 動作影響

shim を入れただけでは何も自動起動しない。次の Phase 2 残ステップで完成:

- Step 2: ラベル確認(既に C-A で同期済み)
- Step 3: ブランチ保護調整(Required check に Claude workflow を含めない)
- Step 4: Allow auto-merge を ON に
- Step 5: 試験 Issue で動作確認

## 確認項目

- [x] 5 ファイルの内容が reusable-*.yml@v1 を正しく参照している
- [ ] merge 後、意図せず workflow が起動していないこと