### PR TITLE
feat(security+tenant): TenantContext + Hibernate Filter + TenantContextFilter 実装 (#87)

### DIFF
--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/security/adapter/web/SecurityConfig.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/security/adapter/web/SecurityConfig.java
@@ -5,6 +5,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.oauth2.server.resource.web.authentication.BearerTokenAuthenticationFilter;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
@@ -13,7 +14,9 @@ public class SecurityConfig {
 
   @Bean
   public SecurityFilterChain securityFilterChain(
-      HttpSecurity http, TasksJwtAuthenticationConverter jwtAuthenticationConverter)
+      HttpSecurity http,
+      TasksJwtAuthenticationConverter jwtAuthenticationConverter,
+      TenantContextFilter tenantContextFilter)
       throws Exception {
     http.csrf(csrf -> csrf.disable())
         .sessionManagement(
@@ -25,8 +28,8 @@ public class SecurityConfig {
                     .anyRequest()
                     .authenticated())
         .oauth2ResourceServer(
-            oauth2 ->
-                oauth2.jwt(jwt -> jwt.jwtAuthenticationConverter(jwtAuthenticationConverter)));
+            oauth2 -> oauth2.jwt(jwt -> jwt.jwtAuthenticationConverter(jwtAuthenticationConverter)))
+        .addFilterAfter(tenantContextFilter, BearerTokenAuthenticationFilter.class);
     return http.build();
   }
 }

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/security/adapter/web/TenantContextFilter.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/security/adapter/web/TenantContextFilter.java
@@ -1,0 +1,67 @@
+package xyz.dgz48.tasks.webapi.security.adapter.web;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import xyz.dgz48.tasks.webapi.shared.domain.TenantContext;
+import xyz.dgz48.tasks.webapi.tenant.usecase.TenantMembershipPort;
+
+/**
+ * X-Tenant-Id ヘッダを読み取り、user_tenants を検証して TenantContext を設定する。
+ *
+ * <p>ヘッダ未指定の場合は TenantContext を設定せずに通過させる。 認証済みユーザーが指定テナントの ACTIVE メンバーでない場合は 403 を返す。
+ */
+@Component
+@RequiredArgsConstructor
+public class TenantContextFilter extends OncePerRequestFilter {
+
+  static final String HEADER_X_TENANT_ID = "X-Tenant-Id";
+
+  private final TenantMembershipPort tenantMembershipPort;
+
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+      throws ServletException, IOException {
+
+    String tenantIdHeader = request.getHeader(HEADER_X_TENANT_ID);
+    if (tenantIdHeader == null) {
+      filterChain.doFilter(request, response);
+      return;
+    }
+
+    Long tenantId;
+    try {
+      tenantId = Long.parseLong(tenantIdHeader);
+    } catch (NumberFormatException e) {
+      response.sendError(HttpStatus.BAD_REQUEST.value(), "Invalid X-Tenant-Id header");
+      return;
+    }
+
+    Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+    if (!(auth instanceof TasksAuthenticationToken token)) {
+      response.sendError(HttpStatus.UNAUTHORIZED.value(), "Authentication required");
+      return;
+    }
+
+    if (!tenantMembershipPort.isActiveMember(token.getPrincipal().getId(), tenantId)) {
+      response.sendError(HttpStatus.FORBIDDEN.value(), "Not a member of the specified tenant");
+      return;
+    }
+
+    TenantContext.set(tenantId);
+    try {
+      filterChain.doFilter(request, response);
+    } finally {
+      TenantContext.clear();
+    }
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/shared/adapter/package-info.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/shared/adapter/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package xyz.dgz48.tasks.webapi.shared.adapter;
+
+import org.jspecify.annotations.NullMarked;

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/shared/adapter/persistence/TenantFilteredEntity.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/shared/adapter/persistence/TenantFilteredEntity.java
@@ -1,0 +1,17 @@
+package xyz.dgz48.tasks.webapi.shared.adapter.persistence;
+
+import jakarta.persistence.MappedSuperclass;
+import org.hibernate.annotations.Filter;
+import org.hibernate.annotations.FilterDef;
+import org.hibernate.annotations.ParamDef;
+
+/**
+ * tenant_id を持つ全業務エンティティの共通 MappedSuperclass。
+ *
+ * <p>@FilterDef を一箇所に集約し、Hibernate Filter "tenantFilter" を全サブクラスに自動適用する。 UPDATE/DELETE / native
+ * query は {@code @Modifying} を持つメソッドで引き続き明示絞り込みが必要(ADR-0010 §3)。
+ */
+@MappedSuperclass
+@FilterDef(name = "tenantFilter", parameters = @ParamDef(name = "tenantId", type = Long.class))
+@Filter(name = "tenantFilter", condition = "tenant_id = :tenantId")
+public abstract class TenantFilteredEntity {}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/shared/adapter/persistence/package-info.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/shared/adapter/persistence/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package xyz.dgz48.tasks.webapi.shared.adapter.persistence;
+
+import org.jspecify.annotations.NullMarked;

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/shared/domain/TenantContext.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/shared/domain/TenantContext.java
@@ -1,0 +1,23 @@
+package xyz.dgz48.tasks.webapi.shared.domain;
+
+import org.jspecify.annotations.Nullable;
+
+/** リクエストスコープの現在テナント ID を ThreadLocal で保持する。 */
+public final class TenantContext {
+
+  private static final ThreadLocal<@Nullable Long> HOLDER = new ThreadLocal<>();
+
+  private TenantContext() {}
+
+  public static void set(Long tenantId) {
+    HOLDER.set(tenantId);
+  }
+
+  public static @Nullable Long get() {
+    return HOLDER.get();
+  }
+
+  public static void clear() {
+    HOLDER.remove();
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/shared/domain/package-info.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/shared/domain/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package xyz.dgz48.tasks.webapi.shared.domain;
+
+import org.jspecify.annotations.NullMarked;

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/shared/infra/TenantAwareJpaTransactionManager.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/shared/infra/TenantAwareJpaTransactionManager.java
@@ -1,0 +1,40 @@
+package xyz.dgz48.tasks.webapi.shared.infra;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import org.hibernate.Session;
+import org.springframework.orm.jpa.EntityManagerFactoryUtils;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import xyz.dgz48.tasks.webapi.shared.domain.TenantContext;
+
+/**
+ * トランザクション開始時に Hibernate Filter "tenantFilter" を自動有効化する JpaTransactionManager 拡張。
+ *
+ * <p>TenantContext に tenantId が設定されている場合のみフィルタを有効化するため、 TenantContext
+ * が未設定の管理系操作・テスト用トランザクションには影響しない。
+ */
+class TenantAwareJpaTransactionManager extends JpaTransactionManager {
+
+  TenantAwareJpaTransactionManager(EntityManagerFactory emf) {
+    super(emf);
+  }
+
+  @Override
+  protected void doBegin(Object transaction, TransactionDefinition definition) {
+    super.doBegin(transaction, definition);
+    Long tenantId = TenantContext.get();
+    if (tenantId == null) {
+      return;
+    }
+    EntityManagerFactory emf = getEntityManagerFactory();
+    if (emf == null) {
+      return;
+    }
+    EntityManager em = EntityManagerFactoryUtils.getTransactionalEntityManager(emf);
+    if (em == null) {
+      return;
+    }
+    em.unwrap(Session.class).enableFilter("tenantFilter").setParameter("tenantId", tenantId);
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/shared/infra/TenantJpaConfig.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/shared/infra/TenantJpaConfig.java
@@ -1,0 +1,15 @@
+package xyz.dgz48.tasks.webapi.shared.infra;
+
+import jakarta.persistence.EntityManagerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Configuration
+class TenantJpaConfig {
+
+  @Bean
+  PlatformTransactionManager transactionManager(EntityManagerFactory emf) {
+    return new TenantAwareJpaTransactionManager(emf);
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/adapter/persistence/TaskJpaEntity.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/adapter/persistence/TaskJpaEntity.java
@@ -20,6 +20,7 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedBy;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import xyz.dgz48.tasks.webapi.shared.adapter.persistence.TenantFilteredEntity;
 import xyz.dgz48.tasks.webapi.task.domain.Priority;
 import xyz.dgz48.tasks.webapi.task.domain.TaskStatus;
 import xyz.dgz48.tasks.webapi.task.domain.Visibility;
@@ -30,7 +31,7 @@ import xyz.dgz48.tasks.webapi.task.domain.Visibility;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SuppressWarnings("NullAway.Init") // JPA requires no-args constructor; fields initialized via JPA
-public class TaskJpaEntity {
+public class TaskJpaEntity extends TenantFilteredEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/adapter/persistence/TaskJpaRepository.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/adapter/persistence/TaskJpaRepository.java
@@ -2,8 +2,16 @@ package xyz.dgz48.tasks.webapi.task.adapter.persistence;
 
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 interface TaskJpaRepository extends JpaRepository<TaskJpaEntity, Long> {
 
-  Optional<TaskJpaEntity> findByIdAndTenantId(Long id, Long tenantId);
+  /**
+   * JPQL クエリとして実行するため、Hibernate Filter "tenantFilter" が有効な場合は 自動的にテナント絞り込みが適用される(ADR-0010)。 {@code
+   * em.find()} ベースの継承実装はフィルタを適用しないため、本メソッドで上書きする。
+   */
+  @Override
+  @Query("SELECT t FROM TaskJpaEntity t WHERE t.id = :id")
+  Optional<TaskJpaEntity> findById(@Param("id") Long id);
 }

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/adapter/persistence/TaskJpaRepositoryAdapter.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/adapter/persistence/TaskJpaRepositoryAdapter.java
@@ -6,10 +6,6 @@ import org.springframework.stereotype.Component;
 import xyz.dgz48.tasks.webapi.task.domain.Task;
 import xyz.dgz48.tasks.webapi.task.usecase.TaskRepository;
 
-/**
- * {@link TaskRepository} ポートを Spring Data JPA で実装。 {@link TaskJpaEntity} と {@link Task}
- * ドメインモデル間の変換責務を担う。
- */
 @Component
 @RequiredArgsConstructor
 class TaskJpaRepositoryAdapter implements TaskRepository {
@@ -17,8 +13,8 @@ class TaskJpaRepositoryAdapter implements TaskRepository {
   private final TaskJpaRepository jpaRepository;
 
   @Override
-  public Optional<Task> findByIdAndTenantId(Long id, Long tenantId) {
-    return jpaRepository.findByIdAndTenantId(id, tenantId).map(this::toDomain);
+  public Optional<Task> findById(Long id) {
+    return jpaRepository.findById(id).map(this::toDomain);
   }
 
   private Task toDomain(TaskJpaEntity entity) {

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/usecase/TaskRepository.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/usecase/TaskRepository.java
@@ -6,5 +6,6 @@ import xyz.dgz48.tasks.webapi.task.domain.Task;
 /** Task の永続化ポート。adapter.persistence の {@code TaskJpaRepositoryAdapter} で実装される。 */
 public interface TaskRepository {
 
-  Optional<Task> findByIdAndTenantId(Long id, Long tenantId);
+  /** Hibernate Filter が有効な場合、現在テナントに属さないタスクは自動的に空を返す。 */
+  Optional<Task> findById(Long id);
 }

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/adapter/persistence/UserTenantId.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/adapter/persistence/UserTenantId.java
@@ -1,0 +1,24 @@
+package xyz.dgz48.tasks.webapi.tenant.adapter.persistence;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.io.Serializable;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor
+@AllArgsConstructor
+@SuppressWarnings("NullAway.Init") // JPA requires no-args constructor; fields initialized via JPA
+class UserTenantId implements Serializable {
+
+  @Column(name = "user_id", nullable = false)
+  private Long userId;
+
+  @Column(name = "tenant_id", nullable = false)
+  private Long tenantId;
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/adapter/persistence/UserTenantJpaEntity.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/adapter/persistence/UserTenantJpaEntity.java
@@ -1,0 +1,35 @@
+package xyz.dgz48.tasks.webapi.tenant.adapter.persistence;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import xyz.dgz48.tasks.webapi.tenant.domain.TenantRole;
+import xyz.dgz48.tasks.webapi.tenant.domain.UserTenantStatus;
+
+@Entity
+@Table(name = "user_tenants")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SuppressWarnings("NullAway.Init") // JPA requires no-args constructor; fields initialized via JPA
+class UserTenantJpaEntity {
+
+  @EmbeddedId private UserTenantId id;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false, columnDefinition = "ENUM('TENANT_ADMIN','MEMBER')")
+  private TenantRole role;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false, columnDefinition = "ENUM('ACTIVE','INVITED','DISABLED')")
+  private UserTenantStatus status;
+
+  @Column(name = "joined_at", nullable = false)
+  private LocalDateTime joinedAt;
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/adapter/persistence/UserTenantJpaRepository.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/adapter/persistence/UserTenantJpaRepository.java
@@ -1,0 +1,10 @@
+package xyz.dgz48.tasks.webapi.tenant.adapter.persistence;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import xyz.dgz48.tasks.webapi.tenant.domain.UserTenantStatus;
+
+interface UserTenantJpaRepository extends JpaRepository<UserTenantJpaEntity, UserTenantId> {
+
+  boolean existsByIdUserIdAndIdTenantIdAndStatus(
+      Long userId, Long tenantId, UserTenantStatus status);
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/adapter/persistence/UserTenantMembershipAdapter.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/adapter/persistence/UserTenantMembershipAdapter.java
@@ -1,0 +1,21 @@
+package xyz.dgz48.tasks.webapi.tenant.adapter.persistence;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import xyz.dgz48.tasks.webapi.tenant.domain.UserTenantStatus;
+import xyz.dgz48.tasks.webapi.tenant.usecase.TenantMembershipPort;
+
+@Component
+@RequiredArgsConstructor
+class UserTenantMembershipAdapter implements TenantMembershipPort {
+
+  private final UserTenantJpaRepository repository;
+
+  @Override
+  @Transactional(readOnly = true)
+  public boolean isActiveMember(Long userId, Long tenantId) {
+    return repository.existsByIdUserIdAndIdTenantIdAndStatus(
+        userId, tenantId, UserTenantStatus.ACTIVE);
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/domain/UserTenantStatus.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/domain/UserTenantStatus.java
@@ -1,0 +1,8 @@
+package xyz.dgz48.tasks.webapi.tenant.domain;
+
+/** user_tenants.status の値。 */
+public enum UserTenantStatus {
+  ACTIVE,
+  INVITED,
+  DISABLED;
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/usecase/TenantMembershipPort.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/usecase/TenantMembershipPort.java
@@ -1,0 +1,8 @@
+package xyz.dgz48.tasks.webapi.tenant.usecase;
+
+/** テナントメンバーシップ検証ポート。 */
+public interface TenantMembershipPort {
+
+  /** 指定ユーザーが指定テナントの ACTIVE メンバーかを返す。 */
+  boolean isActiveMember(Long userId, Long tenantId);
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/usecase/package-info.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/usecase/package-info.java
@@ -1,4 +1,6 @@
 @NullMarked
+@NamedInterface
 package xyz.dgz48.tasks.webapi.tenant.usecase;
 
 import org.jspecify.annotations.NullMarked;
+import org.springframework.modulith.NamedInterface;

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/SecurityConfigTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/SecurityConfigTest.java
@@ -10,6 +10,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import xyz.dgz48.tasks.webapi.tenant.usecase.TenantMembershipPort;
 import xyz.dgz48.tasks.webapi.user.adapter.persistence.UserRepository;
 
 @WebMvcTest
@@ -18,6 +19,7 @@ class SecurityConfigTest {
 
   @MockitoBean JwtDecoder jwtDecoder;
   @MockitoBean UserRepository userRepository;
+  @MockitoBean TenantMembershipPort tenantMembershipPort;
 
   @Autowired MockMvc mockMvc;
 

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/TenantContextFilterTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/TenantContextFilterTest.java
@@ -1,0 +1,86 @@
+package xyz.dgz48.tasks.webapi.security.adapter.web;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import xyz.dgz48.tasks.webapi.shared.domain.TenantContext;
+import xyz.dgz48.tasks.webapi.tenant.usecase.TenantMembershipPort;
+import xyz.dgz48.tasks.webapi.user.adapter.persistence.UserRepository;
+
+@WebMvcTest(TenantContextFilterTest.ProbeController.class)
+@Import({SecurityConfig.class, TenantContextFilter.class, TasksJwtAuthenticationConverter.class})
+class TenantContextFilterTest {
+
+  @RestController
+  static class ProbeController {
+
+    @GetMapping("/probe")
+    ResponseEntity<Long> probe() {
+      Long tenantId = TenantContext.get();
+      if (tenantId == null) {
+        return ResponseEntity.noContent().build();
+      }
+      return ResponseEntity.ok(tenantId);
+    }
+  }
+
+  @MockitoBean JwtDecoder jwtDecoder;
+  @MockitoBean UserRepository userRepository;
+  @MockitoBean TenantMembershipPort tenantMembershipPort;
+
+  @Autowired MockMvc mockMvc;
+
+  @Test
+  @WithMockMember
+  void noTenantIdHeader_passesThrough_contextNotSet() throws Exception {
+    mockMvc.perform(get("/probe")).andExpect(status().isNoContent());
+  }
+
+  @Test
+  @WithMockMember
+  void invalidTenantIdHeader_returnsBadRequest() throws Exception {
+    mockMvc
+        .perform(get("/probe").header(TenantContextFilter.HEADER_X_TENANT_ID, "not-a-number"))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @WithMockUser
+  void nonTasksAuthentication_returnsUnauthorized() throws Exception {
+    mockMvc
+        .perform(get("/probe").header(TenantContextFilter.HEADER_X_TENANT_ID, "1"))
+        .andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  @WithMockMember
+  void inactiveMember_returnsForbidden() throws Exception {
+    given(tenantMembershipPort.isActiveMember(1L, 1L)).willReturn(false);
+    mockMvc
+        .perform(get("/probe").header(TenantContextFilter.HEADER_X_TENANT_ID, "1"))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  @WithMockMember
+  void activeMember_setsTenantContextAndPassesThrough() throws Exception {
+    given(tenantMembershipPort.isActiveMember(1L, 1L)).willReturn(true);
+    mockMvc
+        .perform(get("/probe").header(TenantContextFilter.HEADER_X_TENANT_ID, "1"))
+        .andExpect(status().isOk())
+        .andExpect(content().string("1"));
+  }
+}

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/TenantContextFilterTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/TenantContextFilterTest.java
@@ -20,8 +20,13 @@ import xyz.dgz48.tasks.webapi.shared.domain.TenantContext;
 import xyz.dgz48.tasks.webapi.tenant.usecase.TenantMembershipPort;
 import xyz.dgz48.tasks.webapi.user.adapter.persistence.UserRepository;
 
-@WebMvcTest(TenantContextFilterTest.ProbeController.class)
-@Import({SecurityConfig.class, TenantContextFilter.class, TasksJwtAuthenticationConverter.class})
+@WebMvcTest
+@Import({
+  SecurityConfig.class,
+  TenantContextFilter.class,
+  TasksJwtAuthenticationConverter.class,
+  TenantContextFilterTest.ProbeController.class
+})
 class TenantContextFilterTest {
 
   @RestController

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/shared/domain/TenantContextTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/shared/domain/TenantContextTest.java
@@ -1,0 +1,32 @@
+package xyz.dgz48.tasks.webapi.shared.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class TenantContextTest {
+
+  @AfterEach
+  void cleanup() {
+    TenantContext.clear();
+  }
+
+  @Test
+  void getReturnsNullWhenNotSet() {
+    assertThat(TenantContext.get()).isNull();
+  }
+
+  @Test
+  void setAndGet() {
+    TenantContext.set(42L);
+    assertThat(TenantContext.get()).isEqualTo(42L);
+  }
+
+  @Test
+  void clearRemovesValue() {
+    TenantContext.set(1L);
+    TenantContext.clear();
+    assertThat(TenantContext.get()).isNull();
+  }
+}

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/adapter/persistence/TaskJpaRepositoryAdapterTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/adapter/persistence/TaskJpaRepositoryAdapterTest.java
@@ -51,7 +51,7 @@ class TaskJpaRepositoryAdapterTest {
   }
 
   @Test
-  void findByIdAndTenantIdReturnsDomainTaskWhenFound() {
+  void findByIdReturnsDomainTaskWhenFound() {
     var tenant = new TenantJpaEntity("TENANT-ADP-1", "テナント A");
     entityManager.persist(tenant);
     var user = new UserJpaEntity("sub-adp-1", "adp1@example.com", "山田 太郎", "ヤマダ タロウ", null);
@@ -71,7 +71,7 @@ class TaskJpaRepositoryAdapterTest {
     entityManager.flush();
     entityManager.clear();
 
-    var found = taskRepository.findByIdAndTenantId(jpa.getId(), tenant.getId());
+    var found = taskRepository.findById(jpa.getId());
 
     assertThat(found).isPresent();
     Task task = found.get();
@@ -85,33 +85,8 @@ class TaskJpaRepositoryAdapterTest {
   }
 
   @Test
-  void findByIdAndTenantIdReturnsEmptyWhenNotFound() {
-    var found = taskRepository.findByIdAndTenantId(999_999L, 999_999L);
-    assertThat(found).isEmpty();
-  }
-
-  @Test
-  void findByIdAndTenantIdReturnsEmptyWhenTenantMismatch() {
-    var tenant = new TenantJpaEntity("TENANT-ADP-2", "テナント B");
-    entityManager.persist(tenant);
-    var user = new UserJpaEntity("sub-adp-2", "adp2@example.com", "鈴木 花子", "スズキ ハナコ", null);
-    entityManager.persist(user);
-    entityManager.flush();
-
-    var jpa =
-        new TaskJpaEntity(
-            tenant.getId(),
-            user.getId(),
-            "別テナント",
-            null,
-            TaskStatus.NOT_STARTED,
-            Priority.LOW,
-            LocalDate.of(2026, 12, 31));
-    entityManager.persist(jpa);
-    entityManager.flush();
-
-    // 別 tenant id で探すと空
-    var found = taskRepository.findByIdAndTenantId(jpa.getId(), tenant.getId() + 99_999L);
+  void findByIdReturnsEmptyWhenNotFound() {
+    var found = taskRepository.findById(999_999L);
     assertThat(found).isEmpty();
   }
 }

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/adapter/persistence/TenantFilterIsolationTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/adapter/persistence/TenantFilterIsolationTest.java
@@ -1,0 +1,142 @@
+package xyz.dgz48.tasks.webapi.task.adapter.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.persistence.EntityManager;
+import java.time.LocalDate;
+import java.util.List;
+import org.hibernate.Session;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.transaction.annotation.Transactional;
+import xyz.dgz48.tasks.webapi.MockJwtDecoderConfiguration;
+import xyz.dgz48.tasks.webapi.TestcontainersConfiguration;
+import xyz.dgz48.tasks.webapi.security.adapter.web.TasksAuthenticationToken;
+import xyz.dgz48.tasks.webapi.security.domain.TasksPrincipal;
+import xyz.dgz48.tasks.webapi.task.domain.Priority;
+import xyz.dgz48.tasks.webapi.task.domain.TaskStatus;
+import xyz.dgz48.tasks.webapi.task.usecase.TaskRepository;
+import xyz.dgz48.tasks.webapi.tenant.adapter.persistence.TenantJpaEntity;
+import xyz.dgz48.tasks.webapi.user.adapter.persistence.UserJpaEntity;
+
+/**
+ * Hibernate Filter "tenantFilter" のクロステナント漏洩防止を検証する IT。
+ *
+ * <p>設計規約 §9.4 の受け入れ条件: 参照系でフィルタ有効時に別テナントのタスクが見えないこと。
+ */
+@SpringBootTest
+@Import({TestcontainersConfiguration.class, MockJwtDecoderConfiguration.class})
+@Transactional
+class TenantFilterIsolationTest {
+
+  @Autowired EntityManager entityManager;
+  @Autowired TaskRepository taskRepository;
+
+  @BeforeEach
+  void setUpAuditor() {
+    var auditor =
+        new UserJpaEntity(
+            "sub-iso-auditor", "iso-auditor@example.com", "分離テスト監査", "ブンリテストカンサ", null);
+    entityManager.persist(auditor);
+    entityManager.flush();
+
+    var principal =
+        new TasksPrincipal(
+            auditor.getId(),
+            "sub-iso-auditor",
+            "iso-auditor@example.com",
+            "分離テスト監査",
+            "ブンリテストカンサ",
+            null);
+    SecurityContextHolder.getContext()
+        .setAuthentication(new TasksAuthenticationToken(principal, List.of()));
+  }
+
+  @AfterEach
+  void clearContexts() {
+    SecurityContextHolder.clearContext();
+    entityManager.unwrap(Session.class).disableFilter("tenantFilter");
+  }
+
+  @Test
+  void filterBlocksCrossTenantTaskAccess() {
+    var tenantA = new TenantJpaEntity("ISO-TF-A", "テナントA");
+    var tenantB = new TenantJpaEntity("ISO-TF-B", "テナントB");
+    entityManager.persist(tenantA);
+    entityManager.persist(tenantB);
+
+    var user = new UserJpaEntity("sub-iso-1", "iso1@example.com", "田中 太郎", "タナカ タロウ", null);
+    entityManager.persist(user);
+    entityManager.flush();
+
+    var taskA =
+        new TaskJpaEntity(
+            tenantA.getId(),
+            user.getId(),
+            "テナントAのタスク",
+            null,
+            TaskStatus.NOT_STARTED,
+            Priority.MEDIUM,
+            LocalDate.of(2026, 12, 31));
+    var taskB =
+        new TaskJpaEntity(
+            tenantB.getId(),
+            user.getId(),
+            "テナントBのタスク",
+            null,
+            TaskStatus.NOT_STARTED,
+            Priority.MEDIUM,
+            LocalDate.of(2026, 12, 31));
+    entityManager.persist(taskA);
+    entityManager.persist(taskB);
+    entityManager.flush();
+    entityManager.clear();
+
+    // Enable filter for tenantA
+    entityManager
+        .unwrap(Session.class)
+        .enableFilter("tenantFilter")
+        .setParameter("tenantId", tenantA.getId());
+
+    // tenantB's task must be blocked (参照系 404 相当: empty result)
+    assertThat(taskRepository.findById(taskB.getId())).isEmpty();
+
+    // tenantA's task must be visible
+    assertThat(taskRepository.findById(taskA.getId())).isPresent();
+  }
+
+  @Test
+  void filterAllowsAccessWithinSameTenant() {
+    var tenant = new TenantJpaEntity("ISO-TF-C", "テナントC");
+    entityManager.persist(tenant);
+
+    var user = new UserJpaEntity("sub-iso-2", "iso2@example.com", "鈴木 花子", "スズキ ハナコ", null);
+    entityManager.persist(user);
+    entityManager.flush();
+
+    var task =
+        new TaskJpaEntity(
+            tenant.getId(),
+            user.getId(),
+            "テナントCのタスク",
+            null,
+            TaskStatus.NOT_STARTED,
+            Priority.LOW,
+            LocalDate.of(2026, 12, 31));
+    entityManager.persist(task);
+    entityManager.flush();
+    entityManager.clear();
+
+    entityManager
+        .unwrap(Session.class)
+        .enableFilter("tenantFilter")
+        .setParameter("tenantId", tenant.getId());
+
+    assertThat(taskRepository.findById(task.getId())).isPresent();
+  }
+}


### PR DESCRIPTION
## Summary

- **TenantContext** (`shared.domain`): ThreadLocal で現在テナント ID を保持・クリア
- **TenantFilteredEntity** (`shared.adapter.persistence`): `@MappedSuperclass` に `@FilterDef`/`@Filter` を集約 → `TaskJpaEntity extends TenantFilteredEntity`
- **TenantAwareJpaTransactionManager** (`shared.infra`): `doBegin()` でトランザクション開始時に `tenantFilter` を自動有効化
- **TaskRepository/TaskJpaRepository**: `findByIdAndTenantId` → `findById` に改名（§8.1 v1.4 SELECT 単純命名緩和）; `findById` は JPQL で上書き（Hibernate 7 では `em.find()` が `@Filter` を適用しないため）
- **tenant 層**: `UserTenantStatus` / `UserTenantId` / `UserTenantJpaEntity` / `UserTenantJpaRepository` / `TenantMembershipPort`(@NamedInterface) / `UserTenantMembershipAdapter` を追加
- **TenantContextFilter** (`security.adapter.web`): `X-Tenant-Id` ヘッダ → `user_tenants` 検証 → `TenantContext` 設定。`BearerTokenAuthenticationFilter` の直後に挿入
- **テスト**: `TenantContextTest`(単体) + `TenantFilterIsolationTest`(クロステナント漏洩 IT) + `TenantContextFilterTest`(@WebMvcTest 5 経路)

## ADR-0010 §6 選定根拠（PR description に記載義務）

### `@FilterDef` 配置: `@MappedSuperclass` 案 ✅ vs `package-info.java` 案

`@MappedSuperclass`（`TenantFilteredEntity`）を採用。
- `package-info.java` 案は Hibernate のエンティティスキャン対象パッケージにのみ有効で、`shared.adapter.persistence` のような JPA エンティティを含まない新規パッケージでは確実性が低い
- `@MappedSuperclass` は明示的な Java クラスとして IDE ナビゲーション・GraalVM AOT 処理が自然に機能し、Spring Boot 4 / Hibernate 7 環境で最も確実

### `TenantContext` 注入経路: `TenantAwareJpaTransactionManager.doBegin()` ✅ vs Hibernate `SessionEventListener`

`JpaTransactionManager.doBegin()` 拡張を採用。
- `SessionEventListener` はコールバックにセッション参照を渡さないため、コールバック内から `session.enableFilter()` を呼ぶ経路が存在しない
- `doBegin()` 拡張は `super.doBegin()` 後に `EntityManagerFactoryUtils.getTransactionalEntityManager(emf)` でスレッドバインド済み EM を取得でき、`open-in-view` 不要・AOP フリーで実現できる
- `OncePerRequestFilter` 案は `@Transactional` スコープ外（フィルタ層）で EM を取得できないため不採用

### 実装上の追加知見

- Hibernate 7 は `em.find()` に `@Filter` を適用しないため、`TaskJpaRepository.findById` を JPQL クエリ（`@Query`）で上書きして確実にフィルタが効くようにした
- `TenantContextFilter` を `security.adapter.web` に配置したのは `security ↔ tenant` の循環依存（Modulith cycle violation）を避けるため。`tenant.usecase` には `@NamedInterface` を付与して `security` モジュールから参照可能にした

## Test plan

- [x] `./gradlew :webapi:check` 全テストグリーン確認済み
- [x] `TenantFilterIsolationTest.filterBlocksCrossTenantTaskAccess`: 別テナントのタスクが空を返す
- [x] `TenantFilterIsolationTest.filterAllowsAccessWithinSameTenant`: 同テナントのタスクが取得できる
- [x] `TenantContextTest`: ThreadLocal の set/get/clear が正しく動作
- [x] `ModularityTests.verifyModularity`: Modulith 循環依存なしで通過
- [x] `TenantContextFilterTest`: X-Tenant-Id ヘッダなし/不正値/非TasksAuth/非アクティブメンバー/アクティブメンバーの 5 経路を HTTP レベルで検証

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)
