### PR TITLE
chore: MySQL サーバーのタイムゾーンを Asia/Tokyo に明示設定

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,6 +1,7 @@
 services:
   mysql:
     image: mysql:8.4
+    command: --default-time-zone=Asia/Tokyo
     environment:
       MYSQL_ROOT_PASSWORD: root
       MYSQL_DATABASE: tasks

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/TestcontainersConfiguration.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/TestcontainersConfiguration.java
@@ -12,6 +12,7 @@ public class TestcontainersConfiguration {
   @ServiceConnection
   MySQLContainer mysqlContainer() {
     return new MySQLContainer("mysql:8.4")
+        .withCommand("--default-time-zone=Asia/Tokyo")
         .withUrlParam("connectionTimeZone", "SERVER")
         .withUrlParam("forceConnectionTimeZoneToSession", "true");
   }


### PR DESCRIPTION
## Summary

`connectionTimeZone=SERVER` は「サーバーの TZ に追従する」だけで、MySQL サーバー自体のタイムゾーンは設定しない。両環境とも未指定のままではコンテナデフォルト(UTC)になり、アプリの `jackson.time-zone: Asia/Tokyo` との不一致が潜在的リスクになるため、明示的に固定する。

- `docker-compose.local.yml` — MySQL に `command: --default-time-zone=Asia/Tokyo` を追加
- `TestcontainersConfiguration.java` — `.withCommand("--default-time-zone=Asia/Tokyo")` を追加(CI は Testcontainers 経由のため同変更でカバー)

`TIMESTAMP` 型は使用しない方針だが、明示設定することで意図を文書化し、将来の混乱を防ぐ。

## Test plan

- [x] `./gradlew :webapi:test` ローカル green 確認済み(`.withCommand` で Testcontainers MySQL が正常起動することを確認)
- [ ] Docker Compose 環境での `SELECT @@time_zone;` → `Asia/Tokyo` であることを手動確認推奨

🤖 Generated with [Claude Code](https://claude.com/claude-code)