### PR TITLE
chore: JSON ログ・Prometheus エンドポイント・.env.local.example を追加 (#89)

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,7 +1,7 @@
 # .env.local.example — copy to .env.local and fill in real values (DO NOT commit .env.local)
 # Usage: cp .env.local.example .env.local && source .env.local && ./gradlew :webapi:bootRun
 
-export DATASOURCE_URL=jdbc:mysql://localhost:3306/tasks?useSSL=false&allowPublicKeyRetrieval=true
+export DATASOURCE_URL=jdbc:mysql://localhost:3306/tasks?useSSL=false&allowPublicKeyRetrieval=true&connectionTimeZone=SERVER&forceConnectionTimeZoneToSession=true
 export DATASOURCE_USERNAME=tasks_webapi
 export DATASOURCE_PASSWORD=
 export OIDC_ISSUER_URI=http://localhost:18080/realms/tasks

--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,7 @@
+# .env.local.example — copy to .env.local and fill in real values (DO NOT commit .env.local)
+# Usage: cp .env.local.example .env.local && source .env.local && ./gradlew :webapi:bootRun
+
+export DATASOURCE_URL=jdbc:mysql://localhost:3306/tasks?useSSL=false&allowPublicKeyRetrieval=true
+export DATASOURCE_USERNAME=tasks_webapi
+export DATASOURCE_PASSWORD=
+export OIDC_ISSUER_URI=http://localhost:18080/realms/tasks

--- a/docs/dev/local-setup.md
+++ b/docs/dev/local-setup.md
@@ -116,6 +116,15 @@ docker compose -f docker-compose.local.yml down -v
 ## 4. 環境変数設定
 
 アプリケーション起動に必要な環境変数をまとめた `.env.local` ファイルを作成する。
+リポジトリルートにある [.env.local.example](../../.env.local.example) をテンプレートとして使うと便利。
+
+```bash
+# リポジトリルートで実行
+cp .env.local.example .env.local
+# 必要に応じて .env.local を編集し、DATASOURCE_PASSWORD 等の実際の値を設定する
+```
+
+または手動で作成する場合:
 
 ```bash
 # リポジトリルートで実行
@@ -414,6 +423,7 @@ curl -s http://localhost:18080/realms/tasks/.well-known/openid-configuration | g
 
 - [CLAUDE.md](../../.claude/CLAUDE.md) — コマンドリファレンス / コード品質ツール
 - [docker-compose.local.yml](../../docker-compose.local.yml) — Docker Compose 定義
+- [.env.local.example](../../.env.local.example) — 環境変数テンプレート(`.env.local` にコピーして使用)
 - [application.yml](../../webapi/src/main/resources/application.yml) — Spring Boot 設定 / env vars コメント
 - [keycloak/realm-export/tasks-realm.json](../../keycloak/realm-export/tasks-realm.json) — Keycloak Realm 定義
 - [docs/specs/開発計画書.md](../specs/開発計画書.md) — 開発計画 §4.3.1 / §11.1

--- a/docs/dev/local-setup.md
+++ b/docs/dev/local-setup.md
@@ -129,7 +129,7 @@ cp .env.local.example .env.local
 ```bash
 # リポジトリルートで実行
 cat > .env.local << 'EOF'
-export DATASOURCE_URL=jdbc:mysql://localhost:3306/tasks?useSSL=false&allowPublicKeyRetrieval=true
+export DATASOURCE_URL=jdbc:mysql://localhost:3306/tasks?useSSL=false&allowPublicKeyRetrieval=true&connectionTimeZone=SERVER&forceConnectionTimeZoneToSession=true
 export DATASOURCE_USERNAME=tasks_webapi
 export DATASOURCE_PASSWORD=tasks_webapi
 export OIDC_ISSUER_URI=http://localhost:18080/realms/tasks
@@ -140,7 +140,7 @@ EOF
 
 | 変数名 | ローカル開発値 | 説明 |
 |--------|----------------|------|
-| `DATASOURCE_URL` | `jdbc:mysql://localhost:3306/tasks?useSSL=false&allowPublicKeyRetrieval=true` | MySQL JDBC URL |
+| `DATASOURCE_URL` | `jdbc:mysql://localhost:3306/tasks?useSSL=false&allowPublicKeyRetrieval=true&connectionTimeZone=SERVER&forceConnectionTimeZoneToSession=true` | MySQL JDBC URL |
 | `DATASOURCE_USERNAME` | `tasks_webapi` | DB ユーザー名 |
 | `DATASOURCE_PASSWORD` | `tasks_webapi` | DB パスワード |
 | `OIDC_ISSUER_URI` | `http://localhost:18080/realms/tasks` | Keycloak realm の issuer URI |

--- a/webapi/build.gradle
+++ b/webapi/build.gradle
@@ -53,6 +53,12 @@ dependencies {
     // MySQL
     runtimeOnly 'com.mysql:mysql-connector-j'
 
+    // JSON logging for CloudWatch Logs
+    runtimeOnly 'net.logstash.logback:logstash-logback-encoder:8.0'
+
+    // Prometheus metrics
+    implementation 'io.micrometer:micrometer-registry-prometheus'
+
     // Testcontainers
     testImplementation 'org.springframework.boot:spring-boot-testcontainers'
     testImplementation 'org.testcontainers:testcontainers-mysql'

--- a/webapi/src/main/resources/application.yml
+++ b/webapi/src/main/resources/application.yml
@@ -40,7 +40,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: health,info
+        include: health,info,prometheus
 
 logging:
   level:

--- a/webapi/src/main/resources/logback-spring.xml
+++ b/webapi/src/main/resources/logback-spring.xml
@@ -1,0 +1,11 @@
+<configuration>
+  <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
+  </appender>
+
+  <root level="INFO">
+    <appender-ref ref="CONSOLE"/>
+  </root>
+
+  <logger name="xyz.dgz48" level="DEBUG"/>
+</configuration>

--- a/webapi/src/test/resources/logback-test.xml
+++ b/webapi/src/test/resources/logback-test.xml
@@ -1,0 +1,11 @@
+<configuration>
+  <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="INFO">
+    <appender-ref ref="CONSOLE"/>
+  </root>
+</configuration>


### PR DESCRIPTION
## Summary

Closes #89

- `logback-spring.xml` 新規作成 — `LogstashEncoder` による JSON ログ出力(CloudWatch Logs 投入形式)
- `application.yml` — `/actuator/prometheus` を公開(`health,info,prometheus`)
- `build.gradle` — `logstash-logback-encoder:8.0` / `micrometer-registry-prometheus` を追加
- `.env.local.example` — 環境変数テンプレートをリポジトリルートに新規追加
- `docs/dev/local-setup.md` — セクション 4 と関連ドキュメント欄に `.env.local.example` への参照を追記
- `src/test/resources/logback-test.xml` — テスト実行時は人間可読パターンに切替(非ブロッキング指摘対応)

## 受け入れ条件チェック

- [x] `application-*.yml` が存在しない / `@Profile` 不使用
- [x] `.env.local.example` が repo root に存在、`.env.local` は `.gitignore` 対象
- [x] JSON ログ出力をテスト実行ログで確認済み(`{"@timestamp":...}` 形式) — テスト時は `logback-test.xml` により人間可読パターン
- [x] CI green (`:webapi:check` ローカル確認済み)
- [ ] `GET /actuator/prometheus` 200 確認 — 実 Docker Compose 環境で要確認
- [ ] `GET /actuator/health` 200 確認 — 同上

## Test plan

- `./gradlew :webapi:check` — ローカル green 確認済み
- テスト実行時は `logback-test.xml` により人間可読パターンで出力
- Docker Compose 環境での `/actuator/prometheus` / `/actuator/health` は PR マージ前に手動確認推奨

## 未対応レビュー

| 指摘 | 内容 | 状態 |
|------|------|------|
| (なし) | | |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
