### PR TITLE
ci(#296): PR コメントを marocchino sticky comment に統一し CI 毎に確実 update

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -42,6 +42,8 @@ jobs:
         if: always()
         with:
           files: webapi/build/test-results/**/*.xml
+          comment_mode: off
+          fail_on: nothing
 
       - name: Upload test reports
         uses: actions/upload-artifact@v7
@@ -50,16 +52,102 @@ jobs:
           name: test-reports
           path: webapi/build/reports/tests/test/
 
-      - name: JaCoCo Report
-        uses: madrapps/jacoco-report@v1.7.2
-        if: always()
+      - name: Build CI report
+        id: ci-report
+        if: always() && github.event_name == 'pull_request'
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          RUN_NUM: ${{ github.run_number }}
+          GH_SHA: ${{ github.sha }}
+        run: |
+          SHA_SHORT="${GH_SHA:0:7}"
+          NOW="$(TZ=Asia/Tokyo date '+%Y-%m-%d %H:%M JST')"
+
+          # ── Test results ──────────────────────────────────────────────
+          TEST_DATA=$(python3 << 'PYEOF'
+          import xml.etree.ElementTree as ET, glob, sys
+          files = glob.glob('webapi/build/test-results/**/*.xml', recursive=True)
+          if not files:
+              print('MISSING')
+              sys.exit(0)
+          t = f = e = s = 0
+          for p in files:
+              try:
+                  r = ET.parse(p).getroot()
+                  t += int(r.get('tests', 0))
+                  f += int(r.get('failures', 0))
+                  e += int(r.get('errors', 0))
+                  s += int(r.get('skipped', 0))
+              except Exception:
+                  pass
+          print(f'{t} {f} {e} {s}')
+          PYEOF
+          )
+
+          if [ "$TEST_DATA" = "MISSING" ]; then
+            TEST_ROW="| テスト結果 | :warning: Run #${RUN_NUM} — ビルド/コンパイル失敗のためテスト未実行 |"
+          else
+            read -r TOTAL FAIL ERR SKIP <<< "$TEST_DATA"
+            PASSED=$((TOTAL - FAIL - ERR - SKIP))
+            if [ "$((FAIL + ERR))" -eq 0 ]; then
+              TEST_ICON=":white_check_mark:"
+            else
+              TEST_ICON=":x:"
+            fi
+            TEST_ROW="| テスト結果 ${TEST_ICON} | 合計 ${TOTAL}: 成功 **${PASSED}**, 失敗 $((FAIL + ERR)), スキップ ${SKIP} |"
+          fi
+
+          # ── Coverage ──────────────────────────────────────────────────
+          JACOCO_XML="webapi/build/reports/jacoco/test/jacocoTestReport.xml"
+          if [ -f "$JACOCO_XML" ]; then
+            COVERAGE=$(python3 << 'PYEOF'
+          import xml.etree.ElementTree as ET, sys
+          try:
+              root = ET.parse('webapi/build/reports/jacoco/test/jacocoTestReport.xml').getroot()
+              for c in root.findall('counter'):
+                  if c.get('type') == 'INSTRUCTION':
+                      missed = int(c.get('missed', 0))
+                      covered = int(c.get('covered', 0))
+                      total = missed + covered
+                      print(f'{covered / total * 100:.1f}' if total else '0.0')
+                      sys.exit(0)
+              print('N/A')
+          except Exception:
+              print('N/A')
+          PYEOF
+            )
+            if [ "$COVERAGE" != "N/A" ] && python3 -c "import sys; sys.exit(0 if float('$COVERAGE') >= 80 else 1)" 2>/dev/null; then
+              COV_ICON=":white_check_mark:"
+            elif [ "$COVERAGE" = "N/A" ]; then
+              COV_ICON=":question:"
+            else
+              COV_ICON=":x:"
+            fi
+            COV_ROW="| カバレッジ ${COV_ICON} | 命令カバレッジ **${COVERAGE}%** (基準 80%) |"
+          else
+            COV_ROW="| カバレッジ | :warning: Run #${RUN_NUM} — ビルド/コンパイル失敗のためカバレッジ未計測 |"
+          fi
+
+          # ── Write output ──────────────────────────────────────────────
+          {
+            echo 'BODY<<__CI_REPORT_EOF__'
+            echo "### CI 結果 — Run [#${RUN_NUM}](${RUN_URL}) (\`${SHA_SHORT}\`)"
+            echo ""
+            echo "| 項目 | 結果 |"
+            echo "|------|------|"
+            echo "${TEST_ROW}"
+            echo "${COV_ROW}"
+            echo ""
+            echo "_最終更新: ${NOW}_"
+            echo '__CI_REPORT_EOF__'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Post sticky CI report
+        uses: marocchino/sticky-pull-request-comment@v2
+        if: always() && github.event_name == 'pull_request'
         with:
-          paths: webapi/build/reports/jacoco/test/jacocoTestReport.xml
-          token: ${{ secrets.GITHUB_TOKEN }}
-          min-coverage-overall: 80
-          min-coverage-changed-files: 80
-          update-comment: true
-          title: Code Coverage
+          header: ci-report
+          message: ${{ steps.ci-report.outputs.BODY }}
 
       - name: Upload coverage reports
         uses: actions/upload-artifact@v7

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -116,7 +116,7 @@ jobs:
               print('N/A')
           PYEOF
             )
-            if [ "$COVERAGE" != "N/A" ] && python3 -c "import sys; sys.exit(0 if float('$COVERAGE') >= 80 else 1)" 2>/dev/null; then
+            if [ "$COVERAGE" != "N/A" ] && python3 -c "import sys; sys.exit(0 if float(sys.argv[1]) >= 80 else 1)" "$COVERAGE" 2>/dev/null; then
               COV_ICON=":white_check_mark:"
             elif [ "$COVERAGE" = "N/A" ]; then
               COV_ICON=":question:"
@@ -144,7 +144,7 @@ jobs:
 
       - name: Post sticky CI report
         uses: marocchino/sticky-pull-request-comment@v2
-        if: always() && github.event_name == 'pull_request'
+        if: always() && github.event_name == 'pull_request' && steps.ci-report.outcome == 'success'
         with:
           header: ci-report
           message: ${{ steps.ci-report.outputs.BODY }}

--- a/webapi/build.gradle
+++ b/webapi/build.gradle
@@ -98,6 +98,17 @@ jacocoTestReport {
     }
 }
 
+jacocoTestCoverageVerification {
+    dependsOn test
+    violationRules {
+        rule {
+            limit {
+                minimum = 0.80
+            }
+        }
+    }
+}
+
 spotless {
     // OS に依存せず常に LF を正とする(CI は Linux=LF、Windows ローカルでの CRLF 誤検知を防ぐ)。
     lineEndings = 'UNIX'
@@ -107,5 +118,5 @@ spotless {
 }
 
 tasks.named('check') {
-    dependsOn 'spotlessCheck'
+    dependsOn 'spotlessCheck', 'jacocoTestCoverageVerification'
 }


### PR DESCRIPTION
## 概要

closes #296

PR レビュー中に CI が複数回実行されてもテスト結果・カバレッジコメントが更新されない問題を修正する。Issue の **案B** を採用し、`marocchino/sticky-pull-request-comment@v2` による統一 sticky comment に置き換えた。

## 変更内容

### `.github/workflows/cicd.yml`

- **`EnricoMi/publish-unit-test-result-action@v2`**: `comment_mode: off` + `fail_on: nothing` を追加
  - PR コメント投稿を無効化し、Checks API アノテーション専用に絞る
  - XML 未生成時もステップを失敗させない
- **`madrapps/jacoco-report@v1.7.2`**: 削除
  - `update-comment: true` でもコメント更新が信頼できなかったため完全置換（PR #269 で 8 回中 7 回が no-op）
- **Build CI report** ステップを新規追加
  - Python スクリプトで JUnit XML・JaCoCo XML を直接解析
  - compile fail 等で XML が存在しない場合は stale notice 行を出力
  - テスト結果とカバレッジを 1 つのマークダウン表にまとめ `GITHUB_OUTPUT` に書き込む
- **Post sticky CI report** ステップを新規追加
  - `marocchino/sticky-pull-request-comment@v2` + `header: ci-report` により同一コメントを毎 run 上書き保証
  - 重複コメントを作らない

### `webapi/build.gradle`

- `jacocoTestCoverageVerification` を追加し `check` タスクに組み込む
  - `madrapps/jacoco-report` が担っていた 80% 閾値強制をビルドツール側に移管
  - `./gradlew check` ローカル実行でも 80% 未満で失敗するようになる

## トレードオフ

`madrapps/jacoco-report` の `min-coverage-changed-files: 80`（変更ファイル単位チェック）は廃止。全体 80% 命令カバレッジのみを強制する。

## 移行時の注意

既存のオープン PR に `madrapps` が投稿した "Code Coverage" コメントは次回 CI 実行後も残る（更新が止まるだけ）。手動で dismiss が必要。

## テスト計画

- [ ] CI が 2 回以上回ったとき、テスト結果・カバレッジコメントが最新 run に上書きされる（新規追加されない）
- [ ] compile fail 時のコメントが stale notice に書き換わる
- [ ] PR 内の CI 系コメントが統合 1 件に収束する

🤖 Generated with [Claude Code](https://claude.com/claude-code)