### PR TITLE
feat(test): @WithMockJwt 等のセキュリティテストユーティリティを実装 (#143)

### DIFF
--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/SecurityMockMvcAutoConfiguration.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/SecurityMockMvcAutoConfiguration.java
@@ -1,0 +1,26 @@
+package xyz.dgz48.tasks.webapi;
+
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.webmvc.test.autoconfigure.MockMvcBuilderCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers;
+
+/**
+ * {@code @WebMvcTest} / {@code @AutoConfigureMockMvc} で {@link
+ * SecurityMockMvcConfigurers#springSecurity()} を自動適用するテスト用 AutoConfiguration。
+ *
+ * <p>これにより {@link
+ * org.springframework.security.test.context.support.WithSecurityContext}(@WithMockJwt 等)が MockMvc
+ * リクエスト処理中に正しく SecurityContext を伝播する。
+ *
+ * <p>登録先: {@code
+ * META-INF/spring/org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc.imports}
+ */
+@AutoConfiguration
+public class SecurityMockMvcAutoConfiguration {
+
+  @Bean
+  MockMvcBuilderCustomizer securityMockMvcBuilderCustomizer() {
+    return builder -> builder.apply(SecurityMockMvcConfigurers.springSecurity());
+  }
+}

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/SecurityConfigTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/SecurityConfigTest.java
@@ -1,6 +1,5 @@
 package xyz.dgz48.tasks.webapi.security.adapter.web;
 
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -28,8 +27,27 @@ class SecurityConfigTest {
   }
 
   @Test
+  @WithMockJwt
   void authenticatedRequestIsAllowed() throws Exception {
-    mockMvc.perform(get("/api/tasks").with(jwt())).andExpect(status().isNotFound());
+    mockMvc.perform(get("/api/tasks")).andExpect(status().isNotFound());
+  }
+
+  @Test
+  @WithMockMember
+  void memberIsAllowed() throws Exception {
+    mockMvc.perform(get("/api/tasks")).andExpect(status().isNotFound());
+  }
+
+  @Test
+  @WithMockTenantAdmin
+  void tenantAdminIsAllowed() throws Exception {
+    mockMvc.perform(get("/api/tasks")).andExpect(status().isNotFound());
+  }
+
+  @Test
+  @WithMockSaasAdmin
+  void saasAdminIsAllowed() throws Exception {
+    mockMvc.perform(get("/api/tasks")).andExpect(status().isNotFound());
   }
 
   @Test

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/WithMockJwt.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/WithMockJwt.java
@@ -1,0 +1,44 @@
+package xyz.dgz48.tasks.webapi.security.adapter.web;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+/**
+ * テストメソッドまたはクラスに付与することで、{@link xyz.dgz48.tasks.webapi.security.domain.TasksPrincipal} を
+ * SecurityContext に投入した状態でテストを実行する。
+ *
+ * <p>{@link org.springframework.security.test.context.support.WithMockUser} の代替として使用し、{@link
+ * xyz.dgz48.tasks.webapi.security.adapter.web.TasksAuthenticationToken} を経由する経路をカバーする。
+ */
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Documented
+@WithSecurityContext(factory = WithMockJwtSecurityContextFactory.class)
+public @interface WithMockJwt {
+
+  long id() default 1L;
+
+  String sub() default "test-sub";
+
+  String email() default "test@example.com";
+
+  String fullName() default "テスト太郎";
+
+  String fullNameKana() default "テストタロウ";
+
+  /** 空文字列は {@code null}(部署なし)として扱われる。 */
+  String departmentName() default "";
+
+  /**
+   * 付与するロール名。{@code ROLE_} プレフィックスは不要({@code hasRole()} と同じ形式)。
+   *
+   * <p>例: {@code "MEMBER"}, {@code "TENANT_ADMIN"}, {@code "APP_ADMIN"}
+   */
+  String[] roles() default {"MEMBER"};
+}

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/WithMockJwtSecurityContextFactory.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/WithMockJwtSecurityContextFactory.java
@@ -1,0 +1,41 @@
+package xyz.dgz48.tasks.webapi.security.adapter.web;
+
+import java.util.Arrays;
+import java.util.List;
+import org.jspecify.annotations.Nullable;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+import xyz.dgz48.tasks.webapi.security.domain.TasksPrincipal;
+
+/** {@link WithMockJwt} の SecurityContext を構築するファクトリ。 */
+public class WithMockJwtSecurityContextFactory implements WithSecurityContextFactory<WithMockJwt> {
+
+  @Override
+  public SecurityContext createSecurityContext(WithMockJwt annotation) {
+    List<GrantedAuthority> authorities =
+        Arrays.stream(annotation.roles())
+            .map(role -> (GrantedAuthority) new SimpleGrantedAuthority("ROLE_" + role))
+            .toList();
+
+    @Nullable String departmentName =
+        annotation.departmentName().isEmpty() ? null : annotation.departmentName();
+
+    TasksPrincipal principal =
+        new TasksPrincipal(
+            annotation.id(),
+            annotation.sub(),
+            annotation.email(),
+            annotation.fullName(),
+            annotation.fullNameKana(),
+            departmentName);
+
+    TasksAuthenticationToken authentication = new TasksAuthenticationToken(principal, authorities);
+
+    SecurityContext context = SecurityContextHolder.createEmptyContext();
+    context.setAuthentication(authentication);
+    return context;
+  }
+}

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/WithMockMember.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/WithMockMember.java
@@ -1,0 +1,16 @@
+package xyz.dgz48.tasks.webapi.security.adapter.web;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/** {@code MEMBER} ロールのユーザーを SecurityContext に投入するショートカット。 */
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Documented
+@WithMockJwt(roles = "MEMBER")
+public @interface WithMockMember {}

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/WithMockSaasAdmin.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/WithMockSaasAdmin.java
@@ -1,0 +1,16 @@
+package xyz.dgz48.tasks.webapi.security.adapter.web;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/** {@code APP_ADMIN} ロール(Keycloak realm role)の SaaS 管理者を SecurityContext に投入するショートカット。 */
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Documented
+@WithMockJwt(roles = "APP_ADMIN")
+public @interface WithMockSaasAdmin {}

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/WithMockTenantAdmin.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/WithMockTenantAdmin.java
@@ -1,0 +1,16 @@
+package xyz.dgz48.tasks.webapi.security.adapter.web;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/** {@code TENANT_ADMIN} ロールのユーザーを SecurityContext に投入するショートカット。 */
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Documented
+@WithMockJwt(roles = "TENANT_ADMIN")
+public @interface WithMockTenantAdmin {}

--- a/webapi/src/test/resources/META-INF/spring/org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc.imports
+++ b/webapi/src/test/resources/META-INF/spring/org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc.imports
@@ -1,0 +1,1 @@
+xyz.dgz48.tasks.webapi.SecurityMockMvcAutoConfiguration


### PR DESCRIPTION
## Summary

- `@WithMockJwt` アノテーション + `WithMockJwtSecurityContextFactory` を実装。`TasksPrincipal` を任意の `id / sub / email / roles` で生成し `TasksAuthenticationToken` を SecurityContext に投入する
- `@WithMockMember` / `@WithMockTenantAdmin` / `@WithMockSaasAdmin` のショートカットアノテーションを追加
- `SecurityConfigTest` を `SecurityMockMvcRequestPostProcessors.jwt()` から `@WithMockJwt` 系アノテーションへ移行
- **Spring Boot 4 対応**: `@WebMvcTest` が `springSecurity()` を自動適用しない問題に対応するため `SecurityMockMvcAutoConfiguration` を `AutoConfigureMockMvc.imports` に登録

## 技術的背景

Spring Boot 4 の新パッケージ `org.springframework.boot.webmvc.test.autoconfigure` では、旧 `MockMvcSecurityAutoConfiguration` が廃止され `SecurityMockMvcConfigurer#springSecurity()` が自動適用されなくなった。このため `@WithSecurityContext` ベースのアノテーションが stateless JWT 構成の `@WebMvcTest` で機能しなかった。  
`SecurityMockMvcAutoConfiguration` を `AutoConfigureMockMvc.imports` に登録することで全 `@WebMvcTest` / `@AutoConfigureMockMvc` テストに透過的に適用した。

## 使い方

```java
// 基本: デフォルト値(id=1, sub="test-sub", MEMBER ロール)
@Test
@WithMockJwt
void someTest() { ... }

// カスタム値
@Test
@WithMockJwt(id = 42L, sub = "custom-sub", roles = {"TENANT_ADMIN"})
void anotherTest() { ... }

// ショートカット
@Test
@WithMockMember
void memberTest() { ... }

@Test
@WithMockTenantAdmin
void tenantAdminTest() { ... }

@Test
@WithMockSaasAdmin
void saasAdminTest() { ... }
```

## Test plan

- [x] `SecurityConfigTest` の全テスト(`@WithMockJwt` / `@WithMockMember` / `@WithMockTenantAdmin` / `@WithMockSaasAdmin`)がグリーン
- [x] `./gradlew :webapi:check` 全通過(フォーマット・コンパイル・テスト・カバレッジ)
- [x] `TasksAuthenticationToken` を経由する経路が MockMvc リクエスト処理内でカバーされることを確認

Closes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)