### PR TITLE
feat(security): JwtConverter ロール抽出 + @EnableMethodSecurity 追加 (#88)

### DIFF
--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/security/adapter/web/SecurityConfig.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/security/adapter/web/SecurityConfig.java
@@ -2,6 +2,7 @@ package xyz.dgz48.tasks.webapi.security.adapter.web;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -10,6 +11,7 @@ import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity
 public class SecurityConfig {
 
   @Bean

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/security/adapter/web/TasksJwtAuthenticationConverter.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/security/adapter/web/TasksJwtAuthenticationConverter.java
@@ -1,8 +1,12 @@
 package xyz.dgz48.tasks.webapi.security.adapter.web;
 
 import java.util.List;
+import java.util.Map;
+import org.jspecify.annotations.Nullable;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.server.resource.InvalidBearerTokenException;
 import org.springframework.stereotype.Component;
@@ -39,6 +43,18 @@ public class TasksJwtAuthenticationConverter
             user.getFullName(),
             user.getFullNameKana(),
             user.getDepartmentName());
-    return new TasksAuthenticationToken(principal, List.of());
+    return new TasksAuthenticationToken(principal, realmAuthorities(jwt));
+  }
+
+  private static List<GrantedAuthority> realmAuthorities(Jwt jwt) {
+    @Nullable Map<String, Object> realmAccess = jwt.getClaim("realm_access");
+    if (realmAccess == null) {
+      return List.of();
+    }
+    Object rolesObj = realmAccess.get("roles");
+    if (!(rolesObj instanceof List<?> roles) || !roles.contains("APP_ADMIN")) {
+      return List.of();
+    }
+    return List.of(new SimpleGrantedAuthority("ROLE_APP_ADMIN"));
   }
 }

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/security/adapter/web/TenantContextFilter.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/security/adapter/web/TenantContextFilter.java
@@ -5,19 +5,26 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 import xyz.dgz48.tasks.webapi.shared.domain.TenantContext;
+import xyz.dgz48.tasks.webapi.tenant.domain.TenantRole;
 import xyz.dgz48.tasks.webapi.tenant.usecase.TenantMembershipPort;
 
 /**
  * X-Tenant-Id ヘッダを読み取り、user_tenants を検証して TenantContext を設定する。
  *
- * <p>ヘッダ未指定の場合は TenantContext を設定せずに通過させる。 認証済みユーザーが指定テナントの ACTIVE メンバーでない場合は 403 を返す。
+ * <p>ヘッダ未指定の場合は TenantContext を設定せずに通過させる。認証済みユーザーが指定テナントの ACTIVE メンバーでない場合は 403 を返す。メンバーの場合は
+ * ROLE_TENANT_ADMIN または ROLE_MEMBER を SecurityContext に付与する。
  */
 @Component
 @RequiredArgsConstructor
@@ -52,16 +59,26 @@ public class TenantContextFilter extends OncePerRequestFilter {
       return;
     }
 
-    if (!tenantMembershipPort.isActiveMember(token.getPrincipal().getId(), tenantId)) {
+    Optional<TenantRole> roleOpt =
+        tenantMembershipPort.findActiveRole(token.getPrincipal().getId(), tenantId);
+    if (roleOpt.isEmpty()) {
       response.sendError(HttpStatus.FORBIDDEN.value(), "Not a member of the specified tenant");
       return;
     }
 
+    SecurityContextHolder.getContext().setAuthentication(withTenantRole(token, roleOpt.get()));
     TenantContext.set(tenantId);
     try {
       filterChain.doFilter(request, response);
     } finally {
       TenantContext.clear();
     }
+  }
+
+  private static TasksAuthenticationToken withTenantRole(
+      TasksAuthenticationToken existing, TenantRole role) {
+    List<GrantedAuthority> authorities = new ArrayList<>(existing.getAuthorities());
+    authorities.add(new SimpleGrantedAuthority("ROLE_" + role.name()));
+    return new TasksAuthenticationToken(existing.getPrincipal(), authorities);
   }
 }

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/security/adapter/web/TenantContextFilter.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/security/adapter/web/TenantContextFilter.java
@@ -77,6 +77,10 @@ public class TenantContextFilter extends OncePerRequestFilter {
 
   private static TasksAuthenticationToken withTenantRole(
       TasksAuthenticationToken existing, TenantRole role) {
+    if (role == TenantRole.SAAS_ADMIN) {
+      // SaaS Admin は Keycloak が管理し user_tenants には存在しない(設計規約 §5.2)
+      throw new IllegalArgumentException("SAAS_ADMIN は user_tenants から返却されない");
+    }
     List<GrantedAuthority> authorities = new ArrayList<>(existing.getAuthorities());
     authorities.add(new SimpleGrantedAuthority("ROLE_" + role.name()));
     return new TasksAuthenticationToken(existing.getPrincipal(), authorities);

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/adapter/persistence/UserTenantJpaRepository.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/adapter/persistence/UserTenantJpaRepository.java
@@ -1,10 +1,11 @@
 package xyz.dgz48.tasks.webapi.tenant.adapter.persistence;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import xyz.dgz48.tasks.webapi.tenant.domain.UserTenantStatus;
 
 interface UserTenantJpaRepository extends JpaRepository<UserTenantJpaEntity, UserTenantId> {
 
-  boolean existsByIdUserIdAndIdTenantIdAndStatus(
+  Optional<UserTenantJpaEntity> findByIdUserIdAndIdTenantIdAndStatus(
       Long userId, Long tenantId, UserTenantStatus status);
 }

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/adapter/persistence/UserTenantMembershipAdapter.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/adapter/persistence/UserTenantMembershipAdapter.java
@@ -1,8 +1,10 @@
 package xyz.dgz48.tasks.webapi.tenant.adapter.persistence;
 
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import xyz.dgz48.tasks.webapi.tenant.domain.TenantRole;
 import xyz.dgz48.tasks.webapi.tenant.domain.UserTenantStatus;
 import xyz.dgz48.tasks.webapi.tenant.usecase.TenantMembershipPort;
 
@@ -14,8 +16,9 @@ class UserTenantMembershipAdapter implements TenantMembershipPort {
 
   @Override
   @Transactional(readOnly = true)
-  public boolean isActiveMember(Long userId, Long tenantId) {
-    return repository.existsByIdUserIdAndIdTenantIdAndStatus(
-        userId, tenantId, UserTenantStatus.ACTIVE);
+  public Optional<TenantRole> findActiveRole(Long userId, Long tenantId) {
+    return repository
+        .findByIdUserIdAndIdTenantIdAndStatus(userId, tenantId, UserTenantStatus.ACTIVE)
+        .map(UserTenantJpaEntity::getRole);
   }
 }

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/usecase/TenantMembershipPort.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/usecase/TenantMembershipPort.java
@@ -1,8 +1,11 @@
 package xyz.dgz48.tasks.webapi.tenant.usecase;
 
+import java.util.Optional;
+import xyz.dgz48.tasks.webapi.tenant.domain.TenantRole;
+
 /** テナントメンバーシップ検証ポート。 */
 public interface TenantMembershipPort {
 
-  /** 指定ユーザーが指定テナントの ACTIVE メンバーかを返す。 */
-  boolean isActiveMember(Long userId, Long tenantId);
+  /** 指定ユーザーが指定テナントの ACTIVE メンバーである場合そのロールを返す。非メンバーは空。 */
+  Optional<TenantRole> findActiveRole(Long userId, Long tenantId);
 }

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/TasksJwtAuthenticationConverterTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/TasksJwtAuthenticationConverterTest.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -26,8 +28,7 @@ class TasksJwtAuthenticationConverterTest {
 
   @InjectMocks TasksJwtAuthenticationConverter converter;
 
-  @Test
-  void convertsJwtToAuthenticationToken() {
+  private void stubValidUser() {
     when(jwt.getSubject()).thenReturn("sub123");
     when(userRepository.findByOidcSub("sub123")).thenReturn(Optional.of(user));
     when(user.getId()).thenReturn(1L);
@@ -36,6 +37,11 @@ class TasksJwtAuthenticationConverterTest {
     when(user.getFullName()).thenReturn("山田太郎");
     when(user.getFullNameKana()).thenReturn("ヤマダタロウ");
     when(user.getDepartmentName()).thenReturn("開発部");
+  }
+
+  @Test
+  void convertsJwtToAuthenticationToken() {
+    stubValidUser();
 
     AbstractAuthenticationToken token = converter.convert(jwt);
 
@@ -47,6 +53,37 @@ class TasksJwtAuthenticationConverterTest {
     assertThat(principal.getEmail()).isEqualTo("user@example.com");
     assertThat(principal.getFullName()).isEqualTo("山田太郎");
     assertThat(principal.getDepartmentName()).isEqualTo("開発部");
+    assertThat(token.getAuthorities()).isEmpty();
+  }
+
+  @Test
+  void grantsAppAdminWhenRealmRolePresent() {
+    stubValidUser();
+    when(jwt.getClaim("realm_access"))
+        .thenReturn(Map.of("roles", List.of("APP_ADMIN", "default-roles-realm")));
+
+    AbstractAuthenticationToken token = converter.convert(jwt);
+
+    assertThat(token.getAuthorities()).extracting("authority").containsExactly("ROLE_APP_ADMIN");
+  }
+
+  @Test
+  void noAuthoritiesWhenAppAdminNotInRealmRoles() {
+    stubValidUser();
+    when(jwt.getClaim("realm_access")).thenReturn(Map.of("roles", List.of("default-roles-realm")));
+
+    AbstractAuthenticationToken token = converter.convert(jwt);
+
+    assertThat(token.getAuthorities()).isEmpty();
+  }
+
+  @Test
+  void noAuthoritiesWhenRealmAccessClaimMissing() {
+    stubValidUser();
+
+    AbstractAuthenticationToken token = converter.convert(jwt);
+
+    assertThat(token.getAuthorities()).isEmpty();
   }
 
   @Test

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/TenantContextFilterTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/TenantContextFilterTest.java
@@ -133,6 +133,6 @@ class TenantContextFilterTest {
     assertThatThrownBy(
             () ->
                 mockMvc.perform(get("/probe").header(TenantContextFilter.HEADER_X_TENANT_ID, "1")))
-        .hasRootCauseInstanceOf(IllegalArgumentException.class);
+        .isInstanceOf(IllegalArgumentException.class);
   }
 }

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/TenantContextFilterTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/TenantContextFilterTest.java
@@ -5,11 +5,13 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -17,6 +19,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 import xyz.dgz48.tasks.webapi.shared.domain.TenantContext;
+import xyz.dgz48.tasks.webapi.tenant.domain.TenantRole;
 import xyz.dgz48.tasks.webapi.tenant.usecase.TenantMembershipPort;
 import xyz.dgz48.tasks.webapi.user.adapter.persistence.UserRepository;
 
@@ -39,6 +42,18 @@ class TenantContextFilterTest {
         return ResponseEntity.noContent().build();
       }
       return ResponseEntity.ok(tenantId);
+    }
+
+    @PreAuthorize("hasRole('TENANT_ADMIN')")
+    @GetMapping("/probe/tenant-admin-only")
+    ResponseEntity<Void> tenantAdminOnly() {
+      return ResponseEntity.ok().build();
+    }
+
+    @PreAuthorize("hasRole('MEMBER')")
+    @GetMapping("/probe/member-only")
+    ResponseEntity<Void> memberOnly() {
+      return ResponseEntity.ok().build();
     }
   }
 
@@ -72,8 +87,8 @@ class TenantContextFilterTest {
 
   @Test
   @WithMockMember
-  void inactiveMember_returnsForbidden() throws Exception {
-    given(tenantMembershipPort.isActiveMember(1L, 1L)).willReturn(false);
+  void nonMember_returnsForbidden() throws Exception {
+    given(tenantMembershipPort.findActiveRole(1L, 1L)).willReturn(Optional.empty());
     mockMvc
         .perform(get("/probe").header(TenantContextFilter.HEADER_X_TENANT_ID, "1"))
         .andExpect(status().isForbidden());
@@ -82,10 +97,30 @@ class TenantContextFilterTest {
   @Test
   @WithMockMember
   void activeMember_setsTenantContextAndPassesThrough() throws Exception {
-    given(tenantMembershipPort.isActiveMember(1L, 1L)).willReturn(true);
+    given(tenantMembershipPort.findActiveRole(1L, 1L)).willReturn(Optional.of(TenantRole.MEMBER));
     mockMvc
         .perform(get("/probe").header(TenantContextFilter.HEADER_X_TENANT_ID, "1"))
         .andExpect(status().isOk())
         .andExpect(content().string("1"));
+  }
+
+  @Test
+  @WithMockJwt(roles = {})
+  void memberRole_grantsMemberAuthority() throws Exception {
+    given(tenantMembershipPort.findActiveRole(1L, 1L)).willReturn(Optional.of(TenantRole.MEMBER));
+    mockMvc
+        .perform(get("/probe/member-only").header(TenantContextFilter.HEADER_X_TENANT_ID, "1"))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  @WithMockJwt(roles = {})
+  void tenantAdminRole_grantsTenantAdminAuthority() throws Exception {
+    given(tenantMembershipPort.findActiveRole(1L, 1L))
+        .willReturn(Optional.of(TenantRole.TENANT_ADMIN));
+    mockMvc
+        .perform(
+            get("/probe/tenant-admin-only").header(TenantContextFilter.HEADER_X_TENANT_ID, "1"))
+        .andExpect(status().isOk());
   }
 }

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/TenantContextFilterTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/TenantContextFilterTest.java
@@ -1,5 +1,6 @@
 package xyz.dgz48.tasks.webapi.security.adapter.web;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -122,5 +123,17 @@ class TenantContextFilterTest {
         .perform(
             get("/probe/tenant-admin-only").header(TenantContextFilter.HEADER_X_TENANT_ID, "1"))
         .andExpect(status().isOk());
+  }
+
+  @Test
+  @WithMockJwt(roles = {})
+  void saasAdminRole_throwsIllegalArgumentException() {
+    given(tenantMembershipPort.findActiveRole(1L, 1L))
+        .willReturn(Optional.of(TenantRole.SAAS_ADMIN));
+    assertThatThrownBy(
+            () ->
+                mockMvc.perform(
+                    get("/probe").header(TenantContextFilter.HEADER_X_TENANT_ID, "1")))
+        .hasRootCauseInstanceOf(IllegalArgumentException.class);
   }
 }

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/TenantContextFilterTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/TenantContextFilterTest.java
@@ -132,8 +132,7 @@ class TenantContextFilterTest {
         .willReturn(Optional.of(TenantRole.SAAS_ADMIN));
     assertThatThrownBy(
             () ->
-                mockMvc.perform(
-                    get("/probe").header(TenantContextFilter.HEADER_X_TENANT_ID, "1")))
+                mockMvc.perform(get("/probe").header(TenantContextFilter.HEADER_X_TENANT_ID, "1")))
         .hasRootCauseInstanceOf(IllegalArgumentException.class);
   }
 }

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/tenant/adapter/persistence/UserTenantMembershipAdapterTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/tenant/adapter/persistence/UserTenantMembershipAdapterTest.java
@@ -1,0 +1,119 @@
+package xyz.dgz48.tasks.webapi.tenant.adapter.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.persistence.EntityManager;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.transaction.annotation.Transactional;
+import xyz.dgz48.tasks.webapi.FixedClockConfiguration;
+import xyz.dgz48.tasks.webapi.MockJwtDecoderConfiguration;
+import xyz.dgz48.tasks.webapi.TestcontainersConfiguration;
+import xyz.dgz48.tasks.webapi.tenant.domain.TenantRole;
+import xyz.dgz48.tasks.webapi.tenant.usecase.TenantMembershipPort;
+import xyz.dgz48.tasks.webapi.user.adapter.persistence.UserJpaEntity;
+
+@SpringBootTest
+@Import({
+  TestcontainersConfiguration.class,
+  MockJwtDecoderConfiguration.class,
+  FixedClockConfiguration.class
+})
+@Transactional
+class UserTenantMembershipAdapterTest {
+
+  @Autowired TenantMembershipPort membershipPort;
+  @Autowired EntityManager em;
+
+  private Long userId;
+  private Long tenantId;
+
+  @BeforeEach
+  void setUp() {
+    var user =
+        new UserJpaEntity("sub-membership-test", "member@example.com", "テスト太郎", "テストタロウ", null);
+    em.persist(user);
+
+    em.createNativeQuery(
+            "INSERT INTO tenants (code, name, plan, status, created_at, updated_at) VALUES (?,?,?,?,?,?)")
+        .setParameter(1, "T-MEMBERSHIP")
+        .setParameter(2, "メンバーシップテストテナント")
+        .setParameter(3, "STANDARD")
+        .setParameter(4, "ACTIVE")
+        .setParameter(5, LocalDateTime.of(2026, 1, 1, 0, 0))
+        .setParameter(6, LocalDateTime.of(2026, 1, 1, 0, 0))
+        .executeUpdate();
+
+    em.flush();
+
+    userId = user.getId();
+    tenantId =
+        ((Number)
+                em.createNativeQuery("SELECT id FROM tenants WHERE code = 'T-MEMBERSHIP'")
+                    .getSingleResult())
+            .longValue();
+  }
+
+  @Test
+  void returnsRoleForActiveMember() {
+    insertUserTenant(userId, tenantId, "MEMBER", "ACTIVE");
+    em.flush();
+
+    Optional<TenantRole> role = membershipPort.findActiveRole(userId, tenantId);
+
+    assertThat(role).hasValue(TenantRole.MEMBER);
+  }
+
+  @Test
+  void returnsTenantAdminRoleForActiveTenantAdmin() {
+    insertUserTenant(userId, tenantId, "TENANT_ADMIN", "ACTIVE");
+    em.flush();
+
+    Optional<TenantRole> role = membershipPort.findActiveRole(userId, tenantId);
+
+    assertThat(role).hasValue(TenantRole.TENANT_ADMIN);
+  }
+
+  @Test
+  void returnsEmptyForInactiveMember() {
+    insertUserTenant(userId, tenantId, "MEMBER", "DISABLED");
+    em.flush();
+
+    Optional<TenantRole> role = membershipPort.findActiveRole(userId, tenantId);
+
+    assertThat(role).isEmpty();
+  }
+
+  @Test
+  void returnsEmptyForInvitedMember() {
+    insertUserTenant(userId, tenantId, "MEMBER", "INVITED");
+    em.flush();
+
+    Optional<TenantRole> role = membershipPort.findActiveRole(userId, tenantId);
+
+    assertThat(role).isEmpty();
+  }
+
+  @Test
+  void returnsEmptyWhenNoRecord() {
+    Optional<TenantRole> role = membershipPort.findActiveRole(userId, tenantId);
+
+    assertThat(role).isEmpty();
+  }
+
+  private void insertUserTenant(Long uid, Long tid, String role, String status) {
+    em.createNativeQuery(
+            "INSERT INTO user_tenants (user_id, tenant_id, role, status, joined_at) VALUES (?,?,?,?,?)")
+        .setParameter(1, uid)
+        .setParameter(2, tid)
+        .setParameter(3, role)
+        .setParameter(4, status)
+        .setParameter(5, LocalDateTime.of(2026, 1, 1, 0, 0))
+        .executeUpdate();
+  }
+}


### PR DESCRIPTION
## 概要

Issue #88 の実装。JWT から `APP_ADMIN` ロールを抽出し、テナント選択時に `ROLE_TENANT_ADMIN` / `ROLE_MEMBER` を SecurityContext へ付与することで `@PreAuthorize` による認可判定が機能するようにした。

## 変更内容

### 認証コンバーター (`security` module)
- **`TasksJwtAuthenticationConverter`**: `realm_access.roles` に `APP_ADMIN` が含まれる場合に `ROLE_APP_ADMIN` 権限を付与
- **`TenantContextFilter`**: テナント選択成功後に `findActiveRole` で取得したロール (`TENANT_ADMIN` / `MEMBER`) を `ROLE_TENANT_ADMIN` / `ROLE_MEMBER` として SecurityContext に追加。`SAAS_ADMIN` が渡された場合は `IllegalArgumentException` を throw するガードを追加
- **`SecurityConfig`**: `@EnableMethodSecurity` を追加（`@PreAuthorize` 有効化）

### テナントポート (`tenant` module)
- **`TenantMembershipPort`**: `isActiveMember(boolean)` を廃止し `findActiveRole(Long, Long) → Optional<TenantRole>` に一本化（メンバーシップ確認とロール取得を 1 クエリで実施）
- **`UserTenantJpaRepository`**: `findByIdUserIdAndIdTenantIdAndStatus` を追加（`Optional<UserTenantJpaEntity>` を返す）
- **`UserTenantMembershipAdapter`**: 上記ポートを実装

## ロール付与タイミング

| ロール | 付与タイミング | ソース |
|---|---|---|
| `ROLE_APP_ADMIN` | JWT 検証時（`TasksJwtAuthenticationConverter`） | Keycloak `realm_access.roles` |
| `ROLE_TENANT_ADMIN` / `ROLE_MEMBER` | テナント選択時（`TenantContextFilter`） | `user_tenants` テーブル |

## テスト

- **`TasksJwtAuthenticationConverterTest`**: `APP_ADMIN` 抽出・realm_access なし・APP_ADMIN 不在の 3 ケース追加
- **`TenantContextFilterTest`**: `findActiveRole` モック対応 + `@PreAuthorize` ゲートで SecurityContext へのロール付与を検証する 2 ケース追加 + `SAAS_ADMIN` ガード検証ケース追加
- **`UserTenantMembershipAdapterTest`** (新規): Testcontainers 統合テスト — MEMBER / TENANT_ADMIN / DISABLED / INVITED / レコードなし の 5 ケース

## テスト実行

```
./gradlew :webapi:check  → BUILD SUCCESSFUL
```

## 未対応レビュー

| 指摘 | 内容 | 状態 |
|---|---|---|
| [withTenantRole — SAAS_ADMIN ガード不足](https://github.com/win2cot/tasks-webapi/pull/297#pullrequestreview-2891183602) | `SAAS_ADMIN` が返却された場合に `IllegalArgumentException` を throw するガードを追加 | ✅ 対応済 (acdf34b) |
| [spotlessJavaCheck — TenantContextFilterTest フォーマット違反](https://github.com/win2cot/tasks-webapi/pull/297#pullrequestreview-2891252566) | `saasAdminRole_throwsIllegalArgumentException` のラムダ記述を Google Java Format 準拠に修正 | ✅ 対応済 (cba0396) |
| [saasAdminRole_throwsIllegalArgumentException テスト失敗](https://github.com/win2cot/tasks-webapi/pull/297#pullrequestreview-2891258869) | Spring 6 で NestedServletException が廃止されたため `hasRootCauseInstanceOf` → `isInstanceOf` に修正 | ✅ 対応済 (ee77741) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
