### PR TITLE
docs(spec)+impl: 既存users表記補正 + ADR-0006派生 users schema/JPA/匿名化service (#90)

### DIFF
--- a/docs/diagrams/sequence-01-oidc-login.mmd
+++ b/docs/diagrams/sequence-01-oidc-login.mmd
@@ -1,6 +1,6 @@
 %% ====================================================================
-%% Sequence 01: OIDC Login (Keycloak integration + legacy users lookup)
-%% Task Management System v1.2
+%% Sequence 01: OIDC Login (Keycloak integration + users lookup)
+%% Task Management System v1.3 (ADR-0006: users は本システム内 SoT)
 %% ====================================================================
 sequenceDiagram
   autonumber
@@ -8,8 +8,7 @@ sequenceDiagram
   participant Browser as ブラウザ
   participant AP as Spring Boot AP<br/>(ECS Fargate)
   participant KC as Keycloak<br/>(ECS Fargate)
-  participant LegacyUsers as 既存users DB<br/>(ReadOnlyレプリカ)
-  participant AppDB as アプリDB<br/>(MySQL)
+  participant AppDB as アプリDB<br/>(MySQL / users + 業務テーブル)
 
   User->>Browser: アクセス /
   Browser->>AP: GET /
@@ -24,12 +23,12 @@ sequenceDiagram
   AP->>KC: POST /token (code, code_verifier, client_id, client_secret)
   KC-->>AP: 200 { access_token (JWT), id_token, refresh_token }
   AP->>AP: JWT検証 (署名/iss/aud/exp)
-  AP->>LegacyUsers: SELECT id, email, full_name, full_name_kana, department_name<br/>FROM users WHERE oidc_sub = :sub
+  AP->>AppDB: SELECT id, email, full_name, full_name_kana, department_name<br/>FROM users WHERE oidc_sub = :sub AND deleted_at IS NULL
   alt oidc_subが存在しない
-    LegacyUsers-->>AP: (0件)
+    AppDB-->>AP: (0件)
     AP-->>Browser: 403 E_USER_NOT_REGISTERED<br/>"管理者にユーザー登録を依頼してください"
   else 存在する
-    LegacyUsers-->>AP: { id, email, full_name, ... }
+    AppDB-->>AP: { id, email, full_name, ... }
     AP->>AppDB: SELECT tenant_id, role FROM user_tenants<br/>WHERE user_id = :userId AND status='ACTIVE'
     AppDB-->>AP: 所属テナント+ロール一覧
     alt 所属テナント0件

--- a/docs/specs/基本設計書.md
+++ b/docs/specs/基本設計書.md
@@ -158,7 +158,7 @@ Version 1.4.8
 
 │  MySQL 8.x (DB)                  │
 
-│  + 既存usersテーブル(参照のみ)    │
+│  + usersテーブル(本システム内・ADR-0006)│
 
 └──────────────────────────────────┘
 
@@ -173,7 +173,7 @@ Version 1.4.8
 | Keycloak | ECS on Fargate / 2vCPU・4GB × 2 | 本プロジェクトで構築、共有RDS(専用スキーマ) |
 | コンテナレジストリ | Amazon ECR | Spring Boot AP / Keycloak のDockerイメージ |
 | AP用DB | Amazon RDS for MySQL 8.x / Multi-AZ | 本番のみMulti-AZ、ステージングはSingle-AZ、KMS暗号化 |
-| 既存users用DB | 既存RDS MySQL | ReadOnlyレプリカ経由で参照(本システムからwriteしない) |
+| AP用DB(users 含む) | Amazon RDS for MySQL 8.x | users テーブルは本システム DB 内に保有(ADR-0006)。Keycloak は Writable User Storage SPI 経由で read/write |
 | メール送信 | Amazon SES | 通知メール・招待メールに使用 |
 | 静的コンテンツ | S3 + CloudFront | HTML/CSS/JS の配信 |
 | シークレット管理 | AWS Systems Manager Parameter Store SecureString | Keycloak SMTP password 等、IAM 認証で代替不可な機密。DB password は RDS IAM 認証(K-A 案)により不使用。詳細は[設計規約 §5.4](./設計規約.md#54-通信データ保護) / [infrastructure-plan §3.4 / §3.5](../architecture/infrastructure-plan.md) 参照 |
@@ -246,7 +246,7 @@ Version 1.4.8
 | S-06 | タスク登録/編集 | /tasks/new, /tasks/{id}/edit | 新規・編集兼用(編集は所有者のみ) |
 | S-07 | テナント切替 | /tenants/select | 所属テナントから選択 |
 | S-08 | ユーザー管理(テナント) | /tenant/users | Tenant Adminのみ。招待・ロール変更 |
-| S-09 | プロフィール | /me | 既存usersから氏名・部署を表示(読み取り専用) |
+| S-09 | プロフィール | /me | usersから氏名・部署を表示 |
 | S-10 | 通知設定 | /me/notifications | メール通知ON/OFF |
 | S-11 | テナント新規作成 | /tenants/new | 認証済みでテナント未所属のユーザーが利用。テナント名を入力して作成すると、自分自身が初代 Tenant Admin として登録される(セルフサインアップ、モデル B) |
 | S-12 | プラットフォーム監視ダッシュボード | /admin | SaaS運営者のみ。総テナント数(ACTIVE/SUSPENDED 内訳)・総ユーザー数・総タスク数・直近 24h 新規テナント数を数値カードで表示。時系列グラフは Phase 2 |
@@ -364,18 +364,20 @@ Version 1.4.8
 
 ### 4.2 テーブル定義(MySQL 8.x / utf8mb4_unicode_ci)
 
-既存usersテーブルはスキーマ構造を変更しない(列追加・型変更を行わない)。書き込み権限は **INSERT のみ許可**(初回ログイン時の JIT プロビジョニングで新規行を作成。UPDATE / DELETE は本システムから行わない)。本システムが新規に作成する業務テーブルは、すべて tenant_id 列を持ち、Hibernate Filter で自動絞込する。
+users テーブルは本システム DB 内に保有する新規テーブル(将来的に既存 ID 基盤へのデータ移行余地を残す)。ADR-0006 により本システムが SoT として所有し、Keycloak は Writable User Storage SPI 経由で read/write する。本システム API と Keycloak Console の両方から書き込まれるため楽観排他(`version` 列)を用いる。退会・解約時は論理削除 + 個人情報匿名化(ADR-0006 §3.4)を適用し物理削除は MVP 未提供。本システムが新規に作成する業務テーブルは、すべて tenant_id 列を持ち、Hibernate Filter で自動絞込する。
 
-#### 4.2.1 users (既存スキーマ、本システムから INSERT 可 / UPDATE / DELETE 不可)
+#### 4.2.1 users (本システム内 SoT・ADR-0006)
 
 | カラム名 | 型 | PK | NOT NULL | 備考 |
 |---|---|---|---|---|
 | id | BIGINT AUTO_INCREMENT | ○ | ○ | 主キー(変更不可) |
-| oidc_sub | VARCHAR(255) |   | ○ | Keycloak Subject(UNIQUE) |
-| email | VARCHAR(255) |   | ○ | メールアドレス |
-| full_name | VARCHAR(255) |   | ○ | 氏名 |
-| full_name_kana | VARCHAR(255) |   | ○ | 氏名カナ |
-| department_name | VARCHAR(255) |   |   | 部署名 |
+| oidc_sub | VARCHAR(255) |   | ○ | Keycloak Subject(UNIQUE)。匿名化時は `__deleted__{id}` に置換 |
+| email | VARCHAR(255) |   | ○ | メールアドレス(UNIQUE)。匿名化時は `__deleted__{id}@deleted.invalid` に置換 |
+| full_name | VARCHAR(255) |   | ○ | 氏名。匿名化時は `__deleted__` に置換 |
+| full_name_kana | VARCHAR(255) |   | ○ | 氏名カナ。匿名化時は `__deleted__` に置換 |
+| department_name | VARCHAR(255) |   |   | 部署名。匿名化時は NULL に置換 |
+| version | BIGINT |   | ○ DEFAULT 0 | JPA `@Version` 楽観排他用(ADR-0006 §3.4) |
+| deleted_at | DATETIME |   |   | 論理削除日時。NULL = 有効、NOT NULL = 匿名化済み(ADR-0006 §3.4) |
 
 #### 4.2.2 tenants (テナント)
 

--- a/docs/specs/要件定義書.md
+++ b/docs/specs/要件定義書.md
@@ -102,7 +102,7 @@ Version 1.4.4
 
 ### 1.3 適用範囲
 
-本書は本システムの全機能および非機能要件を対象とする。Keycloak の構築・運用要件、既存usersテーブルとの連携要件も含む。外部システム連携(Slack、Google Calendar等)は本フェーズでは対象外とし、将来拡張機能として位置付ける。
+本書は本システムの全機能および非機能要件を対象とする。Keycloak の構築・運用要件、users テーブル(本システム内 SoT・ADR-0006)との連携要件も含む。外部システム連携(Slack、Google Calendar等)は本フェーズでは対象外とし、将来拡張機能として位置付ける。
 
 ## 2. 業務要件
 
@@ -124,7 +124,7 @@ Version 1.4.4
 - チーム全員のタスクを一元管理し、抜け漏れをゼロにする
 - 担当者・期限・優先度をひと目で把握できる仕組みを提供する
 - 管理者がチームの稼働状況をダッシュボードで可視化できる
-- 既存のID基盤(Keycloak / 既存users)を活用し、ユーザー登録の二重管理を排除する
+- Keycloak + 本システム内 users テーブル(SoT・ADR-0006)を活用し、ユーザー登録の二重管理を排除する
 
 ### 2.3 想定ユーザー・業務
 
@@ -158,13 +158,13 @@ Version 1.4.4
 
 | No. | 機能名 | 概要 |
 |---|---|---|
-| F-01 | ログイン(SSO) | Keycloak経由のOIDCログイン、oidc_subで既存usersと突合 |
+| F-01 | ログイン(SSO) | Keycloak経由のOIDCログイン、oidc_subで users(本システム内 SoT)と突合 |
 | F-02 | ログアウト | Keycloakセッション終了 |
 | F-03 | テナント切替 | 複数テナント所属時に切替可能 |
 | F-04 | テナント管理 | テナント作成は認証済みユーザーがセルフサービスで実行。状態変更(ACTIVE / SUSPENDED 切替)は SaaS運営者が実行 |
 | F-05 | ユーザー招待 | テナント管理者がメールでユーザーを招待 |
 | F-06 | ロール管理 | Tenant Admin / Member の付与・剥奪 |
-| F-07 | プロフィール表示 | 既存usersからfull_name/部署等を表示(更新は既存ID基盤側) |
+| F-07 | プロフィール表示 | users(本システム内 SoT)からfull_name/部署等を表示 |
 | F-08 | タスク登録 | 新規タスクを作成(期限日は必須) |
 | F-09 | タスク編集 | 所有者のみ編集可能(Tenant Admin の特別権限なし、ADR-0005) |
 | F-10 | タスク削除 | 所有者による論理削除のみ。物理削除は MVP 不実装(完全削除はテナント解約 #167 で扱う、Phase 2) |
@@ -184,9 +184,9 @@ Version 1.4.4
 
 - Keycloak (OpenID Connect) によるSSO
 - 認可コードフロー(PKCE)を使用
-- Keycloakから取得したJWTの `sub` クレームを既存usersテーブルの `oidc_sub` と突合
+- Keycloakから取得したJWTの `sub` クレームを users テーブル(本システム内 SoT・ADR-0006)の `oidc_sub` と突合
 - 初回ログイン時、`oidc_sub` が users に存在しない場合は **JIT(Just-In-Time)プロビジョニングで users 行を自動作成**する(セルフサインアップを前提とした仕様。Keycloak の `sub` / `email` / `name` クレームを users に転写)
-- ユーザー属性(full_name 等)は既存usersから取得
+- ユーザー属性(full_name 等)は users(本システム内 SoT)から取得
 
 #### 3.2.2 認可(F-06)
 
@@ -228,7 +228,7 @@ Version 1.4.4
 - テナント管理者がメールアドレス指定で招待
 - 招待されたメールアドレスが Keycloak に未登録の場合、Keycloak 側で先にユーザー登録が必要(本システム外)
 - 招待された人物が初めてログインしたタイミングで、本システム側 users 行は JIT で自動作成される(§3.2.1)。`user_tenants` への紐付けは招待トークンの照合により行う
-- 既存 users に `oidc_sub` が既に登録済みであれば、`user_tenants` への紐付けのみが発生し即時利用可
+- users(本システム内 SoT)に `oidc_sub` が既に登録済みであれば、`user_tenants` への紐付けのみが発生し即時利用可
 - 招待トークンの有効期限、JIT(users 行作成)と `user_tenants` 紐付けのトランザクション境界、招待トークン照合エラー時の挙動等の実装詳細は基本設計書 §3.3 / §6.2 に委任する
 
 #### 3.3.3 ロール管理(F-06)
@@ -408,21 +408,24 @@ Version 1.4.4
 | DB本番 | Amazon RDS for MySQL 8.x / db.r6g.xlarge / Multi-AZ |
 | Keycloak | ECS on Fargate / 2vCPU / 4GB × 2(クラスタ構成)、本プロジェクトで構築 |
 
-### 5.3 既存システムとの連携
+### 5.3 ID 基盤・users テーブルとの連携(ADR-0006)
 
-- 既存MySQLサーバの users テーブルは構造を変更しない
-- oidc_sub 列で Keycloak の sub クレームと突合
-- テナント所属とロールは新規テーブル user_tenants で管理
-- プロフィール(full_name 等)は既存usersを参照、本システムから更新しない
+- users テーブルは**本システム DB 内に保有する新規テーブル**であり、本システムが SoT として所有する(将来的に既存 ID 基盤へのデータ移行余地を残す)
+- Keycloak は Writable User Storage SPI 経由で users を read/write する(Sprint 1 Infra 実装)
+- `oidc_sub` 列で Keycloak の `sub` クレームと突合
+- テナント所属とロールは別テーブル `user_tenants` で管理
+- プロフィール(full_name 等)は users を参照・更新。退会・解約時は論理削除 + 個人情報匿名化(ADR-0006 §3.4)
 
 | カラム名 | 型 | NULL | 説明 |
 |---|---|---|---|
 | id | BIGINT AUTO_INCREMENT | NO | 主キー(変更不可) |
-| oidc_sub | VARCHAR(255) | NO | KeycloakのSubject(UNIQUE、変更不可) |
-| email | VARCHAR(255) | NO | メールアドレス(変更不可) |
-| full_name | VARCHAR(255) | NO | 氏名(変更不可) |
-| full_name_kana | VARCHAR(255) | NO | 氏名カナ(変更不可) |
-| department_name | VARCHAR(255) | YES | 部署名(変更不可) |
+| oidc_sub | VARCHAR(255) | NO | Keycloak の Subject(UNIQUE)。匿名化時は `__deleted__{id}` に置換 |
+| email | VARCHAR(255) | NO | メールアドレス。匿名化時は `__deleted__{id}@deleted.invalid` に置換 |
+| full_name | VARCHAR(255) | NO | 氏名。匿名化時は `__deleted__` に置換 |
+| full_name_kana | VARCHAR(255) | NO | 氏名カナ。匿名化時は `__deleted__` に置換 |
+| department_name | VARCHAR(255) | YES | 部署名。匿名化時は NULL に置換 |
+| version | BIGINT | NO DEFAULT 0 | JPA `@Version` 楽観排他用(本システム API と Keycloak Console の 2 経路書き込みに対応) |
+| deleted_at | DATETIME | YES | 論理削除日時。NULL = 有効、NOT NULL = 匿名化済み |
 
 ### 5.4 法的・標準準拠
 
@@ -441,7 +444,7 @@ Version 1.4.4
 - テナント管理コンソール(SaaS運営者用、状態管理・全体監視)
 - ユーザー招待・ロール管理画面(テナント管理者用)
 - Keycloak本体のECS on Fargate上への構築・Realm/Client初期設定(本プロジェクトの実装範囲)
-- 既存usersテーブルとの参照連携(oidc_subによる突合)+ 初回ログイン時の JIT 自動作成
+- users テーブル(本システム内 SoT・ADR-0006)との連携(oidc_sub による突合)+ 初回ログイン時の JIT 自動作成
 - 公開範囲設定(全公開/関係者限定/非公開)
 - 関係者管理(タスク単位の関係者リスト)
 - 当日タスク表示・日付切替・期限切れ常時表示UI

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/adapter/persistence/UserJpaEntity.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/adapter/persistence/UserJpaEntity.java
@@ -6,6 +6,8 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -37,6 +39,14 @@ public class UserJpaEntity {
   @Nullable
   @Column(name = "department_name", length = 255)
   private String departmentName;
+
+  @Version
+  @Column(nullable = false)
+  private Long version;
+
+  @Nullable
+  @Column(name = "deleted_at")
+  private LocalDateTime deletedAt;
 
   public UserJpaEntity(
       String oidcSub,

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/domain/User.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/domain/User.java
@@ -1,0 +1,58 @@
+package xyz.dgz48.tasks.webapi.user.domain;
+
+import java.time.LocalDateTime;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * User ドメインモデル(JPA 非依存 POJO)。 設計規約 §1.1 のクリーンアーキ 4 層に従い domain 層に配置。 Persistence 層では {@code
+ * UserJpaEntity} と相互変換する。
+ */
+@Getter
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+public class User {
+
+  @EqualsAndHashCode.Include private final Long id;
+  private String oidcSub;
+  private String email;
+  private String fullName;
+  private String fullNameKana;
+  @Nullable private String departmentName;
+  private long version;
+  @Nullable private LocalDateTime deletedAt;
+
+  public User(
+      Long id,
+      String oidcSub,
+      String email,
+      String fullName,
+      String fullNameKana,
+      @Nullable String departmentName,
+      long version,
+      @Nullable LocalDateTime deletedAt) {
+    this.id = id;
+    this.oidcSub = oidcSub;
+    this.email = email;
+    this.fullName = fullName;
+    this.fullNameKana = fullNameKana;
+    this.departmentName = departmentName;
+    this.version = version;
+    this.deletedAt = deletedAt;
+  }
+
+  /**
+   * 論理削除 + 個人情報匿名化(ADR-0006 §3.4 ステップ 1〜6)。
+   *
+   * <p>step 7(version の自動 increment)は JPA {@code @Version} により保存時に自動適用される。 step 8(audit_logs への
+   * ANONYMIZE 記録)は {@link UserAnonymizationDomainService} の TODO コメントを参照(#144 依存)。
+   */
+  public void anonymize(LocalDateTime now) {
+    this.deletedAt = now;
+    this.email = "__deleted__" + id + "@deleted.invalid";
+    this.oidcSub = "__deleted__" + id;
+    this.fullName = "__deleted__";
+    this.fullNameKana = "__deleted__";
+    this.departmentName = null;
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/domain/UserAnonymizationDomainService.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/domain/UserAnonymizationDomainService.java
@@ -1,0 +1,30 @@
+package xyz.dgz48.tasks.webapi.user.domain;
+
+import java.time.LocalDateTime;
+
+/**
+ * ユーザー匿名化処理 SSOT — ADR-0006 §3.4 参照。
+ *
+ * <p>Spring 非依存の純粋関数。SPI(Sprint 1 Infra)および本システム API(将来の解約・退会 API)の 両方から {@code new
+ * UserAnonymizationDomainService()} でインスタンス化して呼び出す。
+ *
+ * <p>ADR-0006 §3.4 の 8 ステップ匿名化処理のうち、step 1〜6 は {@link User#anonymize(LocalDateTime)} に委譲する。 step
+ * 7(version の自動 increment)は JPA {@code @Version} により保存時に自動適用される。
+ */
+public class UserAnonymizationDomainService {
+
+  /**
+   * ユーザーを匿名化する(ADR-0006 §3.4 step 1〜7)。
+   *
+   * <p>呼び出し元(UseCase 層)は {@code @Transactional} 境界内でこのメソッドを呼び出し、 完了後に {@code UserJpaEntity} に反映して
+   * repository.save() を実行すること。
+   *
+   * @param user 匿名化対象の User ドメインオブジェクト
+   * @param now 論理削除日時(呼び出し元で {@code LocalDateTime.now(clock)} を渡すこと)
+   */
+  public void anonymize(User user, LocalDateTime now) {
+    user.anonymize(now);
+    // TODO(#144): step 8 — audit_logs に action='ANONYMIZE', entity_type='users',
+    // entity_id=user.getId() を記録する(#144 監査列 Auditing 機構整備と連携後に実装)
+  }
+}

--- a/webapi/src/main/resources/db/migration/V1.0.0_01__create_tables.sql
+++ b/webapi/src/main/resources/db/migration/V1.0.0_01__create_tables.sql
@@ -8,7 +8,8 @@ CREATE TABLE users (
     version         BIGINT       NOT NULL DEFAULT 0 COMMENT 'JPA @Version 楽観排他用(ADR-0006 §3.4)',
     deleted_at      DATETIME     NULL     COMMENT '論理削除日時。NULL=有効、NOT NULL=匿名化済み(ADR-0006 §3.4)',
     PRIMARY KEY (id),
-    UNIQUE KEY uq_users_oidc_sub (oidc_sub)
+    UNIQUE KEY uq_users_oidc_sub (oidc_sub),
+    UNIQUE KEY uq_users_email (email)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE tenants (

--- a/webapi/src/main/resources/db/migration/V1.0.0_01__create_tables.sql
+++ b/webapi/src/main/resources/db/migration/V1.0.0_01__create_tables.sql
@@ -1,10 +1,12 @@
 CREATE TABLE users (
     id              BIGINT       NOT NULL AUTO_INCREMENT COMMENT '変更不可',
-    oidc_sub        VARCHAR(255) NOT NULL COMMENT 'Keycloak Subject',
-    email           VARCHAR(255) NOT NULL COMMENT 'メールアドレス',
-    full_name       VARCHAR(255) NOT NULL COMMENT '氏名',
-    full_name_kana  VARCHAR(255) NOT NULL COMMENT '氏名カナ',
-    department_name VARCHAR(255) NULL     COMMENT '部署名',
+    oidc_sub        VARCHAR(255) NOT NULL COMMENT 'Keycloak Subject。匿名化時は __deleted__{id} に置換',
+    email           VARCHAR(255) NOT NULL COMMENT 'メールアドレス。匿名化時は __deleted__{id}@deleted.invalid に置換',
+    full_name       VARCHAR(255) NOT NULL COMMENT '氏名。匿名化時は __deleted__ に置換',
+    full_name_kana  VARCHAR(255) NOT NULL COMMENT '氏名カナ。匿名化時は __deleted__ に置換',
+    department_name VARCHAR(255) NULL     COMMENT '部署名。匿名化時は NULL に置換',
+    version         BIGINT       NOT NULL DEFAULT 0 COMMENT 'JPA @Version 楽観排他用(ADR-0006 §3.4)',
+    deleted_at      DATETIME     NULL     COMMENT '論理削除日時。NULL=有効、NOT NULL=匿名化済み(ADR-0006 §3.4)',
     PRIMARY KEY (id),
     UNIQUE KEY uq_users_oidc_sub (oidc_sub)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/user/adapter/persistence/UserEntityTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/user/adapter/persistence/UserEntityTest.java
@@ -30,6 +30,8 @@ class UserEntityTest {
     assertThat(user.getFullName()).isEqualTo("山田 太郎");
     assertThat(user.getFullNameKana()).isEqualTo("ヤマダ タロウ");
     assertThat(user.getDepartmentName()).isEqualTo("開発部");
+    assertThat(user.getVersion()).isEqualTo(0L);
+    assertThat(user.getDeletedAt()).isNull();
   }
 
   @Test

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/user/domain/UserAnonymizationDomainServiceTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/user/domain/UserAnonymizationDomainServiceTest.java
@@ -1,0 +1,70 @@
+package xyz.dgz48.tasks.webapi.user.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+
+class UserAnonymizationDomainServiceTest {
+
+  private static final LocalDateTime FIXED_NOW = LocalDateTime.of(2026, 1, 15, 19, 0, 0);
+
+  private final UserAnonymizationDomainService service = new UserAnonymizationDomainService();
+
+  private User buildActiveUser(long id) {
+    return new User(
+        id, "sub-" + id, "user" + id + "@example.com", "山田 太郎", "ヤマダ タロウ", "開発部", 0L, null);
+  }
+
+  @Test
+  void anonymize_setsDeletedAt() {
+    User user = buildActiveUser(1L);
+    service.anonymize(user, FIXED_NOW);
+    assertThat(user.getDeletedAt()).isEqualTo(FIXED_NOW);
+  }
+
+  @Test
+  void anonymize_replacesEmailWithPlaceholder() {
+    User user = buildActiveUser(42L);
+    service.anonymize(user, FIXED_NOW);
+    assertThat(user.getEmail()).isEqualTo("__deleted__42@deleted.invalid");
+  }
+
+  @Test
+  void anonymize_replacesOidcSubWithPlaceholder() {
+    User user = buildActiveUser(42L);
+    service.anonymize(user, FIXED_NOW);
+    assertThat(user.getOidcSub()).isEqualTo("__deleted__42");
+  }
+
+  @Test
+  void anonymize_replacesFullName() {
+    User user = buildActiveUser(1L);
+    service.anonymize(user, FIXED_NOW);
+    assertThat(user.getFullName()).isEqualTo("__deleted__");
+  }
+
+  @Test
+  void anonymize_replacesFullNameKana() {
+    User user = buildActiveUser(1L);
+    service.anonymize(user, FIXED_NOW);
+    assertThat(user.getFullNameKana()).isEqualTo("__deleted__");
+  }
+
+  @Test
+  void anonymize_clearsDepartmentName() {
+    User user = buildActiveUser(1L);
+    service.anonymize(user, FIXED_NOW);
+    assertThat(user.getDepartmentName()).isNull();
+  }
+
+  @Test
+  void anonymize_placeholderIsUniquePerUserId() {
+    User user1 = buildActiveUser(1L);
+    User user2 = buildActiveUser(2L);
+    service.anonymize(user1, FIXED_NOW);
+    service.anonymize(user2, FIXED_NOW);
+    assertThat(user1.getEmail()).isNotEqualTo(user2.getEmail());
+    assertThat(user1.getOidcSub()).isNotEqualTo(user2.getOidcSub());
+  }
+}


### PR DESCRIPTION
## Summary

- **A. docs補正**: 基本設計書・要件定義書・sequence-01-oidc-login.mmd の「既存usersテーブル(参照のみ)」表記を「本システム内 SoT・ADR-0006」に統一。`version`/`deleted_at` 列を各ドキュメントの表に追記。シーケンス図は `LegacyUsers` 参加者を削除し `AppDB` に統合。
- **B. SQL**: `V1.0.0_01__create_tables.sql` の users テーブルに `version BIGINT NOT NULL DEFAULT 0` / `deleted_at DATETIME NULL` を直接追記(設計規約 §3.1 初期版追記ルール準拠・#248)。また `uq_users_email (email)` UNIQUE 制約を追加(基本設計書 §4.2.1 との整合)。
- **C. JPA**: `UserJpaEntity` に `@Version Long version` + `@Nullable LocalDateTime deletedAt` を追加。
- **D. domain service**: `user.domain` に `User` POJO・`UserAnonymizationDomainService`(Spring 非依存)・`UserAnonymizationDomainServiceTest`(7 ケース) を新規作成。step 8 audit_logs 連携は `TODO(#144)` で残留。

## Test plan

- [ ] `./gradlew :webapi:check` green を確認(ローカル実施済み、CI でも確認)
- [ ] `UserAnonymizationDomainServiceTest` 7 ケース(deletedAt 設定・email/oidcSub placeholder・fullName/fullNameKana 匿名化・departmentName null 化・placeholder 一意性) green
- [ ] `UserEntityTest` 既存 4 ケース green(新列追加で既存テストが壊れていないことを確認、`version`/`deletedAt` アサーション追加済み)
- [ ] ADR-0006 §6 実装メモ 順序 2 の全スコープ(docs + schema + JPA + domain service)を網羅していることをレビューで確認

## レビュー対応テーブル

| 指摘 | 内容 | 対応状況 | コミット |
|---|---|---|---|
| [email UNIQUE 制約欠落](https://github.com/win2cot/tasks-webapi/pull/294#pullrequestreview-3003735763) | SQL に uq_users_email が存在しない | closed: 追加済み | 322f7e7 |
| [UserEntityTest version/deletedAt アサーション](https://github.com/win2cot/tasks-webapi/pull/294#pullrequestreview-3003735763) | @Version 動作確認が不明示(任意) | closed: canPersistUser に追加 | 322f7e7 |

## Closes

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)
