### PR TITLE
docs(adr): ADR-0010 採用 — テナント分離を Hibernate Filter に確定し §3.3/§8.1 を緩和

### DIFF
--- a/docs/adr/0010-tenant-isolation-hibernate-filter.md
+++ b/docs/adr/0010-tenant-isolation-hibernate-filter.md
@@ -1,0 +1,144 @@
+# ADR-0010: マルチテナント絞り込みの自動付与は Hibernate Filter で行う
+
+- **Status**: Accepted
+- **Date**: 2026-05-31
+- **Deciders**: 開発チーム
+- **Tags**: persistence, multi-tenancy, security
+
+## 目次
+
+- [1. コンテキスト](#1-コンテキスト)
+- [2. 検討した選択肢](#2-検討した選択肢)
+  - [選択肢 A: Hibernate Filter(`@FilterDef` + `@Filter`)で全 SELECT に自動付与](#選択肢-a-hibernate-filterfilterdef--filterで全-select-に自動付与)
+  - [選択肢 B: Spring AOP(`@Around`)で Repository メソッドを intercept](#選択肢-b-spring-aoparoundで-repository-メソッドを-intercept)
+  - [選択肢 C: 両者の併用(SELECT は Filter、UPDATE/DELETE/native は AOP)](#選択肢-c-両者の併用select-は-filterupdatedeletenative-は-aop)
+- [3. 決定](#3-決定)
+- [4. 理由](#4-理由)
+- [5. 影響](#5-影響)
+  - [良い影響](#良い影響)
+  - [悪い影響・制約](#悪い影響制約)
+  - [既存ドキュメント・規約への波及](#既存ドキュメント規約への波及)
+- [6. 実装メモ](#6-実装メモ)
+- [7. 参考リンク](#7-参考リンク)
+
+## 1. コンテキスト
+
+tasks-webapi はマルチテナント SaaS であり、全業務テーブルが `tenant_id BIGINT NOT NULL` を持ち、全 SQL に `WHERE tenant_id = :ctx` を自動付与する不変ルール(基本設計書 §6.3 / 設計規約 §3.3)を採る。越境アクセスは参照系 404 / 更新系 403 で拒否する(NIST AC-4)。
+
+設計規約 v1.3 §3.3 は事実上「Hibernate Filter で全 SELECT に自動付与する」前提でドラフトされているが、コーディング規約 v1.3 §8.1 と合わせて「Filter vs Spring AOP の選択は今後の ADR で決定予定 — 想定 ADR-0004」と保留してきた。一方、ADR-0004 番号は別件(`tenants-as-audit-column-exception`、2026-05-16 Accepted)に消費されたため、本決定は **ADR-0010** として起票する。
+
+Sprint 0 着手(2026-06-14 予定)を前に方式を確定し、§3.3 / §8.1 の保留節を解消する必要がある。直近で Accepted となった ADR-0008(GraalVM Native Image 採用)と ADR-0009(JST 全層統一)も本決定の制約条件となる。
+
+なお、現行 scaffold には既に `TaskJpaEntity` / `TenantJpaEntity` / `UserJpaEntity` の 3 JPA entity と `findByIdAndTenantId` 形式の明示絞り込み Repository が配置されているが、Hibernate Filter(`@FilterDef` / `@Filter`)および `TenantContext` 注入経路は**未配線**である。本 ADR は方式の確定のみを行い、実コード配線(`@FilterDef` 配置 + リクエストスコープでの enable + Repository 命名緩和)は本 PR とは別の Sprint 0 着手タスクで起票・実施する(規約決定 ADR は実装を別 PR に分離する運用、ADR-0004 と同形)。
+
+関連 Issue: #145(本 ADR 起票 Issue) / #121(Sprint 0 readiness 親 Issue) / ADR-0001 §6 候補リスト。
+
+## 2. 検討した選択肢
+
+### 選択肢 A: Hibernate Filter(`@FilterDef` + `@Filter`)で全 SELECT に自動付与
+
+- 概要: 共通の mapped superclass(または各エンティティ)に `@FilterDef(name="tenantFilter", parameters=@ParamDef(name="tenantId", type=Long.class))` と `@Filter(name="tenantFilter", condition="tenant_id = :tenantId")` を宣言する。`TenantContext` から現在の `tenant_id` を取得し、リクエストスコープの interceptor(または `@EntityManagerFactoryBean` カスタマイズ)で session ごとに `enableFilter("tenantFilter").setParameter(...)` する。
+- 利点:
+  - Hibernate ネイティブ機能で**追加依存ゼロ**。`@Filter` API は Hibernate 6/7 で安定。
+  - **エンティティ取得と関連ナビゲーション(`task.subTasks` 等)の双方に効く**。lazy loading で発行される SQL にも Filter が乗る。
+  - GraalVM Native Image(ADR-0008)と相性が良い(Spring proxy 不要、reflection hints は Hibernate 側で整備済)。
+  - SaaS Admin の `tenants` テーブルアクセス(ADR-0004 で確定の例外)は Filter 未設定で自然に bypass される。
+  - バッチや管理用途で一時的に bypass する場合も `session.disableFilter("tenantFilter")` を専用ヘルパー経由で明示でき、レビュー対象として可視化しやすい。
+- 欠点:
+  - **`@Modifying` JPQL の UPDATE/DELETE および native query には適用されない**ため、書き込み系は別途明示絞り込みが必要(現行 §3.3 で既にルール化済)。
+  - session で `enableFilter` し忘れると全件漏洩が起きるため、interceptor の設定漏れが致命的(検知は §9.4 クロステナント漏洩テストで担保)。
+  - boolean 型パラメータが `INTEGER` バインドになる等のバージョン差異があり、MySQL 8.4 + Hibernate 7 での挙動確認が必要。
+
+### 選択肢 B: Spring AOP(`@Around`)で Repository メソッドを intercept
+
+- 概要: Repository メソッドに対する `@Around` Aspect を定義し、`TenantContext` から取得した `tenant_id` を Specification / JPQL / native SQL に挿入する。
+- 利点:
+  - UPDATE / DELETE / native query を含め、Repository メソッドを経由する全アクセスを一律 intercept できる(設計上)。
+  - 既存の Spring AOP(`spring-boot-starter-aop` 同梱)で実装可能。
+- 欠点:
+  - **エンティティ関連ナビゲーションには効かない**(Hibernate が SQL を直接発行するため AOP は触れない)。`task.subTasks` 等の lazy ナビゲーションでテナント漏洩が起きる経路をふさげない。
+  - **GraalVM Native Image(ADR-0008)との相性が悪い**。Spring AOP は CGLIB / JDK proxy 依存で、`reflect-config.json` / `proxy-config.json` の追加運用と debug 困難さが Sprint 0 早期に必ず障害となる。
+  - `@Modifying` JPQL の本文を AOP が書き換えるのは現実的でなく、結局は Specification や `EntityManager#createQuery` 経由の書き直しが必要となり、§3.3 の明示絞り込みルールを温存する形に落ち着く。
+  - pointcut 漏れ(新規 Repository / メソッドシグネチャ追加時の追従漏れ)が一部経路だけの漏洩を生むため、検知が困難。
+  - `@SpringBootTest` 必須化でテスト境界が広がり、Slice テスト(`@DataJpaTest`)で Aspect が外れる/付くの差異が混乱を生む。
+
+### 選択肢 C: 両者の併用(SELECT は Filter、UPDATE/DELETE/native は AOP)
+
+- 概要: 選択肢 A の Filter で SELECT を担保しつつ、UPDATE / DELETE / native query は選択肢 B の AOP で intercept する。
+- 利点: 各機構の長所を取り、SELECT は Filter、書き込みは AOP で多層防御できる(設計上)。
+- 欠点:
+  - 二機構の同時運用で**設定漏れ箇所が単独案より増える**。
+  - **重複絞り込み**(Filter と AOP が同じ SELECT に対し `WHERE tenant_id=? AND tenant_id=?` を生む)を回避するロジックが必要で、Filter enable 状態と AOP の判定を相互に参照する必要が出る。
+  - B の GraalVM Native Image 不適合と関連ナビゲーション不対応の欠点を併用案でも引き継ぐ。
+  - デバッグ時、絞り込みが Filter / AOP / 派生クエリの 3 経路のどこで効いたかを追跡するコストが上がる。
+
+## 3. 決定
+
+**採用**: 選択肢 A(Hibernate Filter で全 SELECT に自動付与)
+
+具体的には:
+
+- 設計規約 §3.3 を以下のとおり確定する(本 ADR と同 PR で改訂):
+  - 「Filter vs Spring AOP の選択は今後の ADR で決定予定 — 想定 ADR-0004」の保留節を削除し、「`@FilterDef` + `@Filter` を採用する」旨と本 ADR への参照を明記する。
+  - 既存の「`@Modifying` JPQL / native query は明示的に `tenant_id` を絞り込む」「全件検索を書かない」「一時 disable は専用ヘルパー経由 + レビュー必須」のルールは維持する。
+- コーディング規約 §8.1 を以下のとおり緩和する(本 ADR と同 PR で改訂):
+  - **緩和**: 業務テーブル参照の SELECT 系派生クエリは `findById(Long id)` / `findByStatus(...)` 等の**単純命名で構わない**(`tenant_id` は Filter が自動付与)。
+  - **維持**: `@Modifying` UPDATE / DELETE および native query / `@Query(nativeQuery=true)` は引き続き `findByTenantIdAndId(...)` / `deleteByTenantIdAndId(...)` / 明示 JPQL の `WHERE tenant_id = :tenantId AND ...` を必須とする(設計規約 §3.3)。
+- 実装上の固定点:
+  - `@FilterDef` は共通 mapped superclass(または `package-info.java`)に集約する。
+  - `TenantContext` の値を session に注入する経路は、リクエストスコープの `OncePerRequestFilter` または Hibernate `SessionEventListener` で集約し、忘却を構造的に防止する。具体的な経路は Sprint 0 着手時に PoC で確定する(本 ADR は方式の確定のみを行う)。
+
+## 4. 理由
+
+- **GraalVM Native Image(ADR-0008)との相性が決定打**。Spring AOP は CGLIB / JDK proxy 依存で Native Image での運用コスト(reflect-config / proxy-config の追加運用、debug 困難)が大きく、Sprint 0 早期に必ず障害となる。Hibernate Filter は Hibernate ネイティブ機能で proxy 不要、ADR-0008 と整合的に運用できる。
+- **エンティティ関連ナビゲーション(`task.subTasks` 等)に効くのは Hibernate Filter だけ**。AOP は Hibernate が直接発行する lazy loading SQL を touch できない。テナント漏洩経路の最大候補をふさげるのは A のみ。
+- **設計規約 §3.3 が既に A 案ドラフトの形をしており**、コーディング規約 §8.1 で `findByTenantId` 起点を強制している。本 ADR は「§3.3 を正式化し §8.1 を緩和する」という Issue #145 のスコープと整合する。
+- B / C の最大の利点(UPDATE / DELETE の自動絞り)は AOP の本質的能力ではなく **SQL 書換に依存**しており、AOP では現実的に難しい。書き換え戦略を真剣に採るなら Hibernate `StatementInspector` を別 ADR で評価する方が筋が良く、本 ADR の選択肢には含めない。
+- UPDATE / DELETE / native query の絞り漏れは、§3.3 の明示絞り込みルール + §9.4 クロステナント漏洩 IT(参照系 404 / 更新系 403)+ §3.5 監査ログで多層防御済。AOP を足しても防御層が「proxy 越し」になるだけで根本対処にはならない。
+- 形骸化リスク(Filter session enable 忘れ)は **§9.4 IT が即座に fail する**ため、検知容易な失敗モードに収束する。AOP の pointcut 漏れ(一部経路だけ漏洩)は検知が困難な失敗モードで、運用上の不安が大きい。
+
+## 5. 影響
+
+### 良い影響
+
+- 設計規約 §3.3 / コーディング規約 §8.1 の保留節がクローズし、Sprint 0 着手前の規約整合チェックリストから 2 項目が消える。
+- SELECT 系 Repository メソッドが `findById(Long id)` 等のシンプル命名になり、コードの可読性とテストの記述量が下がる。
+- ADR-0008(GraalVM Native Image)と整合する持続的な方式が確定し、Sprint 0 以降の AOT コンパイル運用で予期せぬ proxy 起因の障害が発生する確率が下がる。
+- `tenants` テーブルの SaaS Admin 操作(ADR-0004)は Filter 未設定で自然に bypass され、追加の bypass 機構を設計する必要がない。
+
+### 悪い影響・制約
+
+- `@Modifying` JPQL / native query では引き続き明示的な `tenant_id` 絞り込みが必要で、レビュー観点として残る。
+- Filter session enable を忘れた場合の影響は「全件漏洩」と大きいため、interceptor 設置箇所の構造的担保(`OncePerRequestFilter` で集約)と §9.4 クロステナント漏洩 IT を**必ず実装**する必要がある。
+- 将来 Hibernate 6 → 7 → 8 のメジャーバージョンアップで `@Filter` API に変更が入った場合の追従工数が残る。
+
+### 既存ドキュメント・規約への波及
+
+- 設計規約 v1.4 §3.3 を改訂(保留節削除 + 本 ADR リンク追加)。本 ADR と同 PR で対応(Issue #145)。
+- コーディング規約 v1.4 §8.1 を緩和(SELECT は単純命名 OK / `@Modifying`・native は明示絞り維持)。本 ADR と同 PR で対応(Issue #145)。
+- ADR-0001 §6 候補リストの「テナント分離実装 — 想定 ADR-0004」は履歴情報として現状維持(候補番号はあくまで起票時の見込みである旨を ADR-0001 §6 が明記済)。
+
+## 6. 実装メモ
+
+- 本 ADR は方式の確定のみを行う。実コードでの配線は **Issue #87(N5: TenantContext + TenantContextFilter + Hibernate Filter 実装)** で行い、以下を実施する:
+  - 既存 `TaskJpaEntity` / `TenantJpaEntity` / `UserJpaEntity`(および後続 entity)への `@Filter` / `@FilterDef` 適用。`@FilterDef` を共通 mapped superclass に置く案と `package-info.java` に置く案の選定(Modulith 内境界への影響を含めて Sprint 0 で確定)。
+  - `TenantContext` の値を session に注入する経路の構築。`OncePerRequestFilter` 案と Hibernate `SessionEventListener` 案を比較選定し、忘却を構造的に防止する。
+  - 既存 `TaskJpaRepository#findByIdAndTenantId` 等の明示絞り込み命名を、コーディング規約 §8.1 v1.4 の緩和に沿って `findById` 等の単純命名に書き換え(SELECT 系のみ。`@Modifying` UPDATE/DELETE と native は明示絞り維持)。
+  - MapStruct(想定 ADR 未決)で DTO 投影する際に Filter が効くことの確認。
+  - boolean 型パラメータの MySQL 8.4 + Hibernate 7 でのバインド挙動の確認。
+  - Spring Modulith `@ApplicationModuleTest` 単位での Filter session 状態の test isolation 確認。
+- 上記配線・検証で重大な不整合が見つかった場合は、本 ADR を Supersede する別 ADR(`StatementInspector` への切替、または併用案再評価)を起こす。
+
+## 7. 参考リンク
+
+- Issue #145(本 ADR 起票 Issue)
+- Issue #121(Sprint 0 readiness 親 Issue)
+- Issue #87(N5: TenantContext + TenantContextFilter + Hibernate Filter 実装 — 本 ADR の実コード配線担当)
+- 設計規約 §3.3 / §3.5(本 ADR と同 PR で改訂)
+- コーディング規約 §8.1 / §9.4(本 ADR と同 PR で改訂)
+- 基本設計書 §6.3(マルチテナント設計)
+- ADR-0001(ADR 制度導入)
+- ADR-0004(SaaS Admin スコープ整理 / `tenants` 監査列例外)
+- ADR-0008(GraalVM Native Image 採用)
+- ADR-0009(JST 全層統一)
+- Hibernate ORM User Guide: Filtering data

--- a/docs/adr/0010-tenant-isolation-hibernate-filter.md
+++ b/docs/adr/0010-tenant-isolation-hibernate-filter.md
@@ -1,7 +1,7 @@
 # ADR-0010: マルチテナント絞り込みの自動付与は Hibernate Filter で行う
 
 - **Status**: Accepted
-- **Date**: 2026-05-31
+- **Date**: 2026-05-30
 - **Deciders**: 開発チーム
 - **Tags**: persistence, multi-tenancy, security
 
@@ -27,7 +27,7 @@ tasks-webapi はマルチテナント SaaS であり、全業務テーブルが 
 
 設計規約 v1.3 §3.3 は事実上「Hibernate Filter で全 SELECT に自動付与する」前提でドラフトされているが、コーディング規約 v1.3 §8.1 と合わせて「Filter vs Spring AOP の選択は今後の ADR で決定予定 — 想定 ADR-0004」と保留してきた。一方、ADR-0004 番号は別件(`tenants-as-audit-column-exception`、2026-05-16 Accepted)に消費されたため、本決定は **ADR-0010** として起票する。
 
-Sprint 0 着手(2026-06-14 予定)を前に方式を確定し、§3.3 / §8.1 の保留節を解消する必要がある。直近で Accepted となった ADR-0008(GraalVM Native Image 採用)と ADR-0009(JST 全層統一)も本決定の制約条件となる。
+Sprint 0 着手(2026-07-14 予定)を前に方式を確定し、§3.3 / §8.1 の保留節を解消する必要がある。直近で Accepted となった ADR-0008(GraalVM Native Image 採用)と ADR-0009(JST 全層統一)も本決定の制約条件となる。
 
 なお、現行 scaffold には既に `TaskJpaEntity` / `TenantJpaEntity` / `UserJpaEntity` の 3 JPA entity と `findByIdAndTenantId` 形式の明示絞り込み Repository が配置されているが、Hibernate Filter(`@FilterDef` / `@Filter`)および `TenantContext` 注入経路は**未配線**である。本 ADR は方式の確定のみを行い、実コード配線(`@FilterDef` 配置 + リクエストスコープでの enable + Repository 命名緩和)は本 PR とは別の Sprint 0 着手タスクで起票・実施する(規約決定 ADR は実装を別 PR に分離する運用、ADR-0004 と同形)。
 

--- a/docs/specs/コーディング規約.md
+++ b/docs/specs/コーディング規約.md
@@ -2,9 +2,9 @@
 
 タスク管理システム(tasks-webapi)
 
-Version 1.3
+Version 1.4
 
-2026-05-30
+2026-05-31
 
 作成者: 開発チーム
 
@@ -17,6 +17,7 @@ Version 1.3
 | 1.1 | 2026-05-24 | §20 Native Image 実装制約 追加(Issue #223、ADR-0008) | 開発チーム |
 | 1.2 | 2026-05-25 | §11 トランザクション 全面改訂(`readOnly` 常に明示 / Propagation・例外 / クラスレベル禁止、Issue #254、#86 事前議論派生) | 開発チーム |
 | 1.3 | 2026-05-30 | §1.4 コンパイル警告ゼロポリシー 新設 / §12 `LocalDateTime.now()` タイムゾーン明示ルール追記 / §14 `BadImport` ルール追記 | 開発チーム |
+| 1.4 | 2026-05-31 | Issue #145 / [ADR-0010](../adr/0010-tenant-isolation-hibernate-filter.md): §8.1 Repository メソッド命名を緩和(SELECT 系は単純命名 OK、`@Modifying`・native は引き続き明示絞り) | 開発チーム |
 
 ## 目次
 
@@ -377,7 +378,11 @@ public record TaskCreateRequest(
 ### 8.1 Repository メソッド命名
 
 - Spring Data JPA の派生クエリは `findBy<Property>...` の規約に従う。
-- マルチテナント対応のため、**業務テーブル参照のメソッドは `findByTenantId` を起点**にする(例: `findByTenantIdAndId(Long tenantId, Long id)`)。テナント絞り込みの自動付与方式が確定したら(今後の ADR で決定予定 — 想定 ADR-0004)、本ルールは緩める(設計規約 §3.3)。
+- **SELECT 系派生クエリ**(`findBy...` / `existsBy...` / `countBy...`)は、Hibernate Filter が `tenant_id` を自動付与する([ADR-0010](../adr/0010-tenant-isolation-hibernate-filter.md) / 設計規約 §3.3)ため、`findById(Long id)` / `findByStatus(...)` 等の**単純命名で構わない**。`findByTenantIdAndId` のような明示絞り込みは不要(書いても害はないが冗長)。
+- **`@Modifying` UPDATE / DELETE および native query**(`@Query(nativeQuery = true)`)は Hibernate Filter が適用されないため、引き続き `tenant_id` を**明示的に絞り込む**(設計規約 §3.3):
+  - 派生クエリ: `deleteByTenantIdAndId(Long tenantId, Long id)` 等。
+  - JPQL: `@Modifying @Query("UPDATE ... WHERE tenant_id = :tenantId AND id = :id ...")`。
+  - native query: `WHERE tenant_id = :tenantId AND ...` を SQL に明示。
 
 ---
 

--- a/docs/specs/コーディング規約.md
+++ b/docs/specs/コーディング規約.md
@@ -4,7 +4,7 @@
 
 Version 1.4
 
-2026-05-31
+2026-05-30
 
 作成者: 開発チーム
 
@@ -17,7 +17,7 @@ Version 1.4
 | 1.1 | 2026-05-24 | §20 Native Image 実装制約 追加(Issue #223、ADR-0008) | 開発チーム |
 | 1.2 | 2026-05-25 | §11 トランザクション 全面改訂(`readOnly` 常に明示 / Propagation・例外 / クラスレベル禁止、Issue #254、#86 事前議論派生) | 開発チーム |
 | 1.3 | 2026-05-30 | §1.4 コンパイル警告ゼロポリシー 新設 / §12 `LocalDateTime.now()` タイムゾーン明示ルール追記 / §14 `BadImport` ルール追記 | 開発チーム |
-| 1.4 | 2026-05-31 | Issue #145 / [ADR-0010](../adr/0010-tenant-isolation-hibernate-filter.md): §8.1 Repository メソッド命名を緩和(SELECT 系は単純命名 OK、`@Modifying`・native は引き続き明示絞り) | 開発チーム |
+| 1.4 | 2026-05-30 | Issue #145 / [ADR-0010](../adr/0010-tenant-isolation-hibernate-filter.md): §8.1 Repository メソッド命名を緩和(SELECT 系は単純命名 OK、`@Modifying`・native は引き続き明示絞り) | 開発チーム |
 
 ## 目次
 

--- a/docs/specs/設計規約.md
+++ b/docs/specs/設計規約.md
@@ -2,9 +2,9 @@
 
 タスク管理システム(tasks-webapi)
 
-Version 1.3
+Version 1.4
 
-2026-05-22
+2026-05-31
 
 作成者: 開発チーム
 
@@ -17,6 +17,7 @@ Version 1.3
 | 1.1 | 2026-05-22 | TOC 追加(Issue #131) | 開発チーム |
 | 1.2 | 2026-05-22 | §12 ドキュメント管理規約追加(Issue #147) | 開発チーム |
 | 1.3 | 2026-05-22 | §12 → §10 に採番修正、§9 末尾の誤配置リンクを移動(PR #203 レビュー対応) | 開発チーム |
+| 1.4 | 2026-05-31 | Issue #145 / [ADR-0010](../adr/0010-tenant-isolation-hibernate-filter.md): §3.3 マルチテナントの保留節(Filter vs Spring AOP 選択)を解消し、Hibernate Filter 採用を確定 | 開発チーム |
 
 ## 目次
 
@@ -302,7 +303,7 @@ dev 環境への tasks-webapi 初回デプロイ前(Flyway 履歴テーブル `f
 
 - **全業務テーブルに `tenant_id BIGINT NOT NULL` 列を必須化**(基本設計書 §6.3)。
 - `tenant_id` を**第1キーに含む複合インデックス**を必ず作成する(例: `INDEX idx_tasks_tenant_status (tenant_id, status)`)。
-- アプリ層では Hibernate Filter(`@Filter` / `@FilterDef`)で**全 SELECT** に `tenant_id` 条件を自動付与する(エンティティ取得時 / 関連ナビゲーション時)。Filter vs Spring AOP の選択は今後の ADR で決定予定 — 想定 ADR-0004。
+- アプリ層では Hibernate Filter(`@Filter` / `@FilterDef`)で**全 SELECT** に `tenant_id` 条件を自動付与する(エンティティ取得時 / 関連ナビゲーション時)。本方式は [ADR-0010](../adr/0010-tenant-isolation-hibernate-filter.md) で確定(Spring AOP 併用案は GraalVM Native Image との相性および関連ナビゲーション非対応のため不採用)。
 - **Hibernate Filter は `@Modifying` JPQL の UPDATE / DELETE には適用されない**ため、書き込み系のリポジトリメソッドは次のいずれかで明示的に `tenant_id` を絞り込む:
   - Spring Data JPA の派生クエリ(例: `deleteByTenantIdAndId(Long tenantId, Long id)`)
   - 明示的な `@Modifying @Query("UPDATE ... WHERE tenant_id = :tenantId AND id = :id ...")` JPQL

--- a/docs/specs/設計規約.md
+++ b/docs/specs/設計規約.md
@@ -4,7 +4,7 @@
 
 Version 1.4
 
-2026-05-31
+2026-05-30
 
 作成者: 開発チーム
 
@@ -17,7 +17,7 @@ Version 1.4
 | 1.1 | 2026-05-22 | TOC 追加(Issue #131) | 開発チーム |
 | 1.2 | 2026-05-22 | §12 ドキュメント管理規約追加(Issue #147) | 開発チーム |
 | 1.3 | 2026-05-22 | §12 → §10 に採番修正、§9 末尾の誤配置リンクを移動(PR #203 レビュー対応) | 開発チーム |
-| 1.4 | 2026-05-31 | Issue #145 / [ADR-0010](../adr/0010-tenant-isolation-hibernate-filter.md): §3.3 マルチテナントの保留節(Filter vs Spring AOP 選択)を解消し、Hibernate Filter 採用を確定 | 開発チーム |
+| 1.4 | 2026-05-30 | Issue #145 / [ADR-0010](../adr/0010-tenant-isolation-hibernate-filter.md): §3.3 マルチテナントの保留節(Filter vs Spring AOP 選択)を解消し、Hibernate Filter 採用を確定 | 開発チーム |
 
 ## 目次
 


### PR DESCRIPTION
## 概要
Issue #145 に基づき、マルチテナント絞り込みの自動付与方式を **Hibernate Filter** に確定し、設計規約 §3.3 / コーディング規約 §8.1 の保留節を解消する。

## 変更点
- `docs/adr/0010-tenant-isolation-hibernate-filter.md` 新規(Status: Accepted、A/B/C 比較 + A 採用)
- 設計規約 v1.4 §3.3: 「Filter vs Spring AOP — 想定 ADR-0004」保留節を解消し ADR-0010 リンク
- コーディング規約 v1.4 §8.1: SELECT 系派生クエリは単純命名 OK、`@Modifying` UPDATE/DELETE と native query は引き続き明示絞り(§3.3 既存ルール)

## 採用理由(ADR §4 要約)
- ADR-0008(GraalVM Native Image)との相性が決定打。Spring AOP は proxy 依存で AOT 運用負荷が高い
- エンティティ関連ナビゲーション(`task.subTasks` 等)に効くのは Hibernate Filter のみ
- §3.3 が既に A 案ドラフト、本 PR で正式化 + §8.1 緩和(Issue #145 のスコープと一致)

## 番号ずれの説明
Issue 起票時の「想定 ADR-0004」は ADR-0001 §6 の予約番号で、その後 ADR-0004 は別件(`tenants-as-audit-column-exception`、2026-05-16 Accepted)に消費されたため、本決定は **ADR-0010** として起票。ADR-0001 §6 の履歴記述は「番号は予約せず起票順」の注記が既にあるためそのまま維持。

## 実コード配線のスコープ分離
本 PR は方式決定 ADR + 規約緩和のみ。Hibernate Filter / TenantContext 配線および Repository 命名緩和の実コード作業は、既存の **Issue #87(N5: TenantContext + TenantContextFilter + Hibernate Filter 実装)** で Sprint 0 着手時に実施する(ADR §6 で明示)。本 PR と同期で Issue #87 本文に ADR-0010 リンクと命名緩和項目を追記済。

## 関連
- Closes #145
- 親: #121(Sprint 0 readiness)
- 関連実装 Issue: #87(N5、本 ADR の実コード配線担当)
- 参照 ADR: 0001 / 0004 / 0008 / 0009

## 未対応レビュー

| 指摘 | 内容 | 状態 |
|---|---|---|
| [Sprint 0 日付誤り](https://github.com/win2cot/tasks-webapi/pull/285#pullrequestreview-3049716488) | ADR-0010 §1 の Sprint 0 開始予定日 `2026-06-14` → `2026-07-14` | ✅ 対応済(a5ddad4) |
| [version date 未来日付](https://github.com/win2cot/tasks-webapi/pull/285#pullrequestreview-3049716488) | ADR/規約の version date `2026-05-31` → `2026-05-30` | ✅ 対応済(a5ddad4) |
