### PR TITLE
feat(task): Task.changeVisibility() を追加 (#133)

### DIFF
--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/domain/Task.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/domain/Task.java
@@ -4,7 +4,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -12,7 +11,6 @@ import org.jspecify.annotations.Nullable;
  * TaskJpaEntity} と相互変換する。
  */
 @Getter
-@RequiredArgsConstructor
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class Task {
 
@@ -22,7 +20,7 @@ public class Task {
   @Nullable private final String description;
   private final TaskStatus status;
   private final Priority priority;
-  private final Visibility visibility;
+  private Visibility visibility;
   private final Long ownerId;
   @Nullable private final Long assigneeId;
   private final LocalDate dueDate;
@@ -30,4 +28,39 @@ public class Task {
   @Nullable private final LocalDateTime deletedAt;
   private final LocalDateTime createdAt;
   private final LocalDateTime updatedAt;
+
+  public Task(
+      Long id,
+      Long tenantId,
+      String title,
+      @Nullable String description,
+      TaskStatus status,
+      Priority priority,
+      Visibility visibility,
+      Long ownerId,
+      @Nullable Long assigneeId,
+      LocalDate dueDate,
+      @Nullable LocalDateTime completedAt,
+      @Nullable LocalDateTime deletedAt,
+      LocalDateTime createdAt,
+      LocalDateTime updatedAt) {
+    this.id = id;
+    this.tenantId = tenantId;
+    this.title = title;
+    this.description = description;
+    this.status = status;
+    this.priority = priority;
+    this.visibility = visibility;
+    this.ownerId = ownerId;
+    this.assigneeId = assigneeId;
+    this.dueDate = dueDate;
+    this.completedAt = completedAt;
+    this.deletedAt = deletedAt;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
+  }
+
+  public void changeVisibility(Visibility newVisibility) {
+    this.visibility = newVisibility;
+  }
 }

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/domain/TaskTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/domain/TaskTest.java
@@ -1,0 +1,47 @@
+package xyz.dgz48.tasks.webapi.task.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+
+class TaskTest {
+
+  private Task buildTask(Visibility visibility) {
+    return new Task(
+        1L,
+        10L,
+        "title",
+        null,
+        TaskStatus.NOT_STARTED,
+        Priority.MEDIUM,
+        visibility,
+        100L,
+        null,
+        LocalDate.of(2026, 12, 31),
+        null,
+        null,
+        LocalDateTime.of(2026, 1, 1, 0, 0),
+        LocalDateTime.of(2026, 1, 1, 0, 0));
+  }
+
+  @Test
+  void changeVisibility_updatesVisibility() {
+    Task task = buildTask(Visibility.TENANT);
+
+    task.changeVisibility(Visibility.PRIVATE);
+
+    assertThat(task.getVisibility()).isEqualTo(Visibility.PRIVATE);
+  }
+
+  @Test
+  void changeVisibility_canBeCalledMultipleTimes() {
+    Task task = buildTask(Visibility.TENANT);
+
+    task.changeVisibility(Visibility.STAKEHOLDERS);
+    task.changeVisibility(Visibility.PRIVATE);
+
+    assertThat(task.getVisibility()).isEqualTo(Visibility.PRIVATE);
+  }
+}


### PR DESCRIPTION
## Summary

- `Task.visibility` フィールドを `non-final` に変更し、`changeVisibility(Visibility)` ドメインメソッドを追加
- `@RequiredArgsConstructor` を削除し、明示的全引数コンストラクタに置換(コーディング規約 §3「明示的に public コンストラクタを書く方針」準拠)
- `TaskJpaRepositoryAdapter.toDomain()` の呼び出し側は引数シグネチャが変わらないため変更不要

## Test plan

- [x] `TaskTest#changeVisibility_updatesVisibility` — TENANT → PRIVATE に変更されることを確認
- [x] `TaskTest#changeVisibility_canBeCalledMultipleTimes` — 複数回呼び出し後に最後の値が返ることを確認
- [x] `./gradlew :webapi:check` 全通過(Spotless / NullAway / テスト / JaCoCo)

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)