### PR TITLE
feat(arch): 関連 JPA Entity を ~JpaEntity サフィックスへリネーム (User/Tenant) (#138)

### DIFF
--- a/webapi/build.gradle
+++ b/webapi/build.gradle
@@ -91,6 +91,8 @@ jacocoTestReport {
 }
 
 spotless {
+    // OS に依存せず常に LF を正とする(CI は Linux=LF、Windows ローカルでの CRLF 誤検知を防ぐ)。
+    lineEndings = 'UNIX'
     java {
         googleJavaFormat('1.24.0')
     }

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/security/adapter/web/TasksJwtAuthenticationConverter.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/security/adapter/web/TasksJwtAuthenticationConverter.java
@@ -7,7 +7,7 @@ import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.server.resource.InvalidBearerTokenException;
 import org.springframework.stereotype.Component;
 import xyz.dgz48.tasks.webapi.security.domain.TasksPrincipal;
-import xyz.dgz48.tasks.webapi.user.adapter.persistence.User;
+import xyz.dgz48.tasks.webapi.user.adapter.persistence.UserJpaEntity;
 import xyz.dgz48.tasks.webapi.user.adapter.persistence.UserRepository;
 
 @Component
@@ -26,7 +26,7 @@ public class TasksJwtAuthenticationConverter
     if (sub == null) {
       throw new InvalidBearerTokenException("JWT missing sub claim");
     }
-    User user =
+    UserJpaEntity user =
         userRepository
             .findByOidcSub(sub)
             .orElseThrow(

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/adapter/persistence/TenantJpaEntity.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/adapter/persistence/TenantJpaEntity.java
@@ -22,7 +22,7 @@ import xyz.dgz48.tasks.webapi.tenant.domain.TenantStatus;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SuppressWarnings("NullAway.Init") // JPA requires no-args constructor; fields initialized via JPA
-public class Tenant {
+public class TenantJpaEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -48,7 +48,7 @@ public class Tenant {
   @Column(name = "updated_at", nullable = false)
   private LocalDateTime updatedAt;
 
-  public Tenant(String code, String name) {
+  public TenantJpaEntity(String code, String name) {
     this.code = code;
     this.name = name;
     this.plan = TenantPlan.STANDARD;

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/adapter/persistence/UserJpaEntity.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/adapter/persistence/UserJpaEntity.java
@@ -16,7 +16,7 @@ import org.jspecify.annotations.Nullable;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SuppressWarnings("NullAway.Init") // JPA requires no-args constructor; fields initialized via JPA
-public class User {
+public class UserJpaEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -38,7 +38,7 @@ public class User {
   @Column(name = "department_name", length = 255)
   private String departmentName;
 
-  public User(
+  public UserJpaEntity(
       String oidcSub,
       String email,
       String fullName,

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/adapter/persistence/UserRepository.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/adapter/persistence/UserRepository.java
@@ -3,6 +3,6 @@ package xyz.dgz48.tasks.webapi.user.adapter.persistence;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface UserRepository extends JpaRepository<User, Long> {
-  Optional<User> findByOidcSub(String oidcSub);
+public interface UserRepository extends JpaRepository<UserJpaEntity, Long> {
+  Optional<UserJpaEntity> findByOidcSub(String oidcSub);
 }

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/TasksJwtAuthenticationConverterTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/TasksJwtAuthenticationConverterTest.java
@@ -14,7 +14,7 @@ import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.server.resource.InvalidBearerTokenException;
 import xyz.dgz48.tasks.webapi.security.domain.TasksPrincipal;
-import xyz.dgz48.tasks.webapi.user.adapter.persistence.User;
+import xyz.dgz48.tasks.webapi.user.adapter.persistence.UserJpaEntity;
 import xyz.dgz48.tasks.webapi.user.adapter.persistence.UserRepository;
 
 @ExtendWith(MockitoExtension.class)
@@ -22,7 +22,7 @@ class TasksJwtAuthenticationConverterTest {
 
   @Mock UserRepository userRepository;
   @Mock Jwt jwt;
-  @Mock User user;
+  @Mock UserJpaEntity user;
 
   @InjectMocks TasksJwtAuthenticationConverter converter;
 

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/adapter/persistence/TaskEntityTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/adapter/persistence/TaskEntityTest.java
@@ -13,8 +13,8 @@ import xyz.dgz48.tasks.webapi.MockJwtDecoderConfiguration;
 import xyz.dgz48.tasks.webapi.TestcontainersConfiguration;
 import xyz.dgz48.tasks.webapi.task.domain.Priority;
 import xyz.dgz48.tasks.webapi.task.domain.TaskStatus;
-import xyz.dgz48.tasks.webapi.tenant.adapter.persistence.Tenant;
-import xyz.dgz48.tasks.webapi.user.adapter.persistence.User;
+import xyz.dgz48.tasks.webapi.tenant.adapter.persistence.TenantJpaEntity;
+import xyz.dgz48.tasks.webapi.user.adapter.persistence.UserJpaEntity;
 
 @SpringBootTest
 @Import({TestcontainersConfiguration.class, MockJwtDecoderConfiguration.class})
@@ -25,7 +25,7 @@ class TaskEntityTest {
 
   @Test
   void canPersistUser() {
-    var user = new User("sub-001", "user@example.com", "山田 太郎", "ヤマダ タロウ", "開発部");
+    var user = new UserJpaEntity("sub-001", "user@example.com", "山田 太郎", "ヤマダ タロウ", "開発部");
     entityManager.persist(user);
     entityManager.flush();
 
@@ -36,7 +36,7 @@ class TaskEntityTest {
 
   @Test
   void canPersistUserWithoutDepartment() {
-    var user = new User("sub-002", "nodept@example.com", "鈴木 花子", "スズキ ハナコ", null);
+    var user = new UserJpaEntity("sub-002", "nodept@example.com", "鈴木 花子", "スズキ ハナコ", null);
     entityManager.persist(user);
     entityManager.flush();
 
@@ -46,11 +46,11 @@ class TaskEntityTest {
 
   @Test
   void canPersistTask() {
-    var tenant = new Tenant("TENANT-001", "テスト株式会社");
+    var tenant = new TenantJpaEntity("TENANT-001", "テスト株式会社");
     entityManager.persist(tenant);
     entityManager.flush();
 
-    var user = new User("sub-003", "owner@example.com", "田中 一郎", "タナカ イチロウ", null);
+    var user = new UserJpaEntity("sub-003", "owner@example.com", "田中 一郎", "タナカ イチロウ", null);
     entityManager.persist(user);
     entityManager.flush();
 
@@ -75,11 +75,11 @@ class TaskEntityTest {
 
   @Test
   void canPersistTaskWithoutDescription() {
-    var tenant = new Tenant("TENANT-002", "別テスト株式会社");
+    var tenant = new TenantJpaEntity("TENANT-002", "別テスト株式会社");
     entityManager.persist(tenant);
     entityManager.flush();
 
-    var user = new User("sub-004", "owner2@example.com", "佐藤 次郎", "サトウ ジロウ", null);
+    var user = new UserJpaEntity("sub-004", "owner2@example.com", "佐藤 次郎", "サトウ ジロウ", null);
     entityManager.persist(user);
     entityManager.flush();
 
@@ -102,11 +102,11 @@ class TaskEntityTest {
 
   @Test
   void canPersistTaskWithInProgressStatus() {
-    var tenant = new Tenant("TENANT-003", "進行中テスト株式会社");
+    var tenant = new TenantJpaEntity("TENANT-003", "進行中テスト株式会社");
     entityManager.persist(tenant);
     entityManager.flush();
 
-    var user = new User("sub-005", "owner3@example.com", "伊藤 三郎", "イトウ サブロウ", null);
+    var user = new UserJpaEntity("sub-005", "owner3@example.com", "伊藤 三郎", "イトウ サブロウ", null);
     entityManager.persist(user);
     entityManager.flush();
 
@@ -127,11 +127,11 @@ class TaskEntityTest {
 
   @Test
   void canPersistTaskWithOnHoldStatus() {
-    var tenant = new Tenant("TENANT-004", "保留テスト株式会社");
+    var tenant = new TenantJpaEntity("TENANT-004", "保留テスト株式会社");
     entityManager.persist(tenant);
     entityManager.flush();
 
-    var user = new User("sub-006", "owner4@example.com", "渡辺 四郎", "ワタナベ シロウ", null);
+    var user = new UserJpaEntity("sub-006", "owner4@example.com", "渡辺 四郎", "ワタナベ シロウ", null);
     entityManager.persist(user);
     entityManager.flush();
 

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/adapter/persistence/TaskJpaRepositoryAdapterTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/adapter/persistence/TaskJpaRepositoryAdapterTest.java
@@ -15,8 +15,8 @@ import xyz.dgz48.tasks.webapi.task.domain.Priority;
 import xyz.dgz48.tasks.webapi.task.domain.Task;
 import xyz.dgz48.tasks.webapi.task.domain.TaskStatus;
 import xyz.dgz48.tasks.webapi.task.usecase.TaskRepository;
-import xyz.dgz48.tasks.webapi.tenant.adapter.persistence.Tenant;
-import xyz.dgz48.tasks.webapi.user.adapter.persistence.User;
+import xyz.dgz48.tasks.webapi.tenant.adapter.persistence.TenantJpaEntity;
+import xyz.dgz48.tasks.webapi.user.adapter.persistence.UserJpaEntity;
 
 @SpringBootTest
 @Import({TestcontainersConfiguration.class, MockJwtDecoderConfiguration.class})
@@ -28,9 +28,9 @@ class TaskJpaRepositoryAdapterTest {
 
   @Test
   void findByIdAndTenantIdReturnsDomainTaskWhenFound() {
-    var tenant = new Tenant("TENANT-ADP-1", "テナント A");
+    var tenant = new TenantJpaEntity("TENANT-ADP-1", "テナント A");
     entityManager.persist(tenant);
-    var user = new User("sub-adp-1", "adp1@example.com", "山田 太郎", "ヤマダ タロウ", null);
+    var user = new UserJpaEntity("sub-adp-1", "adp1@example.com", "山田 太郎", "ヤマダ タロウ", null);
     entityManager.persist(user);
     entityManager.flush();
 
@@ -68,9 +68,9 @@ class TaskJpaRepositoryAdapterTest {
 
   @Test
   void findByIdAndTenantIdReturnsEmptyWhenTenantMismatch() {
-    var tenant = new Tenant("TENANT-ADP-2", "テナント B");
+    var tenant = new TenantJpaEntity("TENANT-ADP-2", "テナント B");
     entityManager.persist(tenant);
-    var user = new User("sub-adp-2", "adp2@example.com", "鈴木 花子", "スズキ ハナコ", null);
+    var user = new UserJpaEntity("sub-adp-2", "adp2@example.com", "鈴木 花子", "スズキ ハナコ", null);
     entityManager.persist(user);
     entityManager.flush();
 

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/user/adapter/persistence/UserEntityTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/user/adapter/persistence/UserEntityTest.java
@@ -20,7 +20,7 @@ class UserEntityTest {
 
   @Test
   void canPersistUser() {
-    var user = new User("sub-001", "user@example.com", "山田 太郎", "ヤマダ タロウ", "開発部");
+    var user = new UserJpaEntity("sub-001", "user@example.com", "山田 太郎", "ヤマダ タロウ", "開発部");
     entityManager.persist(user);
     entityManager.flush();
 
@@ -34,7 +34,7 @@ class UserEntityTest {
 
   @Test
   void canPersistUserWithoutDepartment() {
-    var user = new User("sub-002", "nodept@example.com", "鈴木 花子", "スズキ ハナコ", null);
+    var user = new UserJpaEntity("sub-002", "nodept@example.com", "鈴木 花子", "スズキ ハナコ", null);
     entityManager.persist(user);
     entityManager.flush();
 
@@ -44,12 +44,12 @@ class UserEntityTest {
 
   @Test
   void canFindUserById() {
-    var user = new User("sub-003", "find@example.com", "田中 一郎", "タナカ イチロウ", null);
+    var user = new UserJpaEntity("sub-003", "find@example.com", "田中 一郎", "タナカ イチロウ", null);
     entityManager.persist(user);
     entityManager.flush();
     entityManager.clear();
 
-    var found = entityManager.find(User.class, user.getId());
+    var found = entityManager.find(UserJpaEntity.class, user.getId());
     assertThat(found).isNotNull();
     assertThat(found.getOidcSub()).isEqualTo("sub-003");
     assertThat(found.getEmail()).isEqualTo("find@example.com");
@@ -57,8 +57,8 @@ class UserEntityTest {
 
   @Test
   void canPersistMultipleUsersWithDifferentOidcSubs() {
-    var user1 = new User("sub-004", "first@example.com", "佐藤 次郎", "サトウ ジロウ", null);
-    var user2 = new User("sub-005", "second@example.com", "佐藤 三郎", "サトウ サブロウ", "営業部");
+    var user1 = new UserJpaEntity("sub-004", "first@example.com", "佐藤 次郎", "サトウ ジロウ", null);
+    var user2 = new UserJpaEntity("sub-005", "second@example.com", "佐藤 三郎", "サトウ サブロウ", "営業部");
     entityManager.persist(user1);
     entityManager.persist(user2);
     entityManager.flush();


### PR DESCRIPTION
## 概要

コーディング規約 §4.0 / 設計規約 §1.2.3 に従い、`adapter.persistence` 配下の JPA Entity 単純名を `~JpaEntity` サフィックスへ統一する。

Issue #138 の作業項目「関連エンティティ(`User` / `Tenant` 等)を含めるか別途扱うか」の決定として、本 PR で `User` / `Tenant` をリネームする(`Task` は B-1 / #273 で対応済み)。

## 変更内容

- `User.java` → `UserJpaEntity.java`(git mv、`@Table(name="users")` / スキーマ不変)
- `Tenant.java` → `TenantJpaEntity.java`(git mv、`@Table(name="tenants")` / スキーマ不変)
- 参照追従: `UserRepository` / `TasksJwtAuthenticationConverter` / 関連テスト 4 件
- `build(spotless)`: `lineEndings = 'UNIX'` を追加し Windows ローカルでの CRLF 誤検知を解消(CI=Linux/LF と一致)

`Stakeholder` 等の未実装エンティティは実装時に `~JpaEntity` で新設する(本 PR では対象外)。

## 検証 (JDK 21 / Docker)

- `./gradlew :webapi:check`: green(spotless + 全テスト + JaCoCo カバレッジゲート)
- `ApplicationModules.verify()`(ModularityTests): green

Closes #138
Refs: コーディング規約 §4.0, 設計規約 §1.2.3, #121 (Sprint 0), #273 (B-1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)