### PR TITLE
docs(spec): §11 トランザクション 全面改訂(readOnly 常に明示 / Propagation・例外 / クラスレベル禁止)

### DIFF
--- a/docs/specs/コーディング規約.md
+++ b/docs/specs/コーディング規約.md
@@ -2,9 +2,9 @@
 
 タスク管理システム(tasks-webapi)
 
-Version 1.1
+Version 1.2
 
-2026-05-14
+2026-05-25
 
 作成者: 開発チーム
 
@@ -15,6 +15,7 @@ Version 1.1
 | 1.0 | 2026-05-14 | 新規作成。既存 scaffold(Spring Boot 4.0.6 / Java 21 / Spring Modulith 2.0.6)に整合 | 開発チーム |
 | 1.0 | 2026-05-22 | TOC 追加(Issue #131) | 開発チーム |
 | 1.1 | 2026-05-24 | §20 Native Image 実装制約 追加(Issue #223、ADR-0008) | 開発チーム |
+| 1.2 | 2026-05-25 | §11 トランザクション 全面改訂(`readOnly` 常に明示 / Propagation・例外 / クラスレベル禁止、Issue #254、#86 事前議論派生) | 開発チーム |
 
 ## 目次
 
@@ -54,6 +55,9 @@ Version 1.1
   - [9.6 アサーションスタイル](#96-アサーションスタイル)
 - [10. 依存性注入](#10-依存性注入)
 - [11. トランザクション](#11-トランザクション)
+  - [11.1 `readOnly` の明示](#111-readonly-の明示)
+  - [11.2 Propagation と例外ケース](#112-propagation-と例外ケース)
+  - [11.3 クラスレベル付与の禁止](#113-クラスレベル付与の禁止)
 - [12. 日時・タイムゾーン](#12-日時タイムゾーン)
   - [12.1 JDBC ↔ Java 日時型のマッピング設定(重要)](#121-jdbc--java-日時型のマッピング設定重要)
 - [13. 文字列リテラルと国際化](#13-文字列リテラルと国際化)
@@ -426,9 +430,88 @@ public class TaskUseCase {
 
 ## 11. トランザクション
 
-- `@Transactional` は **`usecase` 層のみ**に付与する。Controller / Repository に付けない(設計規約 §1.2.3)。
-- 読み取りのみのユースケースには `@Transactional(readOnly = true)` を付ける。
-- ネストや伝播属性(`Propagation.REQUIRES_NEW` 等)を使う場合は、**メソッドの Javadoc に理由を残す**。
+`@Transactional` は **`usecase` 層のメソッドに付与** する。Controller / Repository / Domain には付けない(設計規約 §1.2.3)。クラスレベル付与は禁止し、必ずメソッドレベルで明示する(§11.3)。
+
+### 11.1 `readOnly` の明示
+
+`@Transactional` を付与する場合、`readOnly` 属性を **常に明示** する(`true` / `false` どちらでも、暗黙の Spring デフォルトに依存しない)。
+
+```java
+// OK: 読み取り専用 usecase
+@Transactional(readOnly = true)
+public TaskView getTask(Long taskId) { ... }
+
+// OK: 書き込み usecase(false を明示)
+@Transactional(readOnly = false)
+public Task createTask(TaskCreateCommand cmd) { ... }
+
+// NG: readOnly 省略(Spring デフォルト = false に依存)
+@Transactional
+public Task createTask(TaskCreateCommand cmd) { ... }
+```
+
+**理由**: Spring の素のデフォルトは `readOnly = false` だが、規約レベルでは「default は何か」の議論を排除し、**1 行見ればその usecase が読み取りか書き込みか判別できる** ことをレビュー効率の観点で優先する。
+
+### 11.2 Propagation と例外ケース
+
+**read-then-write は単一 usecase 内で完結** する(read 用 usecase の中から別の write 用 usecase を呼び出して 1 トランザクションにしようとしない、別 `@Transactional` の service / usecase を呼び出さない)。ネストした transaction の振る舞いを暗黙の Propagation に依存させないため。同一 usecase 内で read と write を順に行うのは通常の書き込み usecase であり、`@Transactional(readOnly = false)` を付与すれば OK。
+
+ネストや伝播属性(`Propagation.REQUIRES_NEW` 等)を使う場合は、**メソッドの Javadoc に理由を明示** する。
+
+```java
+/**
+ * 監査ログは元 transaction の rollback と独立して必ず記録するため
+ * REQUIRES_NEW で別 transaction にする。
+ */
+@Transactional(propagation = Propagation.REQUIRES_NEW, readOnly = false)
+public void recordAuditEntry(AuditEntry entry) { ... }
+```
+
+**Exception rollback rules**:
+
+- デフォルトでは **unchecked exception(`RuntimeException` / `Error`)のみ rollback トリガー**(Spring の挙動)。
+- `rollbackFor = ...` / `noRollbackFor = ...` を使う場合は **Javadoc で理由を明示** する。
+
+```java
+/**
+ * Mail 送信失敗(checked IOException)時もタスク作成は rollback したいため
+ * rollbackFor を明示。
+ */
+@Transactional(readOnly = false, rollbackFor = { IOException.class })
+public Task createTaskAndNotify(TaskCreateCommand cmd) throws IOException { ... }
+```
+
+**JPA flush の挙動**: `readOnly = true` を付与すると、Spring の `HibernateJpaDialect#beginTransaction` が Hibernate session の flush mode を **`FlushMode.MANUAL`** に切り替え、commit 時の自動 flush(dirty checking 経由の暗黙 UPDATE)を抑止する(これが Spring の "read-only optimization" の主機構)。ただし以下の経路では `readOnly = true` でも DB 書き込みが走る:
+
+- `entityManager.flush()` の **明示呼び出し**
+- JPQL `UPDATE` / `DELETE`(`query.executeUpdate()`)
+- Native SQL の `UPDATE` / `DELETE` / `INSERT`
+- 2nd-level cache の更新(`@Cache` 設定の Entity)
+
+つまり「不注意による書き込み」は防げるが「**意図的な書き込み**」までは bypass されないため、`domain` 層オブジェクトの mutation や上記 4 経路の書き込み API は read-only usecase 内で **書かない**。書き込みが必要なら `@Transactional(readOnly = false)` の usecase に分離する(§11.2 冒頭の「read-then-write は単一 usecase 内で完結」と整合)。
+
+### 11.3 クラスレベル付与の禁止
+
+`@Transactional` を **クラスレベルに付与しない**。メソッドレベルでのみ付与する。
+
+```java
+// NG: クラスレベル付与
+@Service
+@Transactional  // ← 禁止
+public class TaskUseCase { ... }
+
+// OK: 各メソッドに明示
+@Service
+public class TaskUseCase {
+  @Transactional(readOnly = true)
+  public TaskView getTask(Long id) { ... }
+
+  @Transactional(readOnly = false)
+  public Task createTask(TaskCreateCommand cmd) { ... }
+}
+```
+
+**理由**: クラスレベル付与だと「このクラスの全 public method が `@Transactional` 適用」になり、メソッド単位の `readOnly` 値が一望できなくなる。レビュー・grep いずれの面でも不便。
 
 ---
 


### PR DESCRIPTION
## 概要

#86 (N4) 事前議論で確定した `@Transactional` 境界方針について、コーディング規約 §11 を全面改訂する。

## 背景

既存 §11(3 bullet)は「読み取り opt-in、書き込みは Spring デフォルト依存」の構成で、レビュー時の判別性に欠けていた。#254 議論(2026-05-25)で以下が確定:

- **D1** `readOnly` 属性を**常に明示**(true/false どちらでも)
- **D2** §11 に §11.1〜§11.3 のサブセクションを追加
- **D3** クラスレベル `@Transactional` 禁止 + Exception rollback rules(`rollbackFor` 使用時 Javadoc 必須)
- **D4** §11 トップを intro 化 + サブ 3 つで詳細化

## 変更内容

- `docs/specs/コーディング規約.md` version 1.1 → 1.2
- 改訂履歴に v1.2 行追加
- TOC に §11.1 / §11.2 / §11.3 を追加
- §11 を全面書き換え:
  - intro: usecase 層メソッド限定 + クラスレベル禁止の宣言 + §1.2.3 cross-ref
  - §11.1 readOnly の明示(OK/NG 例 + 理由)
  - §11.2 Propagation と例外ケース(REQUIRES_NEW 理由 Javadoc / rollbackFor 理由 Javadoc / JPA flush 挙動の正確な記述)
  - §11.3 クラスレベル付与の禁止(OK/NG 例 + 理由)

## セルフレビュー

- engineering:code-review スキルでレビュー実施
- Critical 1 件(JPA flush 挙動の技術誤り)を検出 → 修正済
  - 修正前: "FlushMode は MANUAL に自動切替されない"(誤)
  - 修正後: "Spring の HibernateJpaDialect が FlushMode.MANUAL に切替える(これが read-only optimization の主機構)+ ただし em.flush() / JPQL UPDATE / Native SQL / 2nd-level cache の 4 経路で bypass される"
- Suggestion 1 件(read-then-write の趣旨明確化)も同時修正済
- Suggestion 1 件(設計規約 §1.2.3 の Domain 追加)は別 Issue 検討、本 PR スコープ外

## 影響範囲

- 規約ドキュメントのみ。コード変更なし。
- 既存 scaffold には現状 `@Transactional` 付与箇所は無いため、retrofit は不要。
- 新規実装(Sprint 0 #86 着手以降)で本規約に従う。

## 関連 Issue

- Closes #254
- Blocks #86(本 PR merge 後に #86 着手可能)

## 受け入れ条件

- [x] §11 が新構造(intro + §11.1〜§11.3)に置き換わっている
- [x] §11.1 で `readOnly` 常に明示 + OK/NG 例
- [x] §11.2 で Propagation 理由 Javadoc + rollbackFor 理由 Javadoc + JPA flush 挙動の正確な注記
- [x] §11.3 でクラスレベル付与禁止 + OK/NG 例
- [x] 改訂履歴に追記
- [ ] #86 着手前(2026-06-14 以前)に merge ← レビュアー確認