### PR TITLE
feat: @CreatedBy / @LastModifiedBy + AuditorAware<Long> で監査列 created_by / updated_by を自動投入 (#144)

### DIFF
--- a/docs/specs/コーディング規約.md
+++ b/docs/specs/コーディング規約.md
@@ -255,7 +255,7 @@ public class TaskJpaEntity {
   // 業務テーブルは created_at / updated_at / created_by / updated_by を必須とする。
   // 自動投入は ADR-0009 で Spring Data JPA Auditing を採用と確定済み。
   // @CreatedDate / @LastModifiedDate は ClockConfig の DateTimeProvider が自動投入する。
-  // @CreatedBy / @LastModifiedBy + AuditorAware<Long> の実装は別途対応。
+  // @CreatedBy / @LastModifiedBy は JpaAuditorAware (security/adapter/persistence) が自動投入する。
   @Column(name = "created_at", nullable = false, updatable = false)
   private OffsetDateTime createdAt;
 

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/security/adapter/persistence/JpaAuditorAware.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/security/adapter/persistence/JpaAuditorAware.java
@@ -1,0 +1,27 @@
+package xyz.dgz48.tasks.webapi.security.adapter.persistence;
+
+import java.util.Optional;
+import org.jspecify.annotations.Nullable;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import xyz.dgz48.tasks.webapi.security.domain.TasksPrincipal;
+
+@Component("jpaAuditorAware")
+class JpaAuditorAware implements AuditorAware<Long> {
+
+  @Override
+  public Optional<Long> getCurrentAuditor() {
+    @Nullable Authentication authentication =
+        SecurityContextHolder.getContext().getAuthentication();
+    if (authentication == null || !authentication.isAuthenticated()) {
+      return Optional.empty();
+    }
+    Object principal = authentication.getPrincipal();
+    if (principal instanceof TasksPrincipal tasksPrincipal) {
+      return Optional.of(tasksPrincipal.getId());
+    }
+    return Optional.empty();
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/shared/infra/ClockConfig.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/shared/infra/ClockConfig.java
@@ -11,7 +11,9 @@ import org.springframework.data.auditing.DateTimeProvider;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @Configuration
-@EnableJpaAuditing(dateTimeProviderRef = "clockDateTimeProvider")
+@EnableJpaAuditing(
+    dateTimeProviderRef = "clockDateTimeProvider",
+    auditorAwareRef = "jpaAuditorAware")
 class ClockConfig {
 
   @Bean

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/adapter/persistence/TaskJpaEntity.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/adapter/persistence/TaskJpaEntity.java
@@ -15,7 +15,9 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.jspecify.annotations.Nullable;
+import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import xyz.dgz48.tasks.webapi.task.domain.Priority;
@@ -81,6 +83,14 @@ public class TaskJpaEntity {
   @LastModifiedDate
   @Column(name = "updated_at", nullable = false)
   private LocalDateTime updatedAt;
+
+  @CreatedBy
+  @Column(name = "created_by", nullable = false, updatable = false)
+  private Long createdBy;
+
+  @LastModifiedBy
+  @Column(name = "updated_by", nullable = false)
+  private Long updatedBy;
 
   public TaskJpaEntity(
       Long tenantId,

--- a/webapi/src/main/resources/db/migration/V1.0.0_01__create_tables.sql
+++ b/webapi/src/main/resources/db/migration/V1.0.0_01__create_tables.sql
@@ -48,6 +48,8 @@ CREATE TABLE tasks (
     deleted_at   DATETIME                                            NULL     COMMENT '論理削除日時(NULL=有効)',
     created_at   DATETIME                                            NOT NULL COMMENT '作成日時',
     updated_at   DATETIME                                            NOT NULL COMMENT '更新日時',
+    created_by   BIGINT                                              NOT NULL COMMENT '作成ユーザーID(users.id)',
+    updated_by   BIGINT                                              NOT NULL COMMENT '更新ユーザーID(users.id)',
     PRIMARY KEY (id),
     KEY idx_tasks_tenant_due        (tenant_id, due_date),
     KEY idx_tasks_tenant_owner_due  (tenant_id, owner_id, due_date),
@@ -55,9 +57,11 @@ CREATE TABLE tasks (
     KEY idx_tasks_tenant_status_due (tenant_id, status, due_date),
     KEY idx_tasks_tenant_visibility (tenant_id, visibility),
     KEY idx_tasks_tenant_deleted    (tenant_id, deleted_at),
-    CONSTRAINT fk_tasks_tenant    FOREIGN KEY (tenant_id)   REFERENCES tenants(id) ON DELETE RESTRICT,
-    CONSTRAINT fk_tasks_owner     FOREIGN KEY (owner_id)    REFERENCES users(id)   ON DELETE RESTRICT,
-    CONSTRAINT fk_tasks_assignee  FOREIGN KEY (assignee_id) REFERENCES users(id)   ON DELETE RESTRICT
+    CONSTRAINT fk_tasks_tenant      FOREIGN KEY (tenant_id)   REFERENCES tenants(id)  ON DELETE RESTRICT,
+    CONSTRAINT fk_tasks_owner       FOREIGN KEY (owner_id)    REFERENCES users(id)    ON DELETE RESTRICT,
+    CONSTRAINT fk_tasks_assignee    FOREIGN KEY (assignee_id) REFERENCES users(id)    ON DELETE RESTRICT,
+    CONSTRAINT fk_tasks_created_by  FOREIGN KEY (created_by)  REFERENCES users(id)    ON DELETE RESTRICT,
+    CONSTRAINT fk_tasks_updated_by  FOREIGN KEY (updated_by)  REFERENCES users(id)    ON DELETE RESTRICT
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE task_stakeholders (

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/adapter/persistence/TaskEntityTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/adapter/persistence/TaskEntityTest.java
@@ -5,14 +5,20 @@ import static org.assertj.core.api.Assertions.assertThat;
 import jakarta.persistence.EntityManager;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.transaction.annotation.Transactional;
 import xyz.dgz48.tasks.webapi.FixedClockConfiguration;
 import xyz.dgz48.tasks.webapi.MockJwtDecoderConfiguration;
 import xyz.dgz48.tasks.webapi.TestcontainersConfiguration;
+import xyz.dgz48.tasks.webapi.security.adapter.web.TasksAuthenticationToken;
+import xyz.dgz48.tasks.webapi.security.domain.TasksPrincipal;
 import xyz.dgz48.tasks.webapi.task.domain.Priority;
 import xyz.dgz48.tasks.webapi.task.domain.TaskStatus;
 import xyz.dgz48.tasks.webapi.tenant.adapter.persistence.TenantJpaEntity;
@@ -28,6 +34,27 @@ import xyz.dgz48.tasks.webapi.user.adapter.persistence.UserJpaEntity;
 class TaskEntityTest {
 
   @Autowired EntityManager entityManager;
+
+  private Long auditorUserId;
+
+  @BeforeEach
+  void setUpAuditor() {
+    var auditor = new UserJpaEntity("sub-auditor", "auditor@example.com", "監査 太郎", "カンサ タロウ", null);
+    entityManager.persist(auditor);
+    entityManager.flush();
+    auditorUserId = auditor.getId();
+
+    var principal =
+        new TasksPrincipal(
+            auditorUserId, "sub-auditor", "auditor@example.com", "監査 太郎", "カンサ タロウ", null);
+    SecurityContextHolder.getContext()
+        .setAuthentication(new TasksAuthenticationToken(principal, List.of()));
+  }
+
+  @AfterEach
+  void clearSecurityContext() {
+    SecurityContextHolder.clearContext();
+  }
 
   @Test
   void canPersistUser() {
@@ -182,5 +209,7 @@ class TaskEntityTest {
 
     assertThat(task.getCreatedAt()).isEqualTo(expectedTimestamp);
     assertThat(task.getUpdatedAt()).isEqualTo(expectedTimestamp);
+    assertThat(task.getCreatedBy()).isEqualTo(auditorUserId);
+    assertThat(task.getUpdatedBy()).isEqualTo(auditorUserId);
   }
 }

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/adapter/persistence/TaskJpaRepositoryAdapterTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/adapter/persistence/TaskJpaRepositoryAdapterTest.java
@@ -4,13 +4,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import jakarta.persistence.EntityManager;
 import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.transaction.annotation.Transactional;
 import xyz.dgz48.tasks.webapi.MockJwtDecoderConfiguration;
 import xyz.dgz48.tasks.webapi.TestcontainersConfiguration;
+import xyz.dgz48.tasks.webapi.security.adapter.web.TasksAuthenticationToken;
+import xyz.dgz48.tasks.webapi.security.domain.TasksPrincipal;
 import xyz.dgz48.tasks.webapi.task.domain.Priority;
 import xyz.dgz48.tasks.webapi.task.domain.Task;
 import xyz.dgz48.tasks.webapi.task.domain.TaskStatus;
@@ -25,6 +31,24 @@ class TaskJpaRepositoryAdapterTest {
 
   @Autowired EntityManager entityManager;
   @Autowired TaskRepository taskRepository;
+
+  @BeforeEach
+  void setUpAuditor() {
+    var auditor = new UserJpaEntity("sub-auditor", "auditor@example.com", "監査 太郎", "カンサ タロウ", null);
+    entityManager.persist(auditor);
+    entityManager.flush();
+
+    var principal =
+        new TasksPrincipal(
+            auditor.getId(), "sub-auditor", "auditor@example.com", "監査 太郎", "カンサ タロウ", null);
+    SecurityContextHolder.getContext()
+        .setAuthentication(new TasksAuthenticationToken(principal, List.of()));
+  }
+
+  @AfterEach
+  void clearSecurityContext() {
+    SecurityContextHolder.clearContext();
+  }
 
   @Test
   void findByIdAndTenantIdReturnsDomainTaskWhenFound() {


### PR DESCRIPTION
## Summary

- `tasks` テーブルに `created_by` / `updated_by` (`BIGINT NOT NULL`, FK → `users.id`) を追加(設計規約 §3.5)
- `JpaAuditorAware` を新規作成(`security/adapter/persistence`)。`SecurityContextHolder` から `TasksPrincipal.getId()` を返す
- `@EnableJpaAuditing` に `auditorAwareRef = "jpaAuditorAware"` を追加
- `TaskJpaEntity` に `@CreatedBy createdBy` / `@LastModifiedBy updatedBy` フィールドを追加

## Test plan

- [x] `TaskEntityTest.timestampsAreSetFromFixedClock` に `createdBy` / `updatedBy` のアサーション追加
- [x] `TaskEntityTest` / `TaskJpaRepositoryAdapterTest` に `@BeforeEach` で監査ユーザー + SecurityContext をセットアップ
- [x] `./gradlew :webapi:test` 全テスト PASS 確認済み

## Notes

- SQL ファイルは Sprint 0 中は分割せず `V1.0.0_01__create_tables.sql` に直接追記
- `JpaAuditorAware` を `security.adapter.persistence` に配置することで `shared` → `security` の逆依存を回避

## 未対応レビュー

| 指摘 | 内容 | 状態 |
|---|---|---|
| (なし) | | |

Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)
