### PR TITLE
fix: @PrePersist/@PreUpdate を Spring JPA Auditing + Clock Bean に置き換え (#132)

### DIFF
--- a/docs/specs/コーディング規約.md
+++ b/docs/specs/コーディング規約.md
@@ -248,9 +248,9 @@ public class TaskJpaEntity {
 
   // ----- 監査列(設計規約 §3.5) -----
   // 業務テーブルは created_at / updated_at / created_by / updated_by を必須とする。
-  // 自動投入の実装方針(Spring Data JPA Auditing の @CreatedDate / @LastModifiedDate /
-  // @CreatedBy / @LastModifiedBy + AuditorAware<Long> を採るか、手動セットか)は
-  // Sprint 0 の ADR で確定する。下記はカラム宣言のみのサンプル。
+  // 自動投入は ADR-0009 で Spring Data JPA Auditing を採用と確定済み。
+  // @CreatedDate / @LastModifiedDate は ClockConfig の DateTimeProvider が自動投入する。
+  // @CreatedBy / @LastModifiedBy + AuditorAware<Long> の実装は別途対応。
   @Column(name = "created_at", nullable = false, updatable = false)
   private OffsetDateTime createdAt;
 
@@ -271,12 +271,12 @@ public class TaskJpaEntity {
     this.title = title;
     this.body = body;
     // createdAt / updatedAt / createdBy / updatedBy はコンストラクタでは受け取らず、
-    // Auditing 機構が永続化時に自動投入する想定(実装方針は Sprint 0 で確定)。
+    // Spring JPA Auditing (@CreatedDate / @LastModifiedDate) が永続化時に自動投入する(ADR-0009)。
   }
 }
 ```
 
-> 設計規約 §3.3 に従い、業務テーブル系の Entity には `tenant_id` 列を**必須**で持たせる(`users` テーブルのみ既存・例外)。サンプル上も `tenantId` フィールドを明示する。設計規約 §3.5 の監査列 4 つも同様に**必須**であり、サンプル末尾にカラム宣言を含めている。`@CreatedDate` / `@LastModifiedDate` 等の Spring Data JPA Auditing アノテーションを使うか手動セットかは Sprint 0 の ADR で確定する。
+> 設計規約 §3.3 に従い、業務テーブル系の Entity には `tenant_id` 列を**必須**で持たせる(`users` テーブルのみ既存・例外)。サンプル上も `tenantId` フィールドを明示する。設計規約 §3.5 の監査列 4 つも同様に**必須**であり、サンプル末尾にカラム宣言を含めている。`@CreatedDate` / `@LastModifiedDate` 等は ADR-0009 で Spring Data JPA Auditing を採用と確定済み。`@EnableJpaAuditing` + `ClockConfig`（`shared/infra`）の `DateTimeProvider` Bean が Asia/Tokyo の現在時刻を自動投入する。
 
 ### 4.2 ルール
 
@@ -531,16 +531,23 @@ public class TaskUseCase {
 - DB 列型は `DATETIME`(MySQL)。Java では原則 **`java.time.OffsetDateTime`** または **`java.time.Instant`** を使う。
 - 「日付」の意味で十分なら `LocalDate`。`LocalDateTime` は JDBC マッピング上必要な箇所だけに留める(タイムゾーン情報を失うため)。
 - CI 環境は `TZ=Asia/Tokyo` 固定(`cicd.yml`)。テストで `LocalDateTime.now()` を直接使うとマシン依存で失敗するため、`Clock` を DI して固定化する。
-- **タイムゾーン未指定の `LocalDateTime.now()` は禁止**(`JavaTimeDefaultTimeZone` Error Prone チェックがビルドエラーにする)。`ZoneId.of("Asia/Tokyo")` を**常に明示**する。JPA Entity の `@PrePersist` / `@PreUpdate` での使用例:
+- **タイムゾーン未指定の `LocalDateTime.now()` は禁止**(`JavaTimeDefaultTimeZone` Error Prone チェックがビルドエラーにする)。`ZoneId.of("Asia/Tokyo")` を**常に明示**する。JPA Entity のタイムスタンプは ADR-0009 で Spring Data JPA Auditing に確定済み。`@PrePersist`/`@PreUpdate` は使わず、`@CreatedDate`/`@LastModifiedDate` + `ClockConfig` パターンを用いる:
 
 ```java
-@PrePersist
-void onCreate() {
-  LocalDateTime now = LocalDateTime.now(ZoneId.of("Asia/Tokyo"));
-  this.createdAt = now;
-  this.updatedAt = now;
+@EntityListeners(AuditingEntityListener.class)
+public class SomeJpaEntity {
+
+  @CreatedDate
+  @Column(name = "created_at", nullable = false, updatable = false)
+  private OffsetDateTime createdAt;
+
+  @LastModifiedDate
+  @Column(name = "updated_at", nullable = false)
+  private OffsetDateTime updatedAt;
 }
 ```
+
+`ClockConfig`（`shared/infra`）が `Clock.system(ZoneId.of("Asia/Tokyo"))` と `clockDateTimeProvider` Bean を定義。テスト時は `FixedClockConfiguration` で差し替え可能（`@ConditionalOnMissingBean` で制御）。
 
 ### 12.1 JDBC ↔ Java 日時型のマッピング設定(重要)
 

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/shared/infra/ClockConfig.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/shared/infra/ClockConfig.java
@@ -1,0 +1,28 @@
+package xyz.dgz48.tasks.webapi.shared.infra;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Optional;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.auditing.DateTimeProvider;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing(dateTimeProviderRef = "clockDateTimeProvider")
+class ClockConfig {
+
+  @Bean
+  @ConditionalOnMissingBean
+  Clock clock() {
+    return Clock.system(ZoneId.of("Asia/Tokyo"));
+  }
+
+  @Bean
+  @ConditionalOnMissingBean(name = "clockDateTimeProvider")
+  DateTimeProvider clockDateTimeProvider(Clock clock) {
+    return () -> Optional.of(LocalDateTime.now(clock));
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/shared/infra/package-info.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/shared/infra/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package xyz.dgz48.tasks.webapi.shared.infra;
+
+import org.jspecify.annotations.NullMarked;

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/adapter/persistence/TaskJpaEntity.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/adapter/persistence/TaskJpaEntity.java
@@ -2,27 +2,29 @@ package xyz.dgz48.tasks.webapi.task.adapter.persistence;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.PrePersist;
-import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.jspecify.annotations.Nullable;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import xyz.dgz48.tasks.webapi.task.domain.Priority;
 import xyz.dgz48.tasks.webapi.task.domain.TaskStatus;
 import xyz.dgz48.tasks.webapi.task.domain.Visibility;
 
 @Entity
 @Table(name = "tasks")
+@EntityListeners(AuditingEntityListener.class)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SuppressWarnings("NullAway.Init") // JPA requires no-args constructor; fields initialized via JPA
@@ -72,9 +74,11 @@ public class TaskJpaEntity {
   @Column(name = "deleted_at")
   private LocalDateTime deletedAt;
 
+  @CreatedDate
   @Column(name = "created_at", nullable = false, updatable = false)
   private LocalDateTime createdAt;
 
+  @LastModifiedDate
   @Column(name = "updated_at", nullable = false)
   private LocalDateTime updatedAt;
 
@@ -94,17 +98,5 @@ public class TaskJpaEntity {
     this.priority = priority;
     this.visibility = Visibility.TENANT;
     this.dueDate = dueDate;
-  }
-
-  @PrePersist
-  void onCreate() {
-    LocalDateTime now = LocalDateTime.now(ZoneId.of("Asia/Tokyo"));
-    this.createdAt = now;
-    this.updatedAt = now;
-  }
-
-  @PreUpdate
-  void onUpdate() {
-    this.updatedAt = LocalDateTime.now(ZoneId.of("Asia/Tokyo"));
   }
 }

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/adapter/persistence/TenantJpaEntity.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/adapter/persistence/TenantJpaEntity.java
@@ -2,24 +2,26 @@ package xyz.dgz48.tasks.webapi.tenant.adapter.persistence;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.PrePersist;
-import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import xyz.dgz48.tasks.webapi.tenant.domain.TenantPlan;
 import xyz.dgz48.tasks.webapi.tenant.domain.TenantStatus;
 
 @Entity
 @Table(name = "tenants")
+@EntityListeners(AuditingEntityListener.class)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SuppressWarnings("NullAway.Init") // JPA requires no-args constructor; fields initialized via JPA
@@ -43,9 +45,11 @@ public class TenantJpaEntity {
   @Column(nullable = false, columnDefinition = "ENUM('ACTIVE','SUSPENDED','DELETED')")
   private TenantStatus status;
 
+  @CreatedDate
   @Column(name = "created_at", nullable = false, updatable = false)
   private LocalDateTime createdAt;
 
+  @LastModifiedDate
   @Column(name = "updated_at", nullable = false)
   private LocalDateTime updatedAt;
 
@@ -54,17 +58,5 @@ public class TenantJpaEntity {
     this.name = name;
     this.plan = TenantPlan.STANDARD;
     this.status = TenantStatus.ACTIVE;
-  }
-
-  @PrePersist
-  void onCreate() {
-    LocalDateTime now = LocalDateTime.now(ZoneId.of("Asia/Tokyo"));
-    this.createdAt = now;
-    this.updatedAt = now;
-  }
-
-  @PreUpdate
-  void onUpdate() {
-    this.updatedAt = LocalDateTime.now(ZoneId.of("Asia/Tokyo"));
   }
 }

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/FixedClockConfiguration.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/FixedClockConfiguration.java
@@ -1,0 +1,21 @@
+package xyz.dgz48.tasks.webapi;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.auditing.DateTimeProvider;
+
+@TestConfiguration
+public class FixedClockConfiguration {
+
+  /** JST 2026-01-15T19:00:00 (= UTC 2026-01-15T10:00:00 + 9h) */
+  public static final LocalDateTime FIXED_NOW = LocalDateTime.of(2026, 1, 15, 19, 0, 0);
+
+  @Bean("clockDateTimeProvider")
+  @Primary
+  public DateTimeProvider clockDateTimeProvider() {
+    return () -> Optional.of(FIXED_NOW);
+  }
+}

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/adapter/persistence/TaskEntityTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/adapter/persistence/TaskEntityTest.java
@@ -4,11 +4,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import jakarta.persistence.EntityManager;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.transaction.annotation.Transactional;
+import xyz.dgz48.tasks.webapi.FixedClockConfiguration;
 import xyz.dgz48.tasks.webapi.MockJwtDecoderConfiguration;
 import xyz.dgz48.tasks.webapi.TestcontainersConfiguration;
 import xyz.dgz48.tasks.webapi.task.domain.Priority;
@@ -17,7 +19,11 @@ import xyz.dgz48.tasks.webapi.tenant.adapter.persistence.TenantJpaEntity;
 import xyz.dgz48.tasks.webapi.user.adapter.persistence.UserJpaEntity;
 
 @SpringBootTest
-@Import({TestcontainersConfiguration.class, MockJwtDecoderConfiguration.class})
+@Import({
+  TestcontainersConfiguration.class,
+  MockJwtDecoderConfiguration.class,
+  FixedClockConfiguration.class
+})
 @Transactional
 class TaskEntityTest {
 
@@ -148,5 +154,33 @@ class TaskEntityTest {
     entityManager.flush();
 
     assertThat(task.getStatus()).isEqualTo(TaskStatus.ON_HOLD);
+  }
+
+  @Test
+  void timestampsAreSetFromFixedClock() {
+    LocalDateTime expectedTimestamp = FixedClockConfiguration.FIXED_NOW;
+
+    var tenant = new TenantJpaEntity("TENANT-005", "タイムスタンプテスト株式会社");
+    entityManager.persist(tenant);
+    entityManager.flush();
+
+    var user = new UserJpaEntity("sub-007", "ts@example.com", "時間 太郎", "ジカン タロウ", null);
+    entityManager.persist(user);
+    entityManager.flush();
+
+    var task =
+        new TaskJpaEntity(
+            tenant.getId(),
+            user.getId(),
+            "タイムスタンプ確認タスク",
+            null,
+            TaskStatus.NOT_STARTED,
+            Priority.LOW,
+            LocalDate.of(2026, 12, 31));
+    entityManager.persist(task);
+    entityManager.flush();
+
+    assertThat(task.getCreatedAt()).isEqualTo(expectedTimestamp);
+    assertThat(task.getUpdatedAt()).isEqualTo(expectedTimestamp);
   }
 }

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/tenant/adapter/persistence/TenantEntityTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/tenant/adapter/persistence/TenantEntityTest.java
@@ -1,0 +1,66 @@
+package xyz.dgz48.tasks.webapi.tenant.adapter.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.persistence.EntityManager;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.transaction.annotation.Transactional;
+import xyz.dgz48.tasks.webapi.FixedClockConfiguration;
+import xyz.dgz48.tasks.webapi.MockJwtDecoderConfiguration;
+import xyz.dgz48.tasks.webapi.TestcontainersConfiguration;
+import xyz.dgz48.tasks.webapi.tenant.domain.TenantPlan;
+import xyz.dgz48.tasks.webapi.tenant.domain.TenantStatus;
+
+@SpringBootTest
+@Import({
+  TestcontainersConfiguration.class,
+  MockJwtDecoderConfiguration.class,
+  FixedClockConfiguration.class
+})
+@Transactional
+class TenantEntityTest {
+
+  @Autowired EntityManager entityManager;
+
+  @Test
+  void canPersistTenant() {
+    var tenant = new TenantJpaEntity("T-001", "テスト株式会社");
+    entityManager.persist(tenant);
+    entityManager.flush();
+
+    assertThat(tenant.getId()).isNotNull();
+    assertThat(tenant.getCode()).isEqualTo("T-001");
+    assertThat(tenant.getName()).isEqualTo("テスト株式会社");
+    assertThat(tenant.getPlan()).isEqualTo(TenantPlan.STANDARD);
+    assertThat(tenant.getStatus()).isEqualTo(TenantStatus.ACTIVE);
+  }
+
+  @Test
+  void canFindTenantById() {
+    var tenant = new TenantJpaEntity("T-002", "検索テスト株式会社");
+    entityManager.persist(tenant);
+    entityManager.flush();
+    entityManager.clear();
+
+    var found = entityManager.find(TenantJpaEntity.class, tenant.getId());
+    assertThat(found).isNotNull();
+    assertThat(found.getCode()).isEqualTo("T-002");
+    assertThat(found.getName()).isEqualTo("検索テスト株式会社");
+  }
+
+  @Test
+  void timestampsAreSetFromFixedClock() {
+    LocalDateTime expectedTimestamp = FixedClockConfiguration.FIXED_NOW;
+
+    var tenant = new TenantJpaEntity("T-003", "タイムスタンプテスト株式会社");
+    entityManager.persist(tenant);
+    entityManager.flush();
+
+    assertThat(tenant.getCreatedAt()).isEqualTo(expectedTimestamp);
+    assertThat(tenant.getUpdatedAt()).isEqualTo(expectedTimestamp);
+  }
+}


### PR DESCRIPTION
## Summary

- `TaskJpaEntity` / `TenantJpaEntity` の `@PrePersist`/`@PreUpdate` を削除し、`@EnableJpaAuditing` + `@CreatedDate`/`@LastModifiedDate` に移行
- `shared/infra/ClockConfig` で `Clock.system(Asia/Tokyo)` と `clockDateTimeProvider` Bean を定義。`@ConditionalOnMissingBean` によりテスト時の差し替えを可能にする
- テスト用 `FixedClockConfiguration`（`@TestConfiguration`）でタイムスタンプを固定し、`TaskEntityTest` / `TenantEntityTest` で厳密なアサートを追加
- `コーディング規約.md` の陳腐化した記述（Sprint 0 未確定表現・`@PrePersist` コード例）を ADR-0009 確定済み内容に更新

## 変更点

| ファイル | 変更内容 |
|---|---|
| `shared/infra/ClockConfig.java` | 新規作成: `@EnableJpaAuditing` + `Clock` + `DateTimeProvider` Bean |
| `shared/infra/package-info.java` | 新規作成: `@NullMarked` |
| `TaskJpaEntity.java` | `@PrePersist`/`@PreUpdate` → `@EntityListeners` + `@CreatedDate`/`@LastModifiedDate` |
| `TenantJpaEntity.java` | 同上 |
| `FixedClockConfiguration.java` | 新規作成: テスト用固定 `DateTimeProvider` |
| `TaskEntityTest.java` | `timestampsAreSetFromFixedClock` テスト追加 |
| `TenantEntityTest.java` | 新規作成: Tenant タイムスタンプ検証 |
| `docs/specs/コーディング規約.md` | §4.1・§12 の未確定表現を ADR-0009 確定済み内容に更新、`@PrePersist` 例を Spring JPA Auditing パターンに差し替え |

## 設計上の注意点

`ClockConfig`（コンポーネントスキャン）は `@SpringBootTest` の `@Import` より後に処理されるため、単純な `@Primary` override では production Bean が勝ってしまう。`@ConditionalOnMissingBean` を使うことで `FixedClockConfiguration` が先に登録した `clockDateTimeProvider` Bean を尊重する。

## Test plan

- [x] `./gradlew :webapi:check` で全テスト通過・フォーマット確認済み
- [x] `timestampsAreSetFromFixedClock` テストが固定時刻 `2026-01-15T19:00:00` でアサートを通過
- [x] 既存テスト全件(59件)通過

## 未対応レビュー

| 指摘 | 内容 | 状態 |
|---|---|---|
| (なし) | — | — |

Closes #132
