### PR TITLE
feat(arch): B-1 基盤 - shared/exception + Task POJO/JPA 分離 + Repository ポート (N4 / B-1) (#273)

### DIFF
--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/shared/exception/DomainException.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/shared/exception/DomainException.java
@@ -1,0 +1,18 @@
+package xyz.dgz48.tasks.webapi.shared.exception;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * 業務例外の基底クラス。{@code @ResponseStatus} は付与せず、各 feature の {@code @RestControllerAdvice} で HTTP
+ * ステータスにマップする(設計規約 §1.1)。
+ */
+public abstract class DomainException extends RuntimeException {
+
+  protected DomainException(String message) {
+    super(message);
+  }
+
+  protected DomainException(String message, @Nullable Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/shared/exception/package-info.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/shared/exception/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package xyz.dgz48.tasks.webapi.shared.exception;
+
+import org.jspecify.annotations.NullMarked;

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/adapter/persistence/TaskJpaEntity.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/adapter/persistence/TaskJpaEntity.java
@@ -25,7 +25,7 @@ import xyz.dgz48.tasks.webapi.task.domain.Visibility;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SuppressWarnings("NullAway.Init") // JPA requires no-args constructor; fields initialized via JPA
-public class Task {
+public class TaskJpaEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -77,7 +77,7 @@ public class Task {
   @Column(name = "updated_at", nullable = false)
   private LocalDateTime updatedAt;
 
-  public Task(
+  public TaskJpaEntity(
       Long tenantId,
       Long ownerId,
       String title,

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/adapter/persistence/TaskJpaRepository.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/adapter/persistence/TaskJpaRepository.java
@@ -1,0 +1,9 @@
+package xyz.dgz48.tasks.webapi.task.adapter.persistence;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+interface TaskJpaRepository extends JpaRepository<TaskJpaEntity, Long> {
+
+  Optional<TaskJpaEntity> findByIdAndTenantId(Long id, Long tenantId);
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/adapter/persistence/TaskJpaRepositoryAdapter.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/adapter/persistence/TaskJpaRepositoryAdapter.java
@@ -1,0 +1,41 @@
+package xyz.dgz48.tasks.webapi.task.adapter.persistence;
+
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import xyz.dgz48.tasks.webapi.task.domain.Task;
+import xyz.dgz48.tasks.webapi.task.usecase.TaskRepository;
+
+/**
+ * {@link TaskRepository} ポートを Spring Data JPA で実装。 {@link TaskJpaEntity} と {@link Task}
+ * ドメインモデル間の変換責務を担う。
+ */
+@Component
+@RequiredArgsConstructor
+class TaskJpaRepositoryAdapter implements TaskRepository {
+
+  private final TaskJpaRepository jpaRepository;
+
+  @Override
+  public Optional<Task> findByIdAndTenantId(Long id, Long tenantId) {
+    return jpaRepository.findByIdAndTenantId(id, tenantId).map(this::toDomain);
+  }
+
+  private Task toDomain(TaskJpaEntity entity) {
+    return new Task(
+        entity.getId(),
+        entity.getTenantId(),
+        entity.getTitle(),
+        entity.getDescription(),
+        entity.getStatus(),
+        entity.getPriority(),
+        entity.getVisibility(),
+        entity.getOwnerId(),
+        entity.getAssigneeId(),
+        entity.getDueDate(),
+        entity.getCompletedAt(),
+        entity.getDeletedAt(),
+        entity.getCreatedAt(),
+        entity.getUpdatedAt());
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/domain/Task.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/domain/Task.java
@@ -2,9 +2,9 @@ package xyz.dgz48.tasks.webapi.task.domain;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -12,7 +12,7 @@ import org.jspecify.annotations.Nullable;
  * TaskJpaEntity} と相互変換する。
  */
 @Getter
-@AllArgsConstructor
+@RequiredArgsConstructor
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class Task {
 

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/domain/Task.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/domain/Task.java
@@ -1,0 +1,33 @@
+package xyz.dgz48.tasks.webapi.task.domain;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Task ドメインモデル(JPA 非依存 POJO)。 設計規約 §1.1 のクリーンアーキ 4 層に従い domain 層に配置。 Persistence 層では {@code
+ * TaskJpaEntity} と相互変換する。
+ */
+@Getter
+@AllArgsConstructor
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+public class Task {
+
+  @EqualsAndHashCode.Include private final Long id;
+  private final Long tenantId;
+  private final String title;
+  @Nullable private final String description;
+  private final TaskStatus status;
+  private final Priority priority;
+  private final Visibility visibility;
+  private final Long ownerId;
+  @Nullable private final Long assigneeId;
+  private final LocalDate dueDate;
+  @Nullable private final LocalDateTime completedAt;
+  @Nullable private final LocalDateTime deletedAt;
+  private final LocalDateTime createdAt;
+  private final LocalDateTime updatedAt;
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/domain/TaskAuthorizationDomainService.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/domain/TaskAuthorizationDomainService.java
@@ -1,7 +1,6 @@
 package xyz.dgz48.tasks.webapi.task.domain;
 
 import java.util.List;
-import xyz.dgz48.tasks.webapi.task.adapter.persistence.Task;
 
 /**
  * タスクごとの認可判定 SSOT — 基本設計書 §6.2.1 参照。
@@ -10,9 +9,7 @@ import xyz.dgz48.tasks.webapi.task.adapter.persistence.Task;
  * の infra 設定クラスで {@code @Bean} 登録する。各メソッドは boolean を返し、 UseCase 層が false 時に
  * TaskNotViewableException(404) または TaskOwnershipException(403) を throw する。
  *
- * <p>TODO: {@link Task} は JPA エンティティ({@code @Entity})であり、Domain 層の純粋性を損なっている。 将来的には {@code
- * task.domain} に JPA 非依存のドメインモデルを分離し、{@link Task} エンティティは {@code task.adapter.persistence}
- * へ移動することが推奨される(技術的負債)。
+ * <p>B-1 (#273) で Domain {@link Task}(POJO)を新規追加し、本クラスは domain.Task を参照する形に整理した。
  */
 public class TaskAuthorizationDomainService {
 

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/usecase/TaskRepository.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/usecase/TaskRepository.java
@@ -1,0 +1,10 @@
+package xyz.dgz48.tasks.webapi.task.usecase;
+
+import java.util.Optional;
+import xyz.dgz48.tasks.webapi.task.domain.Task;
+
+/** Task の永続化ポート。adapter.persistence の {@code TaskJpaRepositoryAdapter} で実装される。 */
+public interface TaskRepository {
+
+  Optional<Task> findByIdAndTenantId(Long id, Long tenantId);
+}

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/SecurityConfigTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/SecurityConfigTest.java
@@ -1,4 +1,4 @@
-package xyz.dgz48.tasks.webapi.security;
+package xyz.dgz48.tasks.webapi.security.adapter.web;
 
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -11,8 +11,6 @@ import org.springframework.context.annotation.Import;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
-import xyz.dgz48.tasks.webapi.security.adapter.web.SecurityConfig;
-import xyz.dgz48.tasks.webapi.security.adapter.web.TasksJwtAuthenticationConverter;
 import xyz.dgz48.tasks.webapi.user.adapter.persistence.UserRepository;
 
 @WebMvcTest

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/TasksAuthenticationTokenTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/TasksAuthenticationTokenTest.java
@@ -1,10 +1,9 @@
-package xyz.dgz48.tasks.webapi.security;
+package xyz.dgz48.tasks.webapi.security.adapter.web;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 import org.junit.jupiter.api.Test;
-import xyz.dgz48.tasks.webapi.security.adapter.web.TasksAuthenticationToken;
 import xyz.dgz48.tasks.webapi.security.domain.TasksPrincipal;
 
 class TasksAuthenticationTokenTest {

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/TasksJwtAuthenticationConverterTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/TasksJwtAuthenticationConverterTest.java
@@ -1,4 +1,4 @@
-package xyz.dgz48.tasks.webapi.security;
+package xyz.dgz48.tasks.webapi.security.adapter.web;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -13,8 +13,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.server.resource.InvalidBearerTokenException;
-import xyz.dgz48.tasks.webapi.security.adapter.web.TasksAuthenticationToken;
-import xyz.dgz48.tasks.webapi.security.adapter.web.TasksJwtAuthenticationConverter;
 import xyz.dgz48.tasks.webapi.security.domain.TasksPrincipal;
 import xyz.dgz48.tasks.webapi.user.adapter.persistence.User;
 import xyz.dgz48.tasks.webapi.user.adapter.persistence.UserRepository;

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/domain/TasksPrincipalTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/domain/TasksPrincipalTest.java
@@ -1,9 +1,8 @@
-package xyz.dgz48.tasks.webapi.security;
+package xyz.dgz48.tasks.webapi.security.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
-import xyz.dgz48.tasks.webapi.security.domain.TasksPrincipal;
 
 class TasksPrincipalTest {
 

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/shared/exception/DomainExceptionTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/shared/exception/DomainExceptionTest.java
@@ -1,0 +1,40 @@
+package xyz.dgz48.tasks.webapi.shared.exception;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class DomainExceptionTest {
+
+  /** 匿名サブクラス: {@link DomainException} は abstract のため、test 内で具象化して挙動を検証。 */
+  private static final class TestDomainException extends DomainException {
+    TestDomainException(String message) {
+      super(message);
+    }
+
+    TestDomainException(String message, Throwable cause) {
+      super(message, cause);
+    }
+  }
+
+  @Test
+  void messageOnlyConstructorPropagatesMessage() {
+    var ex = new TestDomainException("boom");
+    assertThat(ex.getMessage()).isEqualTo("boom");
+    assertThat(ex.getCause()).isNull();
+  }
+
+  @Test
+  void messageAndCauseConstructorPropagatesBoth() {
+    var cause = new IllegalStateException("root");
+    var ex = new TestDomainException("boom", cause);
+    assertThat(ex.getMessage()).isEqualTo("boom");
+    assertThat(ex.getCause()).isSameAs(cause);
+  }
+
+  @Test
+  void isRuntimeExceptionSubclass() {
+    var ex = new TestDomainException("boom");
+    assertThat(ex).isInstanceOf(RuntimeException.class);
+  }
+}

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/adapter/persistence/TaskEntityTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/adapter/persistence/TaskEntityTest.java
@@ -1,4 +1,4 @@
-package xyz.dgz48.tasks.webapi.task;
+package xyz.dgz48.tasks.webapi.task.adapter.persistence;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -11,7 +11,6 @@ import org.springframework.context.annotation.Import;
 import org.springframework.transaction.annotation.Transactional;
 import xyz.dgz48.tasks.webapi.MockJwtDecoderConfiguration;
 import xyz.dgz48.tasks.webapi.TestcontainersConfiguration;
-import xyz.dgz48.tasks.webapi.task.adapter.persistence.Task;
 import xyz.dgz48.tasks.webapi.task.domain.Priority;
 import xyz.dgz48.tasks.webapi.task.domain.TaskStatus;
 import xyz.dgz48.tasks.webapi.tenant.adapter.persistence.Tenant;
@@ -56,7 +55,7 @@ class TaskEntityTest {
     entityManager.flush();
 
     var task =
-        new Task(
+        new TaskJpaEntity(
             tenant.getId(),
             user.getId(),
             "タスク1",
@@ -85,7 +84,7 @@ class TaskEntityTest {
     entityManager.flush();
 
     var task =
-        new Task(
+        new TaskJpaEntity(
             tenant.getId(),
             user.getId(),
             "完了タスク",
@@ -112,7 +111,7 @@ class TaskEntityTest {
     entityManager.flush();
 
     var task =
-        new Task(
+        new TaskJpaEntity(
             tenant.getId(),
             user.getId(),
             "進行中タスク",
@@ -137,7 +136,7 @@ class TaskEntityTest {
     entityManager.flush();
 
     var task =
-        new Task(
+        new TaskJpaEntity(
             tenant.getId(),
             user.getId(),
             "保留タスク",

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/adapter/persistence/TaskJpaRepositoryAdapterTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/adapter/persistence/TaskJpaRepositoryAdapterTest.java
@@ -1,0 +1,93 @@
+package xyz.dgz48.tasks.webapi.task.adapter.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.persistence.EntityManager;
+import java.time.LocalDate;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.transaction.annotation.Transactional;
+import xyz.dgz48.tasks.webapi.MockJwtDecoderConfiguration;
+import xyz.dgz48.tasks.webapi.TestcontainersConfiguration;
+import xyz.dgz48.tasks.webapi.task.domain.Priority;
+import xyz.dgz48.tasks.webapi.task.domain.Task;
+import xyz.dgz48.tasks.webapi.task.domain.TaskStatus;
+import xyz.dgz48.tasks.webapi.task.usecase.TaskRepository;
+import xyz.dgz48.tasks.webapi.tenant.adapter.persistence.Tenant;
+import xyz.dgz48.tasks.webapi.user.adapter.persistence.User;
+
+@SpringBootTest
+@Import({TestcontainersConfiguration.class, MockJwtDecoderConfiguration.class})
+@Transactional
+class TaskJpaRepositoryAdapterTest {
+
+  @Autowired EntityManager entityManager;
+  @Autowired TaskRepository taskRepository;
+
+  @Test
+  void findByIdAndTenantIdReturnsDomainTaskWhenFound() {
+    var tenant = new Tenant("TENANT-ADP-1", "テナント A");
+    entityManager.persist(tenant);
+    var user = new User("sub-adp-1", "adp1@example.com", "山田 太郎", "ヤマダ タロウ", null);
+    entityManager.persist(user);
+    entityManager.flush();
+
+    var jpa =
+        new TaskJpaEntity(
+            tenant.getId(),
+            user.getId(),
+            "アダプタテスト",
+            "詳細",
+            TaskStatus.NOT_STARTED,
+            Priority.MEDIUM,
+            LocalDate.of(2026, 12, 31));
+    entityManager.persist(jpa);
+    entityManager.flush();
+    entityManager.clear();
+
+    var found = taskRepository.findByIdAndTenantId(jpa.getId(), tenant.getId());
+
+    assertThat(found).isPresent();
+    Task task = found.get();
+    assertThat(task.getId()).isEqualTo(jpa.getId());
+    assertThat(task.getTenantId()).isEqualTo(tenant.getId());
+    assertThat(task.getTitle()).isEqualTo("アダプタテスト");
+    assertThat(task.getDescription()).isEqualTo("詳細");
+    assertThat(task.getStatus()).isEqualTo(TaskStatus.NOT_STARTED);
+    assertThat(task.getPriority()).isEqualTo(Priority.MEDIUM);
+    assertThat(task.getOwnerId()).isEqualTo(user.getId());
+  }
+
+  @Test
+  void findByIdAndTenantIdReturnsEmptyWhenNotFound() {
+    var found = taskRepository.findByIdAndTenantId(999_999L, 999_999L);
+    assertThat(found).isEmpty();
+  }
+
+  @Test
+  void findByIdAndTenantIdReturnsEmptyWhenTenantMismatch() {
+    var tenant = new Tenant("TENANT-ADP-2", "テナント B");
+    entityManager.persist(tenant);
+    var user = new User("sub-adp-2", "adp2@example.com", "鈴木 花子", "スズキ ハナコ", null);
+    entityManager.persist(user);
+    entityManager.flush();
+
+    var jpa =
+        new TaskJpaEntity(
+            tenant.getId(),
+            user.getId(),
+            "別テナント",
+            null,
+            TaskStatus.NOT_STARTED,
+            Priority.LOW,
+            LocalDate.of(2026, 12, 31));
+    entityManager.persist(jpa);
+    entityManager.flush();
+
+    // 別 tenant id で探すと空
+    var found = taskRepository.findByIdAndTenantId(jpa.getId(), tenant.getId() + 99_999L);
+    assertThat(found).isEmpty();
+  }
+}

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/domain/TaskAuthorizationDomainServiceTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/domain/TaskAuthorizationDomainServiceTest.java
@@ -8,7 +8,6 @@ import java.util.List;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import xyz.dgz48.tasks.webapi.task.adapter.persistence.Task;
 
 class TaskAuthorizationDomainServiceTest {
 

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/user/adapter/persistence/UserEntityTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/user/adapter/persistence/UserEntityTest.java
@@ -1,4 +1,4 @@
-package xyz.dgz48.tasks.webapi.user;
+package xyz.dgz48.tasks.webapi.user.adapter.persistence;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -10,7 +10,6 @@ import org.springframework.context.annotation.Import;
 import org.springframework.transaction.annotation.Transactional;
 import xyz.dgz48.tasks.webapi.MockJwtDecoderConfiguration;
 import xyz.dgz48.tasks.webapi.TestcontainersConfiguration;
-import xyz.dgz48.tasks.webapi.user.adapter.persistence.User;
 
 @SpringBootTest
 @Import({TestcontainersConfiguration.class, MockJwtDecoderConfiguration.class})


### PR DESCRIPTION
## 概要

A-1 (#86) / A-2 (#272) で整えた 4 層パッケージ上に、GET /api/tasks/{id} 実装の **基盤層**(shared 例外基底 + JPA Entity / Domain POJO 分離 + Repository ポート)を整備。実装 Claude が `git mv` 等 allowedTools 不足で permission denial-loop(15 denials)に陥り max-turn 内に signal 投稿せず Aborted (reason=unknown) で停止したため、人手対応で完遂(memory `project_n4_split_2026_05_29.md` 参照)。

Closes #273

## 本 PR のスコープ(B-1)

- `shared/exception/DomainException.java` + `package-info.java` 新規(業務例外基底、`@ResponseStatus` 禁止)
- `task/domain/Task.java` 新規(JPA 非依存 POJO、`@Getter` + `@AllArgsConstructor` + `@EqualsAndHashCode(onlyExplicitlyIncluded = true)` on `id`)
- `task/adapter/persistence/Task.java` → `TaskJpaEntity.java` `git mv` + クラス宣言修正(JPA アノテーション・スキーマ不変)
- `task/usecase/TaskRepository.java`(ポート interface、`findByIdAndTenantId(Long, Long)` のみ)
- `task/adapter/persistence/TaskJpaRepository.java`(Spring Data JPA、package-private)
- `task/adapter/persistence/TaskJpaRepositoryAdapter.java`(`@Component` で `TaskRepository` 実装、`TaskJpaEntity` → Domain `Task` 変換)
- `TaskAuthorizationDomainService` / 同 Test / `TaskEntityTest` の import 切替・class 名追従(技術的負債 TODO 削除込み)

## やらないこと(B-2 / B-3 範疇)

- `GetTaskUseCase` / `TaskController` / `TaskExceptionHandler` / DTO / 例外 → B-2 (#278)
- DB migration `created_by`/`updated_by` 列追加 / 統合 IT / AuthZ test 更新 → B-3 (#279)

## 検証

- `./gradlew :webapi:compileJava :webapi:compileTestJava` green
- `./gradlew :webapi:test` green (49/49、Testcontainers 経由 JPA 統合テスト含む)
- `ApplicationModules.verify()` green

## 参照

- 前提: #86 / #272 merge 済
- 規約: 設計規約 §1.1 / ADR-0003
- 関連: #273 (本 PR Closes) / #278 (B-2、blocked-by 本) / #279 (B-3) / #274 (C) / #90 (N8、blocked-by #272)
- 経緯: 実装 Claude 1st attempt run id 26654032333 が `git mv` 含む allowedTools 不足で 15 denials → signal なし Aborted → 人手対応(claude-automation 側 SM-19 派生 SM 起票候補)