### PR TITLE
docs(#152): S-13 / S-14 テナント管理 Claude Design 案 3 種 + 採用判断(案 B、Closes #152)

### DIFF
--- a/docs/specs/ui/screens/tenant-admin/decision.md
+++ b/docs/specs/ui/screens/tenant-admin/decision.md
@@ -1,0 +1,208 @@
+# S-13 / S-14 テナント管理 方向性決定(Issue #152)
+
+Version 1.0 / 2026-06-02 / 親 Issue #152 / #149
+
+## 0. 本書の位置付け
+
+- 本書は Issue #152 のサブ画面 **S-13 テナント一覧 / S-14 テナント詳細・状態切替**(SaaS Admin 専用画面群) について、Claude Design に SSOT を投入して生成した 3 案の HTML 案を比較し、方向性を 1 案に絞った決定記録。
+- 採用案・却下案ともこのディレクトリ配下に HTML をそのまま残し、Sprint 1 以降の画面実装スプリントが本書だけで着手判断できるようにする。
+- 本書は実装着手 Issue ではない(ハイファイモック完成ではなく「方向性確定」が目的)。
+- **本書は Issue #152 サブ画面 4 つ目(最終)。本 PR で Issue #152 を close する**。
+
+### 0.1 決定プロセス(2026-06-02)
+
+1. SSOT(`docs/specs/ui/screen-flow.md` §3 SaaS Admin 動線 / §2 サイトマップ / `docs/specs/基本設計書.md` §3.2 / `docs/specs/ui/access-matrix.md` §3 / §6 / `api/openapi.yaml` v1.5.0 `listTenants` / `getTenant` / `updateTenant` / `updateTenantStatus`)+ S-03 / S-04 / S-05 採用案 HTML(デザインシステム継承元)を Claude Design に投入、3 案生成。
+2. 採用判断の前提として要件定義書のペルソナを再確認:
+   - **SaaS 運営者 = 数名・専任**(要件 §2.3、「テナント管理・全体監視。業務データには触れない」)
+   - 想定テナント数 = 数百規模(合計 5000 ユーザー / 1 テナント最大 50 名)
+   - デバイス = PC + タブレット
+   - screen-flow.md §3 注釈「業務動線と SaaS Admin 動線は画面遷移として直結しない、認可境界を視覚的にも明示」
+3. ユーザ議論で以下を確認:
+   - **視覚分離は強く表したい**(濃色 chrome / KPI ストリップ / 別サイドナビ等を積極採用)
+   - **主要動線は「1 件を丁寧に確認・状態切替」**(専任 SaaS Admin、誤操作防止重視)
+4. 上記前提下で 3 案を 7 軸(別空間視覚分離 / 一覧⇄詳細往復速度 / 誤操作防止 / URL 直アクセス整合 / 実装コスト / 想定読者ペルソナ / 拡張余地)で比較し、**案 B 管理コンソール風(別空間フルページ)を採用**。
+
+## 1. 採用案: **案 B 管理コンソール風(Admin Console / Separate-Space Fullpage)**
+
+ファイル: [`option-b-admin-console.html`](./option-b-admin-console.html)
+
+### 採用の理由
+
+1. **要件定義書のペルソナ「専任 SaaS Admin」と整合**
+   - 要件 §2.3 では SaaS 運営者は「数名」「テナント管理・全体監視・業務データには触れない」と明記。専任業務として運営に集中する想定。
+   - 案 B の濃色 chrome + 偽 URL バー + KPI ストリップは「専任業務用画面」の文脈を画面構造で表現する。
+2. **screen-flow.md §3 注釈の「両動線非直結を視覚的にも明示」と最も整合**
+   - SSOT §3 末尾で「両動線は画面遷移として直結しないことで、認可境界を視覚的にも明示する」と明記。
+   - 案 B は濃色 chrome / 別サイドナビ / KPI ストリップで業務動線(S-03〜S-06)とは明確に別空間と認知できる。
+   - 案 A は業務動線を継承するため別空間感がヘッダ帯色頼り、案 C はレイアウト構造で示すが色彩や chrome の主張は弱い。
+3. **状態切替操作の重さに見合った文脈明示**
+   - テナント停止(ACTIVE → SUSPENDED)は所属ユーザー全員がログイン不可になる重大操作。
+   - 案 B のフルページ詳細 + 専任空間 chrome なら誤クリック誘発リスクを構造的に抑制できる。
+   - 案 A のドロワーや案 C のマスターディテール構造はクリック数が少なく、状態切替を「軽い操作」と誤認させる懸念。
+4. **URL 直アクセスと UI 実体が一致**
+   - 案 B は `/admin/tenants/{id}` フルページ遷移なので、URL 直アクセス時のフォールバック対応が不要。実装・テスト・ブックマーク・通知メールリンクのいずれも素直。
+   - 案 A はドロワー UI 実体 + URL fallback(タブ復元等)の二重実装が必要。
+5. **Phase 2 以降の運営画面拡張に強い**
+   - 専用サイドナビ構造は S-12 プラットフォーム監視ダッシュボード / 監査ログ参照 / プラン管理(Phase 2)等が追加されても自然に拡張できる。
+   - 案 A は業務動線を継承するため、運営画面が増える度に「業務 / 運営」の混在を解きほぐす必要がある。
+
+### 採用案の主な構成要素(Claude Design 出力から)
+
+- **濃色トップバー**: 業務動線のブランドより濃い背景色(管理コンソール感)+ ブランド「tasks-webapi 管理コンソール」ラベル + APP_ADMIN バッジ + ユーザアバター(山田太郎)
+- **偽 URL バー**: ヘッダ下に `/admin/tenants` 表示(本実装ではブラウザアドレスバーで代替されるが、モック上で「いま運営空間にいる」を視覚的に明示)
+- **KPI ストリップ**: 数値カード(総テナント数 / ACTIVE 数 / SUSPENDED 数 / 直近 24h 新規)。S-12 プラットフォーム監視の予告も兼ねる(本 PR スコープ外なので静的表示のみ)
+- **左サイドナビ(SaaS Admin 動線専用)**: テナント一覧(active) / プラットフォーム監視(S-12、disabled、Sprint 1 以降) / 監査ログ(disabled、Phase 2 以降)。業務動線リンクは表示しない
+- **S-13 テナント一覧画面**:
+  - 上部フィルタバー(常時展開):状態フィルタ(ACTIVE / SUSPENDED / すべて) + 名前検索(部分一致)
+  - 一覧テーブル:テナント名 / 状態バッジ(緑 = ACTIVE / 赤 = SUSPENDED)/ 所属ユーザー数 / タスク数 / 作成日 / 操作セル(行クリックで S-14 へ)
+  - ページング:50 件/ページ(OpenAPI `listTenants` parameters と一致)
+  - 行クリック → `/admin/tenants/{id}` フルページ遷移
+- **S-14 テナント詳細・状態切替画面**:
+  - パンくず(管理コンソール > テナント一覧 > テナント A 株式会社)
+  - テナント名(大表示 + 編集アイコン、クリックで inline 編集モード → `PUT /api/tenants/{id}` = A-06)
+  - 状態バッジ(現状表示)
+  - 主要メトリクス(所属ユーザー数 / タスク数 / 作成日 / 更新日)
+  - 状態切替セクション:
+    - ACTIVE 時 = 「このテナントを停止する」赤系 destructive ボタン → 確認ダイアログ(テナント名入力で確認、所属ユーザー全員がログイン不可になる旨を明示)
+    - SUSPENDED 時 = 「このテナントを再有効化する」緑系 primary ボタン → 簡易確認
+    - 切替後 `TENANT_SUSPENDED` / `TENANT_REACTIVATED` を監査ログに記録(サーバ側、UI は通知トーストのみ)
+  - 戻るボタン(`/admin/tenants` へ戻る、ブラウザ戻るでも同じ動作)
+
+### 1.1 ハイファイ化で追加された UI 要素(2026-06-02 第 2 反復)
+
+採用後に Claude Design に作り込みを依頼し、以下を追加実装:
+
+- **モック状態プレビューバー**: 開発・レビュー用に listView / detailView / errorView / loading 状態を切り替えるバー(本実装では非表示)
+- **状態切替確認モーダル**(`#statusModal`):テナント名入力で confirm + ユーザー影響範囲表示 + destructive ボタン色強調(ACTIVE→SUSPENDED 時)/ 簡易 confirm(SUSPENDED→ACTIVE 時)
+- **トースト通知ホスト**(`#toastHost`):保存成功 / 失敗のフィードバック(画面右下)
+- **空状態**(`empty-state`):検索 / フィルタ結果 0 件時のメッセージ
+- **エラー画面 fallback**(403 / 404 / 401):
+  - 403:Tenant Admin / Member が `/admin/*` を直接 URL で叩いた時(`ROLE_BASED_DENIED`)
+  - 404:存在しないテナント ID を直接 URL で叩いた時
+  - 401:未認証時
+- **ローディングスケルトン**:GET /api/tenants / GET /api/tenants/{id} 取得中の placeholder
+- **保存スピナー**:PATCH / PUT 送信中の操作ボタン disabled + spinner
+
+## 2. 却下案
+
+### 案 A 業務動線統合型(右ドロワー)
+
+ファイル: [`option-a-integrated-drawer.html`](./option-a-integrated-drawer.html)
+
+**Claude Design 出力 注釈から**:
+- 強み:S-04 の上部フィルタバー + 一覧 + S-05 の右ドロワーをそのまま流用。業務動線とコンポーネントが完全に一致するため学習コストが最小で、実装も既存基盤に素直に乗る。一覧を見たまま詳細を開閉でき、複数テナントの確認テンポが速い。
+- 弱み:視覚が業務画面とほぼ同じため「別空間(運営軸)」の境界がヘッダの帯色・ラベル頼みになり弱め。ドロワー幅 480px では参考メトリクスや今後の運営情報が増えると手狭。URL 直アクセス時はフルページ fallback を別途用意する必要がある。
+- 想定読者:業務側 UI に慣れた運用担当が片手間でテナント状態を確認・切替する兼務 SaaS Admin。一覧⇄詳細を素早く往復したい層。
+
+**却下の理由**(本書):
+- 要件 §2.3 の SaaS 運営者ペルソナ(専任、業務データに触れない)と齟齬。兼務前提の動線設計だが、要件では兼務想定されていない。
+- 視覚分離が弱く、screen-flow.md §3 注釈「両動線非直結を視覚的にも明示」と整合性が低い。
+- ドロワー幅で参考メトリクス / 監査ログ予告 / Phase 2 拡張余地を持ちにくい。
+
+**Phase 2 で復活する余地**: SaaS Admin が業務テナントも兼務して片手間運用するシナリオが現実化した場合、「シンプルドロワーモード」として個人設定で復活する選択肢。
+
+### 案 C マスターディテール(左一覧 + 右詳細)
+
+ファイル: [`option-c-master-detail.html`](./option-c-master-detail.html)
+
+**Claude Design 出力 注釈から**:
+- 強み:一覧と詳細を常時同時表示。左で次々選択するだけで右に S-14 が即時差し替わり、複数テナントを連続して確認・状態切替するパワーユーザの操作効率が最も高い。一覧の文脈を失わずに 1 件を深掘りでき、選択行はハイライトで追跡できる。
+- 弱み:左ペインに 392px を固定で割くため、右の詳細幅が狭まり 1 件の情報量はフルページ案に劣る。タブレット縦・狭幅では上下 2 段に折り返り、同時表示の利点が薄れる。1 件をじっくり見る用途には冗長。
+- 想定読者:多数テナントを横断して棚卸し・一括点検する運用パワーユーザ。「次々に切り替えて状態を確認」する頻度が高い PC 中心の専任 SaaS Admin。
+
+**却下の理由**(本書):
+- 「1 件を丁寧に確認・状態切替」「誤操作防止」というユーザ確定動線と方向が異なる(案 C は「次々切替」が強み)。
+- 詳細幅が狭まると状態切替の重さに見合った文脈表現がしにくい(確認ダイアログでカバーは可能だが、案 B のフルページ警告の方が構造的に強い)。
+- タブレット縦で折返しが発生し、同時表示の利点が薄れる。
+
+**Phase 2 で復活する余地**: テナント数が極端に増えた場合(例:1000 テナント超)に「棚卸しビュー」として個人設定で切替可能にする選択肢。
+
+## 3. 開いている論点(別 Issue に引き継ぐ)
+
+### #154 デザインシステム素案に引き継ぐ
+
+1. **管理コンソール用 chrome の正式トークン化**:
+   - 濃色トップバー / 偽 URL バー / 専用サイドナビの色トークン(`--admin-bg`, `--admin-accent` 等)。
+   - 業務動線との視覚境界(`body.admin-mode` クラスとの相互作用)。
+2. **KPI ストリップコンポーネント**:
+   - 数値カード(総テナント数 / ACTIVE 数 / SUSPENDED 数 / 直近 24h 新規)の規格化。S-12 プラットフォーム監視で再利用予定。
+   - 集計 API(`getPlatformMetrics` A-27)との連携、本 PR ではスコープ外で静的表示のみ。
+3. **状態切替確認ダイアログ**:
+   - ハイファイ版で実装済(`#statusModal`、ACTIVE → SUSPENDED 時はテナント名入力 + ユーザー影響範囲表示、SUSPENDED → ACTIVE 時は簡易 confirm)。
+   - 共通の destructive 操作確認ダイアログコンポーネントとして規格化(他画面の論理削除等にも転用)。
+4. **状態バッジ色トークン**:
+   - 緑(ACTIVE)/ 赤(SUSPENDED)。本 PR では Bootstrap デフォルト色だがトークン化必要。
+5. **inline 編集パターン(テナント名)**:
+   - S-03 / S-04 の行内編集と同じパターンを 1 フィールドに適用。
+6. **左サイドナビの「disabled」項目表示**:
+   - Sprint 1 / Phase 2 で実装予定の項目(S-12 / 監査ログ参照)を予告表示する規約。
+7. **偽 URL バーの本実装での扱い**:
+   - モック上では「いま運営空間にいる」を視覚的に明示するが、本実装ではブラウザアドレスバーで代替。本実装で残すか判断。
+
+### #153 OpenAPI v1.5.0 突き合わせに引き継ぐ
+
+| # | 検討項目 | 本書の前提 | 確認したいこと |
+|---|---|---|---|
+| 1 | テナント一覧 API | OpenAPI v1.5.0 `GET /api/tenants` (A-04, `listTenants`) | 状態フィルタ / 名前検索 / ページング(50 件)が parameters に揃っているか |
+| 2 | テナント単体取得 API | OpenAPI v1.5.0 `GET /api/tenants/{id}` (A-25, `getTenant`) | レスポンスに `userCount` / `taskCount` / `status` / `createdAt` / `updatedAt` が含まれるか |
+| 3 | テナント名更新 API | OpenAPI v1.5.0 `PUT /api/tenants/{id}` (A-06, `updateTenant`) | テナント名のみの更新で確定済(状態は別 endpoint) |
+| 4 | テナント状態切替 API | OpenAPI v1.5.0 `PATCH /api/tenants/{id}/status` (A-26, `updateTenantStatus`) | ACTIVE ↔ SUSPENDED 切替で確定済、監査ログ記録は Server 側 |
+| 5 | KPI 集計 API | OpenAPI v1.5.0 `GET /api/platform/metrics` (A-27, `getPlatformMetrics`) | 総テナント数 / ACTIVE 数 / SUSPENDED 数 / 直近 24h 新規が揃うか(本 PR では静的表示、S-12 で本実装) |
+| 6 | 監査ログ参照 API | `/api/audit-logs`(Tenant Admin 限定) | SaaS Admin が `TENANT_SUSPENDED` / `TENANT_REACTIVATED` の監査ログを参照する画面が必要か(本 PR スコープ外、Phase 2 候補) |
+| 7 | 認可 | SaaS Admin (`hasRole('APP_ADMIN')`) のみ全 endpoint アクセス可 | Spring Security `@PreAuthorize` 設定が API 側で完備されているか |
+
+### 別 Issue として独立起票候補(本書では結論を出さない)
+
+- **S-12 プラットフォーム監視ダッシュボード**: KPI ストリップを本格化したフル画面、時系列グラフ等(基本設計書 §3.2)。Sprint 1 以降。
+- **監査ログ参照画面**: SaaS Admin / Tenant Admin の両者向け。`TENANT_SUSPENDED` / `TENANT_REACTIVATED` を含む全アクション参照(Phase 2 想定)。
+- **テナント削除 / プラン管理**: 物理削除はテナント解約 #167 で扱う(Phase 2)。プラン管理は MVP 範囲外。
+- **テナント新規作成画面 S-11**: 認証済みユーザーのセルフサインアップ(Tenant Admin / Member 動線)、本画面の SaaS Admin 動線とは別。Sprint 1 以降。
+- **個人設定でのビュー切替**: Phase 2 で「シンプルドロワー(案 A)」「マスターディテール(案 C)」を切替可能にする際の設定 UI / API。
+
+## 4. 認可ポリシー整合確認
+
+ロール × 画面 × 操作の認可マトリクスは `docs/specs/ui/access-matrix.md`(#151 成果物、main マージ済み)を SSOT とする。本書は案 B の UI 表現が SSOT と矛盾しないことを以下で局所的に確認する。差分が生じた場合は access-matrix.md と基本設計書 §6.2 を優先する。
+
+| 観点 | 仕様 | 案 B での扱い | OK |
+|---|---|---|---|
+| 画面アクセス可否 | SaaS Admin (`APP_ADMIN`) のみ可、Tenant Admin / Member は 403 | ヘッダにロール切替セレクタを置かず SaaS Admin 一択、APP_ADMIN バッジ表示 | ✓ |
+| visibility の効きどころ | テナント管理は visibility に依存しない(screen-flow.md §4 末尾) | 一覧 / 詳細とも visibility 判定なし、状態(ACTIVE/SUSPENDED)のみ | ✓ |
+| テナント一覧参照 | `GET /api/tenants` (A-04) SaaS Admin 専用 | フィルタ + 検索 + ページング、サーバ側認可前提 | ✓ |
+| テナント単体取得 | `GET /api/tenants/{id}` (A-25) SaaS Admin は任意テナント可 | 全テナントへ任意アクセス、URL 直アクセス時もサーバ側認可 | ✓ |
+| テナント名更新 | `PUT /api/tenants/{id}` (A-06) SaaS Admin のみ | inline 編集パターン、不可時 403 | ✓ |
+| テナント状態切替 | `PATCH /api/tenants/{id}/status` (A-26) SaaS Admin のみ | フルページ destructive 操作、確認ダイアログ | ✓ |
+| 業務 API 不可 | SaaS Admin 単独は業務 API に触れない(ADR-0005) | サイドナビに業務動線リンクなし、業務 API 呼び出しは存在しない | ✓ |
+| 監査ログ記録 | `TENANT_SUSPENDED` / `TENANT_REACTIVATED` を Server 側で記録 | UI 側は通知トーストのみ、サーバが自動記録 | ✓ |
+| 兼務ユーザーの扱い | `APP_ADMIN` + `user_tenants` 行ありユーザーが `/admin/*` を開いた瞬間に SaaS Admin 動線へ切替 | サイドナビに業務動線リンクがないため、URL 変更で明示的に切替必要 | ✓ |
+| Tenant Admin / Member が直接 URL で `/admin/tenants` を叩いた場合 | 403 (`ROLE_BASED_DENIED`、access-matrix.md §6 ケース 8) | サーバ側 `@PreAuthorize` で拒否、ハイファイ版で 403 エラー画面 fallback 実装(`errorView`) | ✓ |
+| 存在しないテナント ID 直接 URL アクセス | 404 (`TENANT_NOT_FOUND`) | ハイファイ版で 404 エラー画面 fallback 実装 | ✓ |
+| 未認証アクセス | 401 (`LOGIN_FAILED`) | ハイファイ版で 401 エラー画面 fallback 実装(Keycloak ログインへリダイレクト前提) | ✓ |
+
+## 5. 関連
+
+- 親 Issue: #152(本書、本 PR で close)/ #149(Sprint 0 画面設計)
+- SSOT: `docs/specs/ui/screen-flow.md` v1.1 §3 / §2 / `docs/specs/基本設計書.md` §3.2 / `docs/specs/ui/access-matrix.md` §3 / §6 / `docs/specs/要件定義書.md` §2.3
+- 前提整合確認済み: PR #348(access-matrix.md)/ PR #349(OpenAPI v1.5.0)/ PR #350(S-03 採用案)/ PR #351(S-04 採用案)/ PR #352(S-05 採用案)
+- 引き継ぎ先: #153(OpenAPI 突合)/ #154(デザインシステム素案、特に管理コンソール用 chrome + KPI ストリップ + destructive 確認ダイアログ)
+- 関連 ADR: ADR-0005(タスク認可 3 役割 = SaaS Admin の業務特権なし、本画面でも整合)
+- 関連 Issue: #167(テナント解約 Phase 2)/ S-12 プラットフォーム監視(Sprint 1 以降)/ S-15 テナント運営者向けダッシュボード(Out of Scope #149)
+
+## 6. ファイル構成と commit 方針
+
+| ファイル | 状態 | commit |
+|---|---|---|
+| `option-a-integrated-drawer.html` | Claude Design 出力、却下案(残置) | ✓ |
+| `option-b-admin-console.html` | Claude Design 出力、採用案 | ✓ |
+| `option-c-master-detail.html` | Claude Design 出力、却下案(残置) | ✓ |
+| `decision.md` | 本書、採用判断 + 引き継ぎ論点 | ✓ |
+
+## 7. Issue #152 完了に向けて
+
+本 PR が **Issue #152 サブ画面 4 つ目(最終)** となり、PR タイトル / commit message / PR body で `Closes #152` を打つ。
+
+Issue #152 完了の定義(Issue 本文より)対応状況:
+
+- [x] **4 画面すべて方向性決定済み**: PR #350(S-03)/ PR #351(S-04)/ PR #352(S-05)/ 本 PR(S-13/S-14)
+- [x] **各画面に `decision.md` あり**(理由 + 却下案 + 残論点)
+- [x] **認可ポリシー(権限マトリクス Issue の成果物)と矛盾しない**: 4 画面とも `decision.md` §4 で access-matrix.md と整合確認済
+- [x] **OpenAPI 突き合わせ Issue に必要なフィールド洗い出しを引き継いでいる**: 4 画面とも `decision.md` §3 で #153 引き継ぎ表を整備

--- a/docs/specs/ui/screens/tenant-admin/option-a-integrated-drawer.html
+++ b/docs/specs/ui/screens/tenant-admin/option-a-integrated-drawer.html
@@ -1,0 +1,453 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>S-13 / S-14 テナント管理 — 案A 業務動線統合型(右ドロワー)</title>
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous" />
+<link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet" />
+<link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet" />
+<style>
+  :root{
+    --bs-body-font-family:"Noto Sans JP", system-ui, -apple-system, "Segoe UI", sans-serif;
+    --app-bg:#f4f5f7;--app-surface:#ffffff;--app-border:#e5e7eb;--app-ink:#1f2733;--app-muted:#6b7280;
+    --app-primary:#3b5bdb;--app-primary-d:#2f49b0;
+    --c-overdue:#e03131;--c-today:#e8830c;--c-soon:#1c7ed6;--c-done:#2f9e44;
+    /* SaaS Admin(運営空間)アクセント */
+    --admin-accent:#5a4bd6;--admin-accent-soft:#efeefb;--admin-accent-border:#ddd9f5;
+    --c-active:#2f9e44;--c-suspended:#b8650b;
+    --bs-body-bg:var(--app-bg);--bs-body-color:var(--app-ink);
+  }
+  body{font-family:var(--bs-body-font-family);font-size:14px;-webkit-font-smoothing:antialiased;}
+  .text-muted-2{color:var(--app-muted)!important;}
+  code{color:#6a44c4;background:#f1edfa;padding:1px 5px;border-radius:4px;font-size:.86em;}
+
+  /* ---- App shell(業務動線から継承)---- */
+  .app-navbar{background:var(--app-surface);border-bottom:1px solid var(--app-border);height:56px;
+    box-shadow:inset 0 3px 0 var(--admin-accent);}
+  .app-brand{font-weight:700;letter-spacing:.02em;color:var(--app-ink);}
+  .app-brand .bi{color:var(--app-primary);}
+  .console-chip{font-size:12px;background:var(--admin-accent-soft);color:var(--admin-accent);
+    border:1px solid var(--admin-accent-border);padding:3px 11px;border-radius:999px;font-weight:700;display:inline-flex;align-items:center;gap:5px;}
+  .role-badge{font-size:10.5px;font-weight:700;letter-spacing:.04em;background:#2a3142;color:#fff;padding:2px 8px;border-radius:5px;}
+  .app-layout{display:flex;min-height:calc(100vh - 56px);}
+  .app-sidebar{width:236px;flex:0 0 236px;background:var(--app-surface);border-right:1px solid var(--app-border);padding:16px 12px;}
+  .app-main{flex:1 1 auto;min-width:0;padding:22px 26px 60px;}
+  .nav-group-label{font-size:11px;font-weight:700;letter-spacing:.08em;color:#9aa1ad;text-transform:uppercase;padding:0 12px;margin:14px 0 6px;}
+  .side-link{display:flex;align-items:center;gap:10px;padding:9px 12px;border-radius:8px;color:#3f4855;text-decoration:none;font-weight:500;font-size:13.5px;margin-bottom:2px;}
+  .side-link .bi{font-size:16px;color:#7a828f;}
+  .side-link:hover{background:#f2f4f7;}
+  .side-link.active{background:var(--admin-accent-soft);color:var(--admin-accent);}
+  .side-link.active .bi{color:var(--admin-accent);}
+  .side-link.is-disabled{opacity:.55;cursor:not-allowed;}
+  .side-link .badge{margin-left:auto;}
+  .scope-note{font-size:11px;color:var(--app-muted);background:#fafaff;border:1px solid var(--admin-accent-border);border-radius:8px;padding:9px 11px;margin-top:14px;line-height:1.55;}
+
+  .page-title{font-weight:700;font-size:20px;margin:0;}
+  .page-date{color:var(--app-muted);font-size:13px;}
+
+  /* ---- 上部フィルタバー(S-04 継承)---- */
+  .filter-bar{background:var(--app-surface);border:1px solid var(--app-border);border-radius:12px;}
+  .filter-bar-head{display:flex;align-items:center;gap:10px;padding:12px 16px;flex-wrap:wrap;}
+  .filter-bar-title{font-size:13px;font-weight:600;color:#3f4855;display:flex;align-items:center;gap:7px;}
+  .seg{display:inline-flex;border:1px solid var(--app-border);border-radius:8px;overflow:hidden;background:#fff;}
+  .seg button{border:none;background:#fff;font-size:12.5px;font-weight:600;color:#566173;padding:6px 14px;cursor:pointer;border-right:1px solid var(--app-border);}
+  .seg button:last-child{border-right:none;}
+  .seg button:hover:not(.on){background:#f4f6fb;}
+  .seg button.on{background:var(--admin-accent);color:#fff;}
+  .search-wrap{position:relative;}
+  .search-wrap .bi{position:absolute;left:11px;top:50%;transform:translateY(-50%);color:#9aa1ad;font-size:14px;}
+  .search-wrap input{padding-left:32px;width:248px;}
+
+  /* ---- テナント一覧テーブル(table.tasks 継承)---- */
+  .task-section{background:var(--app-surface);border:1px solid var(--app-border);border-radius:12px;margin-top:14px;overflow:hidden;}
+  .section-head{display:flex;align-items:center;gap:10px;padding:13px 18px;border-bottom:1px solid var(--app-border);}
+  .section-head .sec-icon{width:26px;height:26px;border-radius:7px;display:grid;place-items:center;color:#fff;font-size:14px;background:var(--admin-accent);}
+  .section-head h2{font-size:15px;font-weight:700;margin:0;}
+  .section-head .sec-count{font-size:12px;color:var(--app-muted);font-weight:500;}
+  .section-head .sec-api{font-size:11px;color:#9aa1ad;margin-left:auto;font-weight:400;}
+  table.tenants{width:100%;margin:0;border-collapse:collapse;}
+  table.tenants th{font-size:11px;font-weight:600;color:#9aa1ad;text-transform:uppercase;letter-spacing:.04em;padding:9px 16px;border-bottom:1px solid var(--app-border);text-align:left;background:#fafbfc;white-space:nowrap;}
+  table.tenants th.num{text-align:right;}
+  table.tenants td{padding:12px 16px;border-bottom:1px solid #f1f2f4;vertical-align:middle;}
+  table.tenants td.num{text-align:right;font-variant-numeric:tabular-nums;}
+  table.tenants tr:last-child td{border-bottom:none;}
+  table.tenants tbody tr{cursor:pointer;}
+  table.tenants tbody tr:hover{background:#f7f8ff;}
+  table.tenants tbody tr.is-suspended{background:#fffdf8;}
+  table.tenants tbody tr.is-suspended:hover{background:#fff7ec;}
+  .t-name{font-weight:600;color:var(--app-ink);}
+  .t-id{font-size:11px;color:#9aa1ad;font-variant-numeric:tabular-nums;}
+  .t-avatar{width:30px;height:30px;border-radius:8px;background:var(--admin-accent-soft);color:var(--admin-accent);display:inline-grid;place-items:center;font-size:13px;font-weight:700;flex:0 0 30px;}
+  .empty-row td{text-align:center;color:#9aa1ad;padding:30px 14px;font-size:13px;}
+  .col-status{width:128px;}.col-users{width:104px;}.col-tasks{width:104px;}.col-created{width:128px;}.col-chevron{width:40px;text-align:right;}
+  .row-chevron{color:#c2c7d0;font-size:14px;}
+
+  /* ---- ステータスバッジ ---- */
+  .ts-badge{font-size:11.5px;font-weight:600;padding:4px 10px;border-radius:6px;display:inline-flex;align-items:center;gap:5px;border:1px solid transparent;}
+  .ts-ACTIVE{background:#e7f5ec;color:#207a3a;border-color:#c3e6cf;}
+  .ts-SUSPENDED{background:#fff3e2;color:#b8650b;border-color:#f3dcb6;}
+  .plan-badge{font-size:10.5px;font-weight:600;padding:2px 8px;border-radius:5px;background:#eef1f6;color:#566173;}
+
+  /* ---- ドロワー(S-05 継承)---- */
+  .offcanvas-end{width:480px;}
+  .drawer-section-label{font-size:11px;font-weight:700;color:#9aa1ad;text-transform:uppercase;letter-spacing:.05em;margin:20px 0 8px;display:flex;align-items:center;gap:7px;}
+  .drawer-section-label .api{margin-left:auto;font-weight:500;color:#b4bac4;text-transform:none;letter-spacing:0;}
+  .field-readonly{background:#f6f7f9;border-radius:7px;padding:9px 12px;font-size:13.5px;border:1px solid var(--app-border);}
+  .metric-box{background:#fff;border:1px solid var(--app-border);border-radius:10px;padding:12px 14px;text-align:center;}
+  .metric-box .m-num{font-size:24px;font-weight:700;line-height:1.1;}
+  .metric-box .m-lbl{font-size:11px;color:var(--app-muted);margin-top:2px;}
+  .metric-box .m-note{font-size:10px;color:#aab0ba;margin-top:1px;}
+  .name-edit-wrap{display:flex;align-items:center;gap:8px;}
+  .name-edit-wrap input{font:inherit;font-size:18px;font-weight:700;border:1px solid var(--app-primary);border-radius:7px;padding:5px 10px;width:100%;}
+  .editable-name{font-size:18px;font-weight:700;border-bottom:1px dashed #b6bcc6;cursor:text;padding-bottom:1px;}
+  .editable-name:hover{background:var(--admin-accent-soft);border-bottom-color:var(--admin-accent);}
+
+  /* ---- 確認ダイアログ ---- */
+  .modal-warn-icon{width:44px;height:44px;border-radius:50%;display:grid;place-items:center;font-size:21px;flex:0 0 44px;}
+  .warn-suspend{background:#fff3e2;color:#b8650b;}
+  .warn-reactivate{background:#e7f5ec;color:#207a3a;}
+  .consequence{font-size:12.5px;color:#5a6270;background:#fbfbfc;border:1px solid var(--app-border);border-radius:9px;padding:11px 13px;line-height:1.65;}
+  .audit-chip{font-size:10.5px;font-weight:700;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;background:#2a3142;color:#fff;padding:2px 7px;border-radius:4px;}
+
+  /* ---- toast ---- */
+  .toast-host{position:fixed;right:18px;bottom:18px;z-index:2000;display:flex;flex-direction:column;gap:8px;}
+
+  /* ---- design notes(継承)---- */
+  .design-notes{margin-top:30px;border:1px dashed #c9ccd3;border-radius:12px;background:#fcfcfd;padding:18px 22px;}
+  .design-notes h3{font-size:13px;font-weight:700;letter-spacing:.04em;color:#5a6270;margin:0 0 10px;display:flex;align-items:center;gap:7px;}
+  .design-notes dl{display:grid;grid-template-columns:96px 1fr;gap:6px 14px;margin:0;font-size:12.5px;}
+  .design-notes dt{font-weight:700;color:#404856;}
+  .design-notes dd{margin:0;color:#5a6270;}
+</style>
+</head>
+<body>
+
+<!-- ===== Top navbar(運営空間)===== -->
+<nav class="app-navbar d-flex align-items-center px-3 gap-3 sticky-top">
+  <div class="app-brand d-flex align-items-center gap-2">
+    <i class="bi bi-check2-square fs-5"></i><span>tasks-webapi</span>
+  </div>
+  <span class="console-chip"><i class="bi bi-hdd-stack"></i>管理コンソール</span>
+  <div class="ms-auto d-flex align-items-center gap-3">
+    <span class="text-muted-2 small d-none d-md-inline"><i class="bi bi-shield-lock me-1"></i>テナント運営軸のみ・業務 API 非到達</span>
+    <div class="d-flex align-items-center gap-2">
+      <div class="rounded-circle d-grid" style="width:30px;height:30px;place-items:center;font-weight:700;font-size:12px;background:#2a3142;color:#fff;">山</div>
+      <div class="d-none d-lg-block lh-1">
+        <div class="small fw-bold">山田 太郎</div>
+        <span class="role-badge">APP_ADMIN</span>
+      </div>
+    </div>
+  </div>
+</nav>
+
+<div class="app-layout">
+  <!-- ===== Sidebar(SaaS Admin 動線専用)===== -->
+  <aside class="app-sidebar d-none d-lg-block">
+    <div class="nav-group-label">プラットフォーム運用</div>
+    <a class="side-link active" href="#" onclick="return false"><i class="bi bi-buildings"></i>テナント一覧 <span class="badge text-bg-light text-muted-2">S-13</span></a>
+    <a class="side-link is-disabled" href="#" onclick="return false" title="Sprint 1 以降"><i class="bi bi-activity"></i>プラットフォーム監視 <span class="badge text-bg-light text-muted-2">S-12</span></a>
+    <a class="side-link is-disabled" href="#" onclick="return false" title="Tenant Admin 機能"><i class="bi bi-journal-text"></i>監査ログ</a>
+
+    <div class="nav-group-label">アカウント</div>
+    <a class="side-link" href="#" onclick="return false"><i class="bi bi-person-circle"></i>プロフィール</a>
+    <a class="side-link" href="#" onclick="return false"><i class="bi bi-box-arrow-right"></i>ログアウト</a>
+
+    <div class="scope-note">
+      <i class="bi bi-diagram-3 me-1"></i>業務動線(S-03〜S-06)とは<b>画面遷移として直結しません</b>。SaaS Admin はテナント運営軸のみを操作し、業務タスク / visibility / 3 役割評価はこの空間では効きません。
+    </div>
+  </aside>
+
+  <!-- ===== Main ===== -->
+  <main class="app-main">
+    <div class="d-flex align-items-center flex-wrap gap-3 mb-3">
+      <div>
+        <h1 class="page-title">テナント一覧</h1>
+        <div class="page-date"><i class="bi bi-link-45deg"></i> URL は <code>/admin/tenants</code> ・ 行クリックで右ドロワーに S-14 を展開(<code>/admin/tenants/{id}</code> 同期)</div>
+      </div>
+      <div class="ms-auto d-flex align-items-center gap-2">
+        <span class="console-chip"><i class="bi bi-people"></i>合計 <b id="totalUsers">0</b> ユーザー</span>
+      </div>
+    </div>
+
+    <!-- フィルタバー -->
+    <div class="filter-bar">
+      <div class="filter-bar-head">
+        <span class="filter-bar-title"><i class="bi bi-funnel-fill"></i>状態</span>
+        <div class="seg" id="statusSeg">
+          <button class="on" data-v="ALL" onclick="setStatusFilter('ALL')">すべて</button>
+          <button data-v="ACTIVE" onclick="setStatusFilter('ACTIVE')">ACTIVE</button>
+          <button data-v="SUSPENDED" onclick="setStatusFilter('SUSPENDED')">SUSPENDED</button>
+        </div>
+        <div class="search-wrap ms-auto">
+          <i class="bi bi-search"></i>
+          <input id="nameSearch" class="form-control form-control-sm" placeholder="テナント名で部分一致検索" oninput="renderList()" />
+        </div>
+      </div>
+    </div>
+
+    <!-- 一覧テーブル -->
+    <section class="task-section">
+      <div class="section-head">
+        <span class="sec-icon"><i class="bi bi-buildings"></i></span>
+        <h2>テナント</h2><span class="sec-count" id="listCount">0 件</span>
+        <span class="sec-api"><code>GET /api/tenants</code>(A-04 listTenants)・既定ソート createdAt DESC</span>
+      </div>
+      <table class="tenants">
+        <thead><tr>
+          <th>テナント</th>
+          <th class="col-status">状態</th>
+          <th class="col-users num">ユーザー数</th>
+          <th class="col-tasks num">タスク数</th>
+          <th class="col-created">作成日</th>
+          <th class="col-chevron"></th>
+        </tr></thead>
+        <tbody id="listBody"></tbody>
+      </table>
+      <div class="d-flex align-items-center gap-2 px-3 py-2 border-top" style="font-size:12px;color:var(--app-muted);background:#fafbfc;">
+        <span>全 <b id="pagerTotal">0</b> 件中 1–<b id="pagerShown">0</b> 件を表示</span>
+        <div class="ms-auto d-flex align-items-center gap-1">
+          <button class="btn btn-sm btn-outline-secondary py-0 px-2" disabled>前へ</button>
+          <span class="px-2">1 / 1</span>
+          <button class="btn btn-sm btn-outline-secondary py-0 px-2" disabled>次へ</button>
+          <span class="ms-2">50 件 / ページ(<code>page</code> / <code>size</code>)</span>
+        </div>
+      </div>
+    </section>
+
+    <!-- 設計判断ポイント -->
+    <div class="design-notes">
+      <h3><i class="bi bi-clipboard-data"></i>設計判断ポイント — 案A 業務動線統合型(右ドロワー)</h3>
+      <dl>
+        <dt>強み</dt><dd>S-04 の上部フィルタバー + 一覧 + S-05 の右ドロワーをそのまま流用。業務動線とコンポーネントが完全に一致するため学習コストが最小で、実装も既存基盤に素直に乗る。一覧を見たまま詳細を開閉でき、複数テナントの確認テンポが速い。</dd>
+        <dt>弱み</dt><dd>視覚が業務画面とほぼ同じため「別空間(運営軸)」の境界がヘッダの帯色・ラベル頼みになり弱め。ドロワー幅 480px では参考メトリクスや今後の運営情報が増えると手狭。URL 直アクセス時はフルページ fallback を別途用意する必要がある。</dd>
+        <dt>想定読者</dt><dd>業務側 UI に慣れた運用担当が片手間でテナント状態を確認・切替する兼務 SaaS Admin。一覧⇄詳細を素早く往復したい層。</dd>
+      </dl>
+    </div>
+  </main>
+</div>
+
+<!-- ===== S-14 詳細ドロワー ===== -->
+<div class="offcanvas offcanvas-end" tabindex="-1" id="detailDrawer" aria-labelledby="detailLabel">
+  <div class="offcanvas-header border-bottom">
+    <h5 class="offcanvas-title d-flex align-items-center gap-2" id="detailLabel"><i class="bi bi-buildings text-primary"></i>テナント詳細</h5>
+    <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="閉じる"></button>
+  </div>
+  <div class="offcanvas-body" id="detailBody"></div>
+</div>
+
+<!-- ===== 状態切替 確認モーダル ===== -->
+<div class="modal fade" id="statusModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content" id="statusModalContent"></div>
+  </div>
+</div>
+
+<div class="toast-host" id="toastHost"></div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
+<script>
+/* ===================== データ(検証用ダミー)===================== */
+const CURRENT_USER = { name:"山田 太郎", role:"APP_ADMIN" };
+const TENANTS = [
+  { id:1, code:"tenant-a",  name:"テナントA株式会社",       status:"ACTIVE",    plan:"FREE", userCount:18, taskCount:421,  createdAt:"2025-12-03", updatedAt:"2026-05-20", suspendedAt:null },
+  { id:2, code:"tenant-b",  name:"テナントB商事",           status:"ACTIVE",    plan:"FREE", userCount:32, taskCount:1247, createdAt:"2025-08-15", updatedAt:"2026-05-18", suspendedAt:null },
+  { id:3, code:"tenant-c",  name:"テナントC工業",           status:"SUSPENDED", plan:"FREE", userCount:11, taskCount:283,  createdAt:"2024-11-20", updatedAt:"2026-03-12", suspendedAt:"2026-03-12" },
+  { id:4, code:"demo",      name:"デモ用テナント",           status:"ACTIVE",    plan:"FREE", userCount:3,  taskCount:12,   createdAt:"2026-05-01", updatedAt:"2026-05-01", suspendedAt:null },
+  { id:5, code:"tenant-d",  name:"テナントD物流",           status:"ACTIVE",    plan:"FREE", userCount:25, taskCount:892,  createdAt:"2025-04-10", updatedAt:"2026-04-22", suspendedAt:null },
+  { id:6, code:"tenant-e",  name:"テナントEメディア",       status:"SUSPENDED", plan:"FREE", userCount:7,  taskCount:65,   createdAt:"2024-06-01", updatedAt:"2025-09-30", suspendedAt:"2025-09-30" },
+  { id:7, code:"tenant-f",  name:"テナントF不動産",         status:"ACTIVE",    plan:"FREE", userCount:42, taskCount:2103, createdAt:"2024-02-14", updatedAt:"2026-05-12", suspendedAt:null },
+  { id:8, code:"tenant-g",  name:"テナントGスタートアップ", status:"ACTIVE",    plan:"FREE", userCount:5,  taskCount:34,   createdAt:"2026-05-28", updatedAt:"2026-05-28", suspendedAt:null },
+];
+
+let statusFilter = "ALL";
+
+/* ----- helpers ----- */
+function statusMeta(s){ return s==="ACTIVE"
+  ? ["ACTIVE","ts-ACTIVE","bi-check-circle-fill"]
+  : ["SUSPENDED","ts-SUSPENDED","bi-pause-circle-fill"]; }
+function fmtDate(d){ return d ? d.replace(/-/g,"/") : "—"; }
+function initial(name){ const m=name.match(/[A-Za-zＡ-Ｚ]|[ァ-ヶ]|[一-龠]|[ぁ-ん]/); return (m?m[0]:name[0]); }
+function nf(n){ return n.toLocaleString("ja-JP"); }
+
+/* ----- list render(状態フィルタ + 名前部分一致)----- */
+function visibleTenants(){
+  const kw = (document.getElementById("nameSearch").value||"").trim().toLowerCase();
+  return TENANTS
+    .filter(t=> statusFilter==="ALL" || t.status===statusFilter)
+    .filter(t=> !kw || t.name.toLowerCase().includes(kw) || (t.code||"").includes(kw))
+    .slice().sort((a,b)=> b.createdAt.localeCompare(a.createdAt)); /* createdAt DESC */
+}
+function rowHTML(t){
+  const [sl,sc,si]=statusMeta(t.status);
+  return `<tr class="${t.status==='SUSPENDED'?'is-suspended':''}" onclick="openDetail(${t.id})">
+    <td>
+      <div class="d-flex align-items-center gap-2">
+        <span class="t-avatar">${initial(t.name)}</span>
+        <div>
+          <div class="t-name">${t.name}</div>
+          <div class="t-id">ID ${t.id} ・ <code>${t.code}</code> ・ <span class="plan-badge">${t.plan}</span></div>
+        </div>
+      </div>
+    </td>
+    <td class="col-status"><span class="ts-badge ${sc}"><i class="bi ${si}"></i>${sl}</span></td>
+    <td class="col-users num">${nf(t.userCount)}</td>
+    <td class="col-tasks num">${nf(t.taskCount)}</td>
+    <td class="col-created">${fmtDate(t.createdAt)}</td>
+    <td class="col-chevron"><i class="bi bi-chevron-right row-chevron"></i></td>
+  </tr>`;
+}
+function renderList(){
+  const list = visibleTenants();
+  document.getElementById("listBody").innerHTML = list.length
+    ? list.map(rowHTML).join("")
+    : `<tr class="empty-row"><td colspan="6"><i class="bi bi-inbox me-1"></i>該当するテナントはありません</td></tr>`;
+  document.getElementById("listCount").textContent = `${list.length} 件`;
+  document.getElementById("pagerTotal").textContent = list.length;
+  document.getElementById("pagerShown").textContent = list.length;
+  document.getElementById("totalUsers").textContent = nf(TENANTS.reduce((s,t)=>s+t.userCount,0));
+}
+function setStatusFilter(v){
+  statusFilter=v;
+  [...document.querySelectorAll("#statusSeg button")].forEach(b=>b.classList.toggle("on", b.dataset.v===v));
+  renderList();
+}
+
+/* ----- S-14 詳細ドロワー ----- */
+function openDetail(id){
+  renderDetail(id);
+  bootstrap.Offcanvas.getOrCreateInstance(document.getElementById("detailDrawer")).show();
+}
+function renderDetail(id){
+  const t=TENANTS.find(x=>x.id===id);
+  const [sl,sc,si]=statusMeta(t.status);
+  const isActive = t.status==="ACTIVE";
+  document.getElementById("detailLabel").innerHTML =
+    `<i class="bi bi-buildings text-primary"></i>テナント詳細 <span class="text-muted-2 small">#${t.id}</span>`;
+  document.getElementById("detailBody").innerHTML = `
+    <div class="text-muted-2 small mb-2"><i class="bi bi-link-45deg"></i> URL は <code>/admin/tenants/${t.id}</code> に同期(S-14)</div>
+
+    <div class="d-flex align-items-center gap-2 mb-2">
+      <span class="ts-badge ${sc}"><i class="bi ${si}"></i>${sl}</span>
+      <span class="plan-badge">${t.plan}</span>
+      <span class="text-muted-2 small ms-auto"><code>${t.code}</code></span>
+    </div>
+
+    <div class="drawer-section-label">テナント名 <span class="api"><code>PUT /api/tenants/${t.id}</code>(A-06)</span></div>
+    <div id="nameView" class="name-edit-wrap">
+      <span class="editable-name" onclick="startNameEdit(${t.id})" title="クリックで編集(SaaS Admin)">${t.name}</span>
+      <button class="btn btn-sm btn-light ms-auto" onclick="startNameEdit(${t.id})"><i class="bi bi-pencil"></i></button>
+    </div>
+
+    <div class="drawer-section-label">参考メトリクス <span class="api">参照のみ</span></div>
+    <div class="row g-2">
+      <div class="col-6"><div class="metric-box"><div class="m-num">${nf(t.userCount)}</div><div class="m-lbl">所属ユーザー数</div><div class="m-note">/ 最大 50 名</div></div></div>
+      <div class="col-6"><div class="metric-box"><div class="m-num">${nf(t.taskCount)}</div><div class="m-lbl">タスク数</div><div class="m-note">業務データ(無傷)</div></div></div>
+    </div>
+
+    <div class="drawer-section-label">タイムスタンプ</div>
+    <div class="row g-2">
+      <div class="col-6"><div class="text-muted-2" style="font-size:11px;">作成日</div><div class="field-readonly">${fmtDate(t.createdAt)}</div></div>
+      <div class="col-6"><div class="text-muted-2" style="font-size:11px;">更新日</div><div class="field-readonly">${fmtDate(t.updatedAt)}</div></div>
+      ${t.suspendedAt?`<div class="col-12"><div class="text-muted-2" style="font-size:11px;">停止日</div><div class="field-readonly" style="color:var(--c-suspended);">${fmtDate(t.suspendedAt)} に SUSPENDED</div></div>`:''}
+    </div>
+
+    <div class="drawer-section-label">状態切替 <span class="api"><code>PATCH /api/tenants/${t.id}/status</code>(A-26)</span></div>
+    <div class="consequence mb-3">
+      <i class="bi bi-info-circle me-1"></i>${isActive
+        ? '停止すると所属ユーザーは当該テナントへの業務 API アクセスが 403 で拒否されます(ログイン自体は通過、データは無傷)。'
+        : '再有効化すると所属ユーザーの業務 API アクセスが復帰します。'}
+      監査ログに <span class="audit-chip">${isActive?'TENANT_SUSPENDED':'TENANT_REACTIVATED'}</span> を記録。
+    </div>
+    ${isActive
+      ? `<button class="btn btn-outline-warning w-100" onclick="confirmStatus(${t.id})"><i class="bi bi-pause-circle me-1"></i>このテナントを停止(SUSPEND)</button>`
+      : `<button class="btn btn-success w-100" onclick="confirmStatus(${t.id})"><i class="bi bi-play-circle me-1"></i>このテナントを再有効化(ACTIVATE)</button>`}
+    <div class="text-muted-2 small mt-2 text-center"><i class="bi bi-shield-check me-1"></i>操作可能なのは SaaS Admin(APP_ADMIN)のみ</div>
+  `;
+}
+
+/* ----- テナント名 行内編集 ----- */
+function startNameEdit(id){
+  const t=TENANTS.find(x=>x.id===id);
+  const host=document.getElementById("nameView");
+  host.innerHTML = `<input id="nameInput" value="${t.name.replace(/"/g,'&quot;')}" maxlength="255" />
+    <button class="btn btn-sm btn-primary" onclick="commitName(${id})"><i class="bi bi-check-lg"></i></button>
+    <button class="btn btn-sm btn-light" onclick="renderDetail(${id})">取消</button>`;
+  const inp=document.getElementById("nameInput"); inp.focus(); inp.select();
+  inp.addEventListener("keydown",e=>{ if(e.key==="Enter")commitName(id); if(e.key==="Escape")renderDetail(id); });
+}
+function commitName(id){
+  const t=TENANTS.find(x=>x.id===id);
+  const v=(document.getElementById("nameInput").value||"").trim();
+  if(v){ t.name=v; t.updatedAt="2026-06-02"; toast(`テナント名を「${v}」に更新しました`,"success"); }
+  renderDetail(id); renderList();
+}
+
+/* ----- 状態切替 確認モーダル(案A: 停止は名前入力確認 / 再有効化は簡易)----- */
+function confirmStatus(id){
+  const t=TENANTS.find(x=>x.id===id);
+  const toSuspend = t.status==="ACTIVE";
+  const body = toSuspend
+    ? `<div class="modal-header border-0 pb-0">
+         <div class="d-flex align-items-start gap-3">
+           <div class="modal-warn-icon warn-suspend"><i class="bi bi-pause-circle-fill"></i></div>
+           <div><h5 class="modal-title mb-1">テナントを停止しますか?</h5>
+           <div class="text-muted-2 small">${t.name}(ID ${t.id})</div></div>
+         </div>
+         <button type="button" class="btn-close ms-auto" data-bs-dismiss="modal"></button>
+       </div>
+       <div class="modal-body">
+         <div class="consequence mb-3">所属ユーザー <b>${nf(t.userCount)} 名</b>はログインはできますが、当該テナントの業務 API アクセスが <b>403</b> で拒否されます。タスク <b>${nf(t.taskCount)} 件</b>を含むデータは削除されず、いつでも再有効化できます。</div>
+         <label class="form-label small fw-bold">確認のためテナント名を入力してください</label>
+         <input id="confirmName" class="form-control" placeholder="${t.name}" oninput="document.getElementById('doStatusBtn').disabled = this.value.trim() !== '${t.name}'" />
+         <div class="form-text">監査ログに <span class="audit-chip">TENANT_SUSPENDED</span> として記録されます。</div>
+       </div>
+       <div class="modal-footer border-0 pt-0">
+         <button class="btn btn-light" data-bs-dismiss="modal">取消</button>
+         <button id="doStatusBtn" class="btn btn-warning" disabled onclick="applyStatus(${t.id})"><i class="bi bi-pause-circle me-1"></i>停止する</button>
+       </div>`
+    : `<div class="modal-header border-0 pb-0">
+         <div class="d-flex align-items-start gap-3">
+           <div class="modal-warn-icon warn-reactivate"><i class="bi bi-play-circle-fill"></i></div>
+           <div><h5 class="modal-title mb-1">テナントを再有効化しますか?</h5>
+           <div class="text-muted-2 small">${t.name}(ID ${t.id})</div></div>
+         </div>
+         <button type="button" class="btn-close ms-auto" data-bs-dismiss="modal"></button>
+       </div>
+       <div class="modal-body">
+         <div class="consequence">所属ユーザー <b>${nf(t.userCount)} 名</b>の業務 API アクセスが復帰します。監査ログに <span class="audit-chip">TENANT_REACTIVATED</span> を記録します。</div>
+       </div>
+       <div class="modal-footer border-0 pt-0">
+         <button class="btn btn-light" data-bs-dismiss="modal">取消</button>
+         <button id="doStatusBtn" class="btn btn-success" onclick="applyStatus(${t.id})"><i class="bi bi-play-circle me-1"></i>再有効化する</button>
+       </div>`;
+  document.getElementById("statusModalContent").innerHTML = body;
+  bootstrap.Modal.getOrCreateInstance(document.getElementById("statusModal")).show();
+}
+function applyStatus(id){
+  const t=TENANTS.find(x=>x.id===id);
+  const wasActive = t.status==="ACTIVE";
+  t.status = wasActive ? "SUSPENDED" : "ACTIVE";
+  t.updatedAt = "2026-06-02";
+  t.suspendedAt = wasActive ? "2026-06-02" : null;
+  bootstrap.Modal.getInstance(document.getElementById("statusModal")).hide();
+  renderDetail(id); renderList();
+  toast(wasActive ? `「${t.name}」を停止しました(TENANT_SUSPENDED)` : `「${t.name}」を再有効化しました(TENANT_REACTIVATED)`, wasActive?"warn":"success");
+}
+
+/* ----- toast ----- */
+function toast(msg,kind){
+  const el=document.createElement("div");
+  const color = kind==="success" ? "#207a3a" : kind==="warn" ? "#b8650b" : "#3f4855";
+  const icon  = kind==="success" ? "bi-check-circle-fill" : kind==="warn" ? "bi-pause-circle-fill" : "bi-info-circle-fill";
+  el.className="shadow-sm";
+  el.style.cssText=`background:#fff;border:1px solid var(--app-border);border-left:4px solid ${color};border-radius:9px;padding:11px 14px;font-size:13px;max-width:340px;display:flex;align-items:center;gap:9px;`;
+  el.innerHTML=`<i class="bi ${icon}" style="color:${color};font-size:16px;"></i><span>${msg}</span>`;
+  document.getElementById("toastHost").appendChild(el);
+  setTimeout(()=>{ el.style.transition="opacity .4s"; el.style.opacity="0"; setTimeout(()=>el.remove(),400); }, 3200);
+}
+
+renderList();
+</script>
+</body>
+</html>

--- a/docs/specs/ui/screens/tenant-admin/option-b-admin-console.html
+++ b/docs/specs/ui/screens/tenant-admin/option-b-admin-console.html
@@ -1,0 +1,826 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>S-13 / S-14 テナント管理 — 案B 管理コンソール風(ハイファイ)</title>
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous" />
+<link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet" />
+<link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet" />
+<style>
+  :root{
+    --bs-body-font-family:"Noto Sans JP", system-ui, -apple-system, "Segoe UI", sans-serif;
+    --app-bg:#f4f5f7;--app-surface:#ffffff;--app-border:#e5e7eb;--app-ink:#1f2733;--app-muted:#6b7280;
+    --app-primary:#3b5bdb;--app-primary-d:#2f49b0;
+    --c-overdue:#e03131;--c-today:#e8830c;--c-soon:#1c7ed6;--c-done:#2f9e44;
+    /* 管理コンソール = 別空間。濃色スレート + ティールで業務動線と視覚分離 */
+    --console-band:#1b212e;--console-band-2:#242c3c;--console-line:#333d52;
+    --console-accent:#13a394;--console-accent-d:#0f8678;--console-accent-soft:#e3f5f2;--console-accent-border:#bfe7e1;
+    --c-active:#2f9e44;--c-suspended:#b8650b;
+    --ring:0 0 0 3px rgba(19,163,148,.26);
+    --ring-warn:0 0 0 3px rgba(184,101,11,.20);
+    --shadow-xs:0 1px 2px rgba(20,26,38,.06);
+    --shadow-sm:0 2px 6px rgba(20,26,38,.07);
+    --shadow-md:0 8px 26px rgba(20,26,38,.12);
+    --shadow-pop:0 14px 44px rgba(15,20,30,.20);
+    --bs-body-bg:var(--app-bg);--bs-body-color:var(--app-ink);
+  }
+  *{scrollbar-width:thin;scrollbar-color:#c7ccd6 transparent;}
+  body{font-family:var(--bs-body-font-family);font-size:14px;-webkit-font-smoothing:antialiased;}
+  .text-muted-2{color:var(--app-muted)!important;}
+  code{color:#0f766e;background:#e6f4f1;padding:1px 5px;border-radius:4px;font-size:.86em;}
+  .btn{transition:background .14s,border-color .14s,color .14s,box-shadow .14s,transform .05s;}
+  .btn:active{transform:translateY(.5px);}
+  .btn:focus-visible,.form-control:focus-visible,.seg button:focus-visible,a:focus-visible{outline:none;box-shadow:var(--ring);}
+  .form-control:focus{border-color:var(--console-accent);box-shadow:var(--ring);}
+  .btn-success{background:var(--c-active);border-color:var(--c-active);}
+  .btn-success:hover{background:#268339;border-color:#268339;}
+  .btn-warning{background:#e8930f;border-color:#e8930f;color:#fff;}
+  .btn-warning:hover{background:#cf820b;border-color:#cf820b;color:#fff;}
+  .btn-outline-warning{color:#b8650b;border-color:#eccb97;}
+  .btn-outline-warning:hover{background:#b8650b;border-color:#b8650b;color:#fff;}
+  .btn-teal{background:var(--console-accent);border-color:var(--console-accent);color:#04332e;font-weight:600;}
+  .btn-teal:hover{background:var(--console-accent-d);border-color:var(--console-accent-d);color:#04332e;}
+  ::selection{background:#c9efe9;}
+  @keyframes shimmer{0%{background-position:-460px 0;}100%{background-position:460px 0;}}
+  /* 注: 視認性を opacity に依存させない。アニメ未実行/凍結時も内容は常に表示される(transform のみ動かす)。 */
+  @keyframes fadeUp{from{transform:translateY(7px);}to{transform:none;}}
+  @keyframes spinp{to{transform:rotate(360deg);}}
+  .fade-up{animation:fadeUp .26s ease both;}
+
+  /* ---- コンソール トップバー(濃色帯)---- */
+  .console-navbar{background:linear-gradient(180deg,#1f2634 0%,var(--console-band) 100%);height:56px;color:#e7eaf0;
+    border-bottom:1px solid #0f1420;box-shadow:0 1px 0 rgba(255,255,255,.03) inset;}
+  .console-brand{font-weight:700;letter-spacing:.02em;color:#fff;display:flex;align-items:center;gap:8px;}
+  .console-brand .bi{color:var(--console-accent);}
+  .console-tag{font-size:11px;font-weight:700;letter-spacing:.08em;text-transform:uppercase;color:#a9b7c9;
+    border:1px solid var(--console-line);padding:3px 10px;border-radius:6px;display:inline-flex;align-items:center;gap:6px;background:rgba(255,255,255,.02);}
+  .role-badge{font-size:10.5px;font-weight:700;letter-spacing:.04em;background:var(--console-accent);color:#04332e;padding:2px 8px;border-radius:5px;}
+  .console-user{color:#cdd5e1;}
+  .nav-ic{width:34px;height:34px;border-radius:8px;display:grid;place-items:center;color:#aeb9cb;font-size:16px;cursor:pointer;transition:background .14s,color .14s;}
+  .nav-ic:hover{background:#2c3548;color:#fff;}
+
+  /* ---- モック状態プレビューバー(本番非表示)---- */
+  .mock-bar{background:#11161f;border-bottom:1px dashed #36425a;padding:7px 16px;display:flex;align-items:center;gap:14px;flex-wrap:wrap;position:sticky;top:56px;z-index:1019;}
+  .mock-tag{font-size:10px;font-weight:700;letter-spacing:.06em;color:#7e8aa0;text-transform:uppercase;display:flex;align-items:center;gap:5px;}
+  .seg{display:inline-flex;border:1px solid #2c3548;border-radius:8px;overflow:hidden;background:#1a202c;box-shadow:var(--shadow-xs);}
+  .seg button{border:none;background:transparent;font-size:12px;font-weight:600;color:#9fb0c4;padding:5px 11px;cursor:pointer;border-right:1px solid #2c3548;display:flex;align-items:center;gap:5px;transition:background .14s,color .14s;}
+  .seg button:last-child{border-right:none;}
+  .seg button:hover:not(.on){background:#222a3a;color:#dfe6ef;}
+  .seg button.on{background:var(--console-accent);color:#04332e;}
+
+  .app-layout{display:flex;min-height:calc(100vh - 56px);}
+  /* ---- コンソール サイドナビ(濃色)---- */
+  .console-sidebar{width:238px;flex:0 0 238px;background:var(--console-band-2);border-right:1px solid var(--console-line);padding:16px 12px;}
+  .cnav-label{font-size:11px;font-weight:700;letter-spacing:.08em;color:#7e8aa0;text-transform:uppercase;padding:0 12px;margin:14px 0 6px;}
+  .cnav-link{display:flex;align-items:center;gap:10px;padding:9px 12px;border-radius:8px;color:#c2cad8;text-decoration:none;font-weight:500;font-size:13.5px;margin-bottom:2px;transition:background .14s,color .14s;position:relative;}
+  .cnav-link .bi{font-size:16px;color:#8794a8;transition:color .14s;}
+  .cnav-link:hover{background:#313b50;color:#fff;}
+  .cnav-link:hover .bi{color:#cfd8e6;}
+  .cnav-link.active{background:var(--console-accent);color:#04332e;font-weight:700;}
+  .cnav-link.active .bi{color:#04332e;}
+  .cnav-link.is-disabled{opacity:.5;cursor:not-allowed;}
+  .cnav-link .badge{margin-left:auto;background:#313b50!important;color:#9fb0c4!important;}
+  .cnav-note{font-size:11px;color:#9aa7bb;background:#1f283a;border:1px solid var(--console-line);border-radius:8px;padding:9px 11px;margin-top:14px;line-height:1.55;}
+
+  .app-main{flex:1 1 auto;min-width:0;padding:22px 26px 60px;}
+  .page-title{font-weight:700;font-size:21px;margin:0;letter-spacing:.01em;}
+  .page-sub{color:var(--app-muted);font-size:13px;}
+
+  .url-bar{display:inline-flex;align-items:center;gap:8px;background:#11161f;border:1px solid #2c3548;border-radius:8px;padding:6px 12px;font-size:12.5px;color:#9fb0c4;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;}
+  .url-bar .bi{color:var(--console-accent);}
+  .url-bar b{color:#e7eaf0;font-weight:600;}
+
+  /* ---- KPI ストリップ ---- */
+  .kpi-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:12px;}
+  @media(max-width:900px){.kpi-grid{grid-template-columns:repeat(2,1fr);}}
+  .kpi{background:var(--app-surface);border:1px solid var(--app-border);border-radius:12px;padding:14px 16px;box-shadow:var(--shadow-xs);position:relative;overflow:hidden;}
+  .kpi .k-ic{position:absolute;right:12px;top:12px;font-size:20px;opacity:.16;}
+  .kpi .k-lbl{font-size:11.5px;color:var(--app-muted);font-weight:500;display:flex;align-items:center;gap:6px;}
+  .kpi .k-num{font-size:27px;font-weight:700;line-height:1.15;margin-top:5px;font-variant-numeric:tabular-nums;letter-spacing:.01em;}
+  .kpi .k-sub{font-size:10.5px;color:#aab0ba;margin-top:1px;}
+  .kpi.k-active{border-left:4px solid var(--c-active);}
+  .kpi.k-suspended{border-left:4px solid var(--c-suspended);}
+  .kpi.k-accent{border-left:4px solid var(--console-accent);}
+
+  /* ---- フィルタ ---- */
+  .filter-bar{background:var(--app-surface);border:1px solid var(--app-border);border-radius:12px;box-shadow:var(--shadow-xs);}
+  .filter-bar-head{display:flex;align-items:center;gap:10px;padding:12px 16px;flex-wrap:wrap;}
+  .filter-bar-title{font-size:13px;font-weight:600;color:#3f4855;display:flex;align-items:center;gap:7px;}
+  .fseg{display:inline-flex;border:1px solid var(--app-border);border-radius:8px;overflow:hidden;background:#fff;}
+  .fseg button{border:none;background:#fff;font-size:12.5px;font-weight:600;color:#566173;padding:6px 14px;cursor:pointer;border-right:1px solid var(--app-border);display:flex;align-items:center;gap:6px;transition:background .14s,color .14s;}
+  .fseg button:last-child{border-right:none;}
+  .fseg button:hover:not(.on){background:#eef7f5;}
+  .fseg button.on{background:var(--console-accent);color:#fff;}
+  .fseg button .pill{font-size:10px;font-weight:700;background:rgba(0,0,0,.08);border-radius:20px;padding:0 6px;min-width:17px;text-align:center;}
+  .fseg button.on .pill{background:rgba(255,255,255,.28);}
+  .search-wrap{position:relative;}
+  .search-wrap .bi-search{position:absolute;left:11px;top:50%;transform:translateY(-50%);color:#9aa1ad;font-size:14px;}
+  .search-wrap input{padding-left:32px;padding-right:30px;width:260px;}
+  .search-clear{position:absolute;right:7px;top:50%;transform:translateY(-50%);border:none;background:#eceef1;color:#6b7280;width:19px;height:19px;border-radius:50%;display:none;place-items:center;font-size:11px;cursor:pointer;}
+  .search-clear:hover{background:#dfe2e7;}
+  .search-clear.show{display:grid;}
+  .active-chips{display:flex;gap:7px;flex-wrap:wrap;}
+  .a-chip{font-size:11.5px;font-weight:500;background:var(--console-accent-soft);color:#0f766e;border:1px solid var(--console-accent-border);border-radius:999px;padding:3px 6px 3px 11px;display:inline-flex;align-items:center;gap:6px;}
+  .a-chip button{border:none;background:none;color:#0f766e;line-height:1;padding:0;cursor:pointer;display:grid;place-items:center;}
+
+  /* ---- テーブル ---- */
+  .panel{background:var(--app-surface);border:1px solid var(--app-border);border-radius:12px;margin-top:14px;overflow:hidden;box-shadow:var(--shadow-sm);}
+  .panel-head{display:flex;align-items:center;gap:10px;padding:13px 18px;border-bottom:1px solid var(--app-border);}
+  .panel-head .p-icon{width:26px;height:26px;border-radius:7px;display:grid;place-items:center;color:#04332e;font-size:14px;background:var(--console-accent);}
+  .panel-head h2{font-size:15px;font-weight:700;margin:0;}
+  .panel-head .p-count{font-size:12px;color:var(--app-muted);font-weight:500;}
+  .panel-head .p-api{font-size:11px;color:#9aa1ad;margin-left:auto;font-weight:400;}
+  table.tenants{width:100%;margin:0;border-collapse:collapse;}
+  table.tenants th{font-size:11px;font-weight:600;color:#9aa1ad;text-transform:uppercase;letter-spacing:.04em;padding:9px 18px;border-bottom:1px solid var(--app-border);text-align:left;background:#fafbfc;white-space:nowrap;}
+  table.tenants th.num{text-align:right;}
+  table.tenants th.sortable{cursor:pointer;user-select:none;}
+  table.tenants th.sortable:hover{color:#566173;}
+  table.tenants th .bi{font-size:10px;opacity:.7;}
+  table.tenants td{padding:13px 18px;border-bottom:1px solid #f1f2f4;vertical-align:middle;}
+  table.tenants td.num{text-align:right;font-variant-numeric:tabular-nums;}
+  table.tenants tr:last-child td{border-bottom:none;}
+  table.tenants tbody tr.trow{cursor:pointer;transition:background .12s;}
+  table.tenants tbody tr.trow:hover{background:#eef7f5;}
+  table.tenants tbody tr.trow:hover .open-link{opacity:1;transform:translateX(0);}
+  table.tenants tbody tr.trow:hover .chev{transform:translateX(3px);}
+  table.tenants tbody tr.is-suspended{background:#fffdf8;}
+  table.tenants tbody tr.is-suspended:hover{background:#fff6ea;}
+  .t-name{font-weight:600;color:var(--app-ink);}
+  .t-id{font-size:11px;color:#9aa1ad;}
+  .t-avatar{width:32px;height:32px;border-radius:9px;background:var(--console-accent-soft);color:#0f766e;display:inline-grid;place-items:center;font-size:13px;font-weight:700;flex:0 0 32px;}
+  .col-status{width:130px;}.col-users{width:108px;}.col-tasks{width:108px;}.col-created{width:122px;}.col-chevron{width:78px;text-align:right;}
+  .open-link{font-size:11.5px;font-weight:600;color:var(--console-accent);opacity:0;transform:translateX(-4px);transition:opacity .14s,transform .14s;white-space:nowrap;}
+  .chev{display:inline-block;transition:transform .14s;color:var(--console-accent);}
+
+  .ts-badge{font-size:11.5px;font-weight:600;padding:4px 10px;border-radius:6px;display:inline-flex;align-items:center;gap:5px;border:1px solid transparent;}
+  .ts-ACTIVE{background:#e7f5ec;color:#207a3a;border-color:#c3e6cf;}
+  .ts-SUSPENDED{background:#fff3e2;color:#b8650b;border-color:#f3dcb6;}
+  .plan-badge{font-size:10.5px;font-weight:600;padding:2px 8px;border-radius:5px;background:#eef1f6;color:#566173;}
+
+  .pager{display:flex;align-items:center;gap:10px;padding:10px 18px;border-top:1px solid var(--app-border);font-size:12px;color:var(--app-muted);background:#fafbfc;}
+
+  /* ---- スケルトン ---- */
+  .sk{background:#eef0f3;background-image:linear-gradient(90deg,#eef0f3 0px,#f6f7f9 200px,#eef0f3 460px);background-size:920px 100%;border-radius:6px;animation:shimmer 1.25s infinite linear;display:inline-block;}
+  .sk-avatar{width:32px;height:32px;border-radius:9px;}
+
+  /* ---- 空状態 ---- */
+  .empty-state{padding:54px 20px;text-align:center;color:#9aa1ad;}
+  .empty-state .ei{width:64px;height:64px;border-radius:16px;background:#f1f3f6;color:#aeb6c2;display:grid;place-items:center;font-size:28px;margin:0 auto 14px;}
+  .empty-state h4{font-size:15px;font-weight:700;color:#5a6270;margin:0 0 4px;}
+
+  /* ---- S-14 フルページ ---- */
+  .crumb{font-size:12.5px;color:var(--app-muted);display:flex;align-items:center;gap:6px;}
+  .crumb a{color:var(--console-accent);text-decoration:none;font-weight:600;display:inline-flex;align-items:center;gap:5px;}
+  .crumb a:hover{text-decoration:underline;}
+  .detail-grid{display:grid;grid-template-columns:1fr 344px;gap:18px;align-items:start;}
+  @media(max-width:920px){.detail-grid{grid-template-columns:1fr;}}
+  .card-box{background:var(--app-surface);border:1px solid var(--app-border);border-radius:13px;overflow:hidden;box-shadow:var(--shadow-sm);}
+  .card-head{display:flex;align-items:center;gap:9px;padding:13px 18px;border-bottom:1px solid var(--app-border);}
+  .card-head .ci{width:25px;height:25px;border-radius:7px;display:grid;place-items:center;color:#04332e;font-size:13px;background:var(--console-accent);}
+  .card-head h2{font-size:13.5px;font-weight:700;margin:0;}
+  .card-head .api{font-size:11px;color:#9aa1ad;margin-left:auto;font-weight:500;}
+  .card-pad{padding:18px;}
+  .name-row{display:flex;align-items:center;gap:10px;}
+  .editable-name{font-size:24px;font-weight:700;border-bottom:1px dashed #b6bcc6;cursor:text;padding-bottom:2px;transition:background .12s,border-color .12s;}
+  .editable-name:hover{background:var(--console-accent-soft);border-bottom-color:var(--console-accent);}
+  .name-row input{font:inherit;font-size:22px;font-weight:700;border:1px solid var(--console-accent);border-radius:8px;padding:5px 11px;width:100%;box-shadow:var(--ring);}
+  .meta-row{display:flex;padding:11px 0;border-bottom:1px solid #f1f2f4;font-size:13.5px;}
+  .meta-row:last-child{border-bottom:none;}
+  .meta-row .mk{width:120px;flex:0 0 120px;color:var(--app-muted);font-size:12px;font-weight:600;}
+  .metric-box{background:#fcfdfd;border:1px solid var(--app-border);border-radius:10px;padding:14px;text-align:center;}
+  .metric-box .m-num{font-size:28px;font-weight:700;line-height:1.05;font-variant-numeric:tabular-nums;}
+  .metric-box .m-lbl{font-size:11.5px;color:var(--app-muted);margin-top:3px;}
+  .metric-box .m-note{font-size:10px;color:#aab0ba;margin-top:1px;}
+  .gauge{height:6px;border-radius:4px;background:#eef0f3;overflow:hidden;margin-top:9px;}
+  .gauge>i{display:block;height:100%;border-radius:4px;background:var(--console-accent);}
+  .consequence{font-size:12.5px;color:#5a6270;background:#fbfbfc;border:1px solid var(--app-border);border-radius:9px;padding:11px 13px;line-height:1.65;}
+  .audit-chip{font-size:10.5px;font-weight:700;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;background:#1b212e;color:#fff;padding:2px 7px;border-radius:4px;}
+  .status-hero{display:flex;align-items:center;gap:13px;padding:15px 17px;border-radius:12px;box-shadow:var(--shadow-xs);}
+  .status-hero.s-active{background:linear-gradient(180deg,#f1fbf4,#eef9f1);border:1px solid #c3e6cf;}
+  .status-hero.s-suspended{background:linear-gradient(180deg,#fff8ee,#fff6ea);border:1px solid #f3dcb6;}
+  .status-hero .sh-icon{font-size:27px;}
+  .status-hero.s-active .sh-icon{color:var(--c-active);}
+  .status-hero.s-suspended .sh-icon{color:var(--c-suspended);}
+
+  /* ---- エラー / フォールバック画面 ---- */
+  .errscreen{max-width:680px;margin:36px auto;}
+  .err-card{background:var(--app-surface);border:1px solid var(--app-border);border-radius:16px;box-shadow:var(--shadow-md);overflow:hidden;}
+  .err-top{padding:30px 32px 22px;display:flex;align-items:flex-start;gap:18px;}
+  .err-ic{width:60px;height:60px;border-radius:16px;display:grid;place-items:center;font-size:30px;flex:0 0 60px;}
+  .err-403{background:#fdecec;color:#c92a2a;}
+  .err-404{background:#eef2ff;color:#3b5bdb;}
+  .err-401{background:#fff3e2;color:#b8650b;}
+  .err-code-badge{font-size:11px;font-weight:700;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;padding:3px 9px;border-radius:6px;letter-spacing:.04em;}
+  .err-403 .err-code-badge,.err-top .err-code-badge.b-403{background:#fdecec;color:#c92a2a;}
+  .err-title{font-size:21px;font-weight:700;margin:8px 0 5px;letter-spacing:.01em;}
+  .err-msg{color:#5a6270;font-size:14px;line-height:1.7;}
+  .err-resp{margin:0 32px;border:1px solid var(--app-border);border-radius:11px;overflow:hidden;background:#fcfcfd;}
+  .err-resp-head{font-size:11px;font-weight:700;color:#7e8aa0;text-transform:uppercase;letter-spacing:.05em;padding:9px 14px;border-bottom:1px solid var(--app-border);background:#f7f8fa;display:flex;align-items:center;gap:7px;}
+  .err-resp pre{margin:0;padding:14px 16px;font-size:12.5px;line-height:1.65;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;color:#3f4855;white-space:pre-wrap;word-break:break-word;}
+  .err-resp .jk{color:#8a93a3;}.err-resp .js{color:#0f766e;}.err-resp .jn{color:#b8650b;}
+  .err-actions{padding:20px 32px 28px;display:flex;gap:10px;flex-wrap:wrap;}
+  .err-note{font-size:11.5px;color:#9aa1ad;padding:0 32px 26px;display:flex;align-items:center;gap:7px;}
+
+  /* ---- 確認モーダル ---- */
+  .modal-content{border:none;border-radius:15px;box-shadow:var(--shadow-pop);overflow:hidden;}
+  .modal-warn-icon{width:46px;height:46px;border-radius:50%;display:grid;place-items:center;font-size:22px;flex:0 0 46px;}
+  .warn-suspend{background:#fff3e2;color:#b8650b;}
+  .warn-reactivate{background:#e7f5ec;color:#207a3a;}
+  .spinner-x{width:15px;height:15px;border:2px solid rgba(255,255,255,.5);border-top-color:#fff;border-radius:50%;display:inline-block;animation:spinp .7s linear infinite;vertical-align:-2px;}
+
+  /* ---- toast ---- */
+  .toast-host{position:fixed;right:18px;bottom:18px;z-index:2000;display:flex;flex-direction:column;gap:8px;}
+  .ttoast{animation:fadeUp .26s ease both;}
+
+  .design-notes{margin-top:30px;border:1px dashed #c9ccd3;border-radius:12px;background:#fcfcfd;padding:18px 22px;}
+  .design-notes h3{font-size:13px;font-weight:700;letter-spacing:.04em;color:#5a6270;margin:0 0 10px;display:flex;align-items:center;gap:7px;}
+  .design-notes dl{display:grid;grid-template-columns:96px 1fr;gap:6px 14px;margin:0;font-size:12.5px;}
+  .design-notes dt{font-weight:700;color:#404856;}
+  .design-notes dd{margin:0;color:#5a6270;}
+</style>
+</head>
+<body>
+
+<!-- ===== コンソール トップバー ===== -->
+<nav class="console-navbar d-flex align-items-center px-3 gap-3 sticky-top">
+  <div class="console-brand"><i class="bi bi-hdd-stack-fill fs-5"></i>tasks-webapi</div>
+  <span class="console-tag"><i class="bi bi-shield-lock"></i>管理コンソール</span>
+  <div class="ms-auto d-flex align-items-center gap-2">
+    <span class="nav-ic" title="ヘルプ"><i class="bi bi-question-circle"></i></span>
+    <div class="d-flex align-items-center gap-2 ps-2">
+      <div class="rounded-circle d-grid" style="width:30px;height:30px;place-items:center;font-weight:700;font-size:12px;background:var(--console-accent);color:#04332e;">山</div>
+      <div class="d-none d-lg-block lh-1">
+        <div class="small fw-bold console-user">山田 太郎</div>
+        <span class="role-badge">APP_ADMIN</span>
+      </div>
+    </div>
+  </div>
+</nav>
+
+<!-- ===== モック状態プレビューバー(本番では非表示・レビュー用)===== -->
+<div class="mock-bar">
+  <span class="mock-tag"><i class="bi bi-easel2"></i>モック状態プレビュー</span>
+  <div class="seg" id="stateSeg">
+    <button class="on" data-s="normal" onclick="setState('normal')"><i class="bi bi-grid-3x3-gap"></i>通常(S-13)</button>
+    <button data-s="loading" onclick="setState('loading')"><i class="bi bi-hourglass-split"></i>ローディング</button>
+    <button data-s="empty" onclick="setState('empty')"><i class="bi bi-inbox"></i>結果0件</button>
+    <button data-s="403" onclick="setState('403')"><i class="bi bi-shield-x"></i>403</button>
+    <button data-s="404" onclick="setState('404')"><i class="bi bi-question-octagon"></i>404</button>
+    <button data-s="401" onclick="setState('401')"><i class="bi bi-person-x"></i>401</button>
+  </div>
+  <span class="mock-tag ms-auto d-none d-lg-flex"><i class="bi bi-info-circle"></i>access-matrix §8 のフォールバック動線を確認できます</span>
+</div>
+
+<div class="app-layout">
+  <!-- ===== コンソール サイドナビ ===== -->
+  <aside class="console-sidebar d-none d-lg-block">
+    <div class="cnav-label">プラットフォーム運用</div>
+    <a class="cnav-link active" href="#" onclick="goList();return false"><i class="bi bi-buildings"></i>テナント一覧 <span class="badge">S-13</span></a>
+    <a class="cnav-link is-disabled" href="#" onclick="return false" data-bs-toggle="tooltip" title="Sprint 1 以降(本 PR スコープ外)"><i class="bi bi-activity"></i>プラットフォーム監視 <span class="badge">S-12</span></a>
+    <a class="cnav-link is-disabled" href="#" onclick="return false" data-bs-toggle="tooltip" title="Tenant Admin 機能(本書スコープ外)"><i class="bi bi-journal-text"></i>監査ログ</a>
+
+    <div class="cnav-label">アカウント</div>
+    <a class="cnav-link" href="#" onclick="return false"><i class="bi bi-person-circle"></i>プロフィール</a>
+    <a class="cnav-link" href="#" onclick="return false"><i class="bi bi-box-arrow-right"></i>ログアウト</a>
+
+    <div class="cnav-note">
+      <i class="bi bi-diagram-3 me-1"></i>ここは <b>SaaS Admin 動線(運営空間)</b>。業務動線(S-03〜S-06)とは画面遷移として直結しません。業務タスク・visibility・3 役割評価はこの空間では効きません。
+    </div>
+  </aside>
+
+  <!-- ===== Main ===== -->
+  <main class="app-main">
+    <div id="listView"></div>      <!-- S-13 一覧 -->
+    <div id="detailView" style="display:none;"></div>  <!-- S-14 詳細 -->
+    <div id="errorView" style="display:none;"></div>   <!-- 403/404/401 -->
+  </main>
+</div>
+
+<!-- ===== 状態切替 確認モーダル ===== -->
+<div class="modal fade" id="statusModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered"><div class="modal-content" id="statusModalContent"></div></div>
+</div>
+<div class="toast-host" id="toastHost"></div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
+<script>
+/* ===================== データ ===================== */
+const CURRENT_USER = { name:"山田 太郎", role:"APP_ADMIN" };
+const NOW_ISO = "2026-06-02T11:24:51+09:00";
+const TENANTS = [
+  { id:1, code:"tenant-a",  name:"テナントA株式会社",       status:"ACTIVE",    plan:"FREE", userCount:18, taskCount:421,  createdAt:"2025-12-03", updatedAt:"2026-05-20", suspendedAt:null },
+  { id:2, code:"tenant-b",  name:"テナントB商事",           status:"ACTIVE",    plan:"FREE", userCount:32, taskCount:1247, createdAt:"2025-08-15", updatedAt:"2026-05-18", suspendedAt:null },
+  { id:3, code:"tenant-c",  name:"テナントC工業",           status:"SUSPENDED", plan:"FREE", userCount:11, taskCount:283,  createdAt:"2024-11-20", updatedAt:"2026-03-12", suspendedAt:"2026-03-12" },
+  { id:4, code:"demo",      name:"デモ用テナント",           status:"ACTIVE",    plan:"FREE", userCount:3,  taskCount:12,   createdAt:"2026-05-01", updatedAt:"2026-05-01", suspendedAt:null },
+  { id:5, code:"tenant-d",  name:"テナントD物流",           status:"ACTIVE",    plan:"FREE", userCount:25, taskCount:892,  createdAt:"2025-04-10", updatedAt:"2026-04-22", suspendedAt:null },
+  { id:6, code:"tenant-e",  name:"テナントEメディア",       status:"SUSPENDED", plan:"FREE", userCount:7,  taskCount:65,   createdAt:"2024-06-01", updatedAt:"2025-09-30", suspendedAt:"2025-09-30" },
+  { id:7, code:"tenant-f",  name:"テナントF不動産",         status:"ACTIVE",    plan:"FREE", userCount:42, taskCount:2103, createdAt:"2024-02-14", updatedAt:"2026-05-12", suspendedAt:null },
+  { id:8, code:"tenant-g",  name:"テナントGスタートアップ", status:"ACTIVE",    plan:"FREE", userCount:5,  taskCount:34,   createdAt:"2026-05-28", updatedAt:"2026-05-28", suspendedAt:null },
+];
+let statusFilter="ALL";
+let searchKw="";
+let sortField="createdAt", sortDir="desc";
+let currentView="list";   /* list | detail | error */
+let isLoading=false;
+
+/* ----- helpers ----- */
+function statusMeta(s){ return s==="ACTIVE"
+  ? ["ACTIVE","ts-ACTIVE","bi-check-circle-fill"]
+  : ["SUSPENDED","ts-SUSPENDED","bi-pause-circle-fill"]; }
+function fmtDate(d){ return d ? d.replace(/-/g,"/") : "—"; }
+function initial(name){ const m=name.match(/[A-Za-zＡ-Ｚ]|[ァ-ヶ]|[一-龠]|[ぁ-ん]/); return (m?m[0]:name[0]); }
+function nf(n){ return n.toLocaleString("ja-JP"); }
+function esc(s){ return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;'); }
+
+const PRI=null;
+function sortVal(t){ return sortField==="createdAt"?t.createdAt:sortField==="userCount"?t.userCount:sortField==="taskCount"?t.taskCount:sortField==="name"?t.name:t.createdAt; }
+function visibleTenants(){
+  const kw=searchKw.trim().toLowerCase();
+  let list=TENANTS
+    .filter(t=> statusFilter==="ALL" || t.status===statusFilter)
+    .filter(t=> !kw || t.name.toLowerCase().includes(kw) || (t.code||"").includes(kw));
+  const sgn=sortDir==="asc"?1:-1;
+  list=list.slice().sort((a,b)=>{ const av=sortVal(a),bv=sortVal(b); if(av<bv)return -1*sgn; if(av>bv)return 1*sgn; return 0; });
+  return list;
+}
+
+/* ===================== S-13 一覧ビュー ===================== */
+function listShellHTML(){
+  return `
+    <div class="d-flex align-items-center flex-wrap gap-3 mb-3">
+      <div>
+        <h1 class="page-title">テナント一覧</h1>
+        <div class="page-sub">SaaS Admin 専用・全テナントの運営状態を一望</div>
+      </div>
+      <div class="ms-auto url-bar"><i class="bi bi-hdd-network"></i><b>/admin/tenants</b></div>
+    </div>
+
+    <div class="kpi-grid mb-3">
+      <div class="kpi k-accent"><i class="bi bi-buildings k-ic"></i><div class="k-lbl">総テナント</div><div class="k-num" id="kTotal">—</div><div class="k-sub">登録済み全テナント</div></div>
+      <div class="kpi k-active"><i class="bi bi-check-circle-fill k-ic" style="color:var(--c-active);"></i><div class="k-lbl">ACTIVE</div><div class="k-num" id="kActive" style="color:var(--c-active);">—</div><div class="k-sub">業務 API 利用可</div></div>
+      <div class="kpi k-suspended"><i class="bi bi-pause-circle-fill k-ic" style="color:var(--c-suspended);"></i><div class="k-lbl">SUSPENDED</div><div class="k-num" id="kSusp" style="color:var(--c-suspended);">—</div><div class="k-sub">業務 API 403</div></div>
+      <div class="kpi k-accent"><i class="bi bi-people-fill k-ic"></i><div class="k-lbl">合計ユーザー</div><div class="k-num" id="kUsers">—</div><div class="k-sub">全テナント合算</div></div>
+    </div>
+
+    <div class="filter-bar">
+      <div class="filter-bar-head">
+        <span class="filter-bar-title"><i class="bi bi-funnel-fill"></i>状態</span>
+        <div class="fseg" id="statusSeg">
+          <button class="on" data-v="ALL" onclick="setStatusFilter('ALL')">すべて <span class="pill" id="pAll">0</span></button>
+          <button data-v="ACTIVE" onclick="setStatusFilter('ACTIVE')">ACTIVE <span class="pill" id="pAct">0</span></button>
+          <button data-v="SUSPENDED" onclick="setStatusFilter('SUSPENDED')">SUSPENDED <span class="pill" id="pSus">0</span></button>
+        </div>
+        <div class="active-chips" id="activeChips"></div>
+        <div class="search-wrap ms-auto">
+          <i class="bi bi-search"></i>
+          <input id="nameSearch" class="form-control form-control-sm" placeholder="テナント名で部分一致検索" autocomplete="off"
+            value="${esc(searchKw)}" oninput="onSearchInput(this.value)" />
+          <button class="search-clear ${searchKw?'show':''}" id="searchClear" onclick="clearSearch()" title="クリア"><i class="bi bi-x"></i></button>
+        </div>
+      </div>
+    </div>
+
+    <section class="panel">
+      <div class="panel-head">
+        <span class="p-icon"><i class="bi bi-buildings"></i></span>
+        <h2>テナント</h2><span class="p-count" id="listCount">—</span>
+        <span class="p-api"><code>GET /api/tenants</code>(A-04 listTenants)</span>
+      </div>
+      <table class="tenants">
+        <thead><tr>
+          <th class="sortable" onclick="cycleSort('name')">テナント ${sortCaret('name')}</th>
+          <th class="col-status">状態</th>
+          <th class="col-users num sortable" onclick="cycleSort('userCount')">ユーザー数 ${sortCaret('userCount')}</th>
+          <th class="col-tasks num sortable" onclick="cycleSort('taskCount')">タスク数 ${sortCaret('taskCount')}</th>
+          <th class="col-created sortable" onclick="cycleSort('createdAt')">作成日 ${sortCaret('createdAt')}</th>
+          <th class="col-chevron"></th>
+        </tr></thead>
+        <tbody id="listBody"></tbody>
+      </table>
+      <div class="pager">
+        <span>全 <b id="pagerTotal">0</b> 件中 1–<b id="pagerShown">0</b> 件を表示</span>
+        <div class="ms-auto d-flex align-items-center gap-1">
+          <button class="btn btn-sm btn-outline-secondary py-0 px-2" disabled>前へ</button>
+          <span class="px-2">1 / 1</span>
+          <button class="btn btn-sm btn-outline-secondary py-0 px-2" disabled>次へ</button>
+          <span class="ms-2">50 件 / ページ(<code>page</code> / <code>size</code>)</span>
+        </div>
+      </div>
+    </section>
+
+    <div class="design-notes">
+      <h3><i class="bi bi-clipboard-data"></i>設計判断ポイント — 案B 管理コンソール風(ハイファイ)</h3>
+      <dl>
+        <dt>強み</dt><dd>濃色トップバー + サイドナビ + 偽 URL バー + KPI ストリップで「運営空間」を強く分離。行クリックでフルページ遷移(<code>/admin/tenants/{id}</code>)し URL 直アクセスと UI 実体が一致。ローディング / 結果 0 件 / 403 / 404 / 401 のフォールバックまで作り込み、停止のような重い操作の文脈が明確。</dd>
+        <dt>弱み</dt><dd>一覧⇄詳細がページ遷移のため往復コストはドロワー案より高い。濃色 chrome は業務デザインシステムからの逸脱が大きく、共通カラートークンの追加メンテが必要。</dd>
+        <dt>想定読者</dt><dd>テナント運営を主務とする専任 SaaS Admin。1 件を腰を据えて確認・操作し、誤操作を確実に防ぎたい運用・サポート担当。</dd>
+      </dl>
+    </div>`;
+}
+
+function skeletonRows(n){
+  let h="";
+  for(let i=0;i<n;i++){
+    h+=`<tr>
+      <td><div class="d-flex align-items-center gap-2">
+        <span class="sk sk-avatar"></span>
+        <div><div class="sk" style="width:${120+(i%3)*36}px;height:13px;"></div>
+        <div class="sk mt-1" style="width:104px;height:10px;"></div></div></div></td>
+      <td class="col-status"><span class="sk" style="width:84px;height:22px;border-radius:6px;"></span></td>
+      <td class="col-users num"><span class="sk" style="width:36px;height:13px;"></span></td>
+      <td class="col-tasks num"><span class="sk" style="width:46px;height:13px;"></span></td>
+      <td class="col-created"><span class="sk" style="width:74px;height:13px;"></span></td>
+      <td class="col-chevron"></td>
+    </tr>`;
+  }
+  return h;
+}
+function rowHTML(t){
+  const [sl,sc,si]=statusMeta(t.status);
+  return `<tr class="trow ${t.status==='SUSPENDED'?'is-suspended':''}" onclick="goDetail(${t.id})" tabindex="0" onkeydown="if(event.key==='Enter')goDetail(${t.id})">
+    <td><div class="d-flex align-items-center gap-2">
+      <span class="t-avatar">${initial(t.name)}</span>
+      <div><div class="t-name">${esc(t.name)}</div>
+      <div class="t-id">ID ${t.id} ・ <code>${t.code}</code> ・ <span class="plan-badge">${t.plan}</span></div></div>
+    </div></td>
+    <td class="col-status"><span class="ts-badge ${sc}"><i class="bi ${si}"></i>${sl}</span></td>
+    <td class="col-users num">${nf(t.userCount)}</td>
+    <td class="col-tasks num">${nf(t.taskCount)}</td>
+    <td class="col-created">${fmtDate(t.createdAt)}</td>
+    <td class="col-chevron"><span class="open-link">開く</span> <i class="bi bi-chevron-right chev"></i></td>
+  </tr>`;
+}
+function emptyStateHTML(){
+  const filtered = statusFilter!=="ALL" || searchKw.trim();
+  return `<tr><td colspan="6"><div class="empty-state">
+    <div class="ei"><i class="bi bi-inbox"></i></div>
+    <h4>${filtered?'条件に一致するテナントがありません':'テナントがまだありません'}</h4>
+    <div class="mb-3">${filtered?'状態フィルタ・検索条件を変えてお試しください。':'セルフサインアップで作成されると、ここに表示されます。'}</div>
+    ${filtered?`<button class="btn btn-sm btn-teal" onclick="resetFilters()"><i class="bi bi-arrow-counterclockwise me-1"></i>条件をクリア</button>`:''}
+  </div></td></tr>`;
+}
+
+function paintList(){
+  const total=TENANTS.length;
+  const act=TENANTS.filter(t=>t.status==="ACTIVE").length;
+  const sus=TENANTS.filter(t=>t.status==="SUSPENDED").length;
+  setText("kTotal",total); setText("kActive",act); setText("kSusp",sus);
+  setText("kUsers",nf(TENANTS.reduce((s,t)=>s+t.userCount,0)));
+  setText("pAll",total); setText("pAct",act); setText("pSus",sus);
+  const list=visibleTenants();
+  document.getElementById("listBody").innerHTML = list.length ? list.map(rowHTML).join("") : emptyStateHTML();
+  setText("listCount",`${list.length} 件`);
+  setText("pagerTotal",list.length); setText("pagerShown",list.length);
+  renderActiveChips();
+}
+function setText(id,v){ const el=document.getElementById(id); if(el) el.textContent=v; }
+
+function renderActiveChips(){
+  const host=document.getElementById("activeChips"); if(!host) return;
+  const chips=[];
+  if(statusFilter!=="ALL") chips.push(`<span class="a-chip">状態: ${statusFilter}<button onclick="setStatusFilter('ALL')" title="解除"><i class="bi bi-x"></i></button></span>`);
+  if(searchKw.trim()) chips.push(`<span class="a-chip">検索: ${esc(searchKw.trim())}<button onclick="clearSearch()" title="解除"><i class="bi bi-x"></i></button></span>`);
+  host.innerHTML=chips.join("");
+}
+
+/* ----- filter / sort / search ----- */
+function setStatusFilter(v){
+  statusFilter=v;
+  [...document.querySelectorAll("#statusSeg button")].forEach(b=>b.classList.toggle("on", b.dataset.v===v));
+  paintList();
+}
+let searchTimer=null;
+function onSearchInput(v){
+  searchKw=v;
+  document.getElementById("searchClear").classList.toggle("show", !!v);
+  clearTimeout(searchTimer);
+  searchTimer=setTimeout(paintList,160); /* debounce */
+}
+function clearSearch(){ searchKw=""; const el=document.getElementById("nameSearch"); if(el){el.value="";el.focus();} document.getElementById("searchClear").classList.remove("show"); paintList(); }
+function resetFilters(){ statusFilter="ALL"; searchKw=""; renderList(); }
+function cycleSort(f){
+  if(sortField===f){ sortDir=sortDir==="asc"?"desc":"asc"; } else { sortField=f; sortDir=(f==="name")?"asc":"desc"; }
+  renderList();
+}
+function sortCaret(f){
+  if(sortField!==f) return `<i class="bi bi-chevron-expand"></i>`;
+  return sortDir==="asc"?`<i class="bi bi-caret-up-fill"></i>`:`<i class="bi bi-caret-down-fill"></i>`;
+}
+
+/* ===================== ビュー切替 ===================== */
+function showOnly(view){
+  currentView=view;
+  document.getElementById("listView").style.display   = view==="list"?"":"none";
+  document.getElementById("detailView").style.display = view==="detail"?"":"none";
+  document.getElementById("errorView").style.display  = view==="error"?"":"none";
+}
+function renderList(){
+  showOnly("list");
+  document.getElementById("listView").innerHTML=listShellHTML();
+  document.getElementById("listView").classList.add("fade-up");
+  paintList();
+  initTooltips();
+  syncStateSeg("normal");
+}
+function goList(){ window.scrollTo(0,0); renderList(); }
+
+function goDetail(id){
+  const t=TENANTS.find(x=>x.id===id);
+  if(!t){ return; }
+  window.scrollTo(0,0);
+  showOnly("detail");
+  renderDetail(id);
+}
+
+function renderDetail(id){
+  const t=TENANTS.find(x=>x.id===id);
+  const [sl,sc,si]=statusMeta(t.status);
+  const isActive=t.status==="ACTIVE";
+  const cap=Math.min(100,Math.round(t.userCount/50*100));
+  document.getElementById("detailView").className="fade-up";
+  document.getElementById("detailView").innerHTML = `
+    <div class="d-flex align-items-center flex-wrap gap-3 mb-3">
+      <div>
+        <div class="crumb mb-1"><a href="#" onclick="goList();return false"><i class="bi bi-buildings"></i> テナント一覧</a><i class="bi bi-chevron-right" style="font-size:10px;color:#c2c7d0;"></i><span>${esc(t.name)}</span></div>
+        <h1 class="page-title">${esc(t.name)}</h1>
+      </div>
+      <div class="ms-auto d-flex align-items-center gap-2">
+        <button class="btn btn-sm btn-light" onclick="goList()"><i class="bi bi-arrow-left me-1"></i>一覧へ <span class="text-muted-2 ms-1" style="font-size:11px;">Esc</span></button>
+        <span class="url-bar"><i class="bi bi-hdd-network"></i><b>/admin/tenants/${t.id}</b></span>
+      </div>
+    </div>
+
+    <div class="status-hero ${isActive?'s-active':'s-suspended'} mb-3">
+      <i class="bi ${si} sh-icon"></i>
+      <div>
+        <div class="fw-bold" style="font-size:15px;">現在の状態: ${sl}</div>
+        <div class="text-muted-2 small">${isActive
+          ? '所属ユーザーは業務 API を利用できます。'
+          : `${fmtDate(t.suspendedAt)} に停止。所属ユーザーの業務 API アクセスは 403 で拒否中(データは無傷)。`}</div>
+      </div>
+      <div class="ms-auto">
+        ${isActive
+          ? `<button class="btn btn-outline-warning" onclick="confirmStatus(${t.id})"><i class="bi bi-pause-circle me-1"></i>停止(SUSPEND)</button>`
+          : `<button class="btn btn-success" onclick="confirmStatus(${t.id})"><i class="bi bi-play-circle me-1"></i>再有効化(ACTIVATE)</button>`}
+      </div>
+    </div>
+
+    <div class="detail-grid">
+      <div class="d-flex flex-column gap-3">
+        <div class="card-box">
+          <div class="card-head"><span class="ci"><i class="bi bi-pencil-square"></i></span><h2>基本情報</h2><span class="api"><code>PUT /api/tenants/${t.id}</code>(A-06)</span></div>
+          <div class="card-pad">
+            <div class="text-muted-2 small mb-1 fw-bold">テナント名(編集可・SaaS Admin)</div>
+            <div id="nameRow" class="name-row mb-3">
+              <span class="editable-name" onclick="startNameEdit(${t.id})" title="クリックで編集">${esc(t.name)}</span>
+              <button class="btn btn-sm btn-light ms-auto" onclick="startNameEdit(${t.id})"><i class="bi bi-pencil me-1"></i>編集</button>
+            </div>
+            <div class="meta-row"><div class="mk">テナント ID</div><div>${t.id}</div></div>
+            <div class="meta-row"><div class="mk">コード</div><div><code>${t.code}</code></div></div>
+            <div class="meta-row"><div class="mk">プラン</div><div><span class="plan-badge">${t.plan}</span> <span class="text-muted-2 small">本フェーズ固定・契約管理は Phase 2</span></div></div>
+            <div class="meta-row"><div class="mk">作成日</div><div>${fmtDate(t.createdAt)}</div></div>
+            <div class="meta-row"><div class="mk">更新日</div><div>${fmtDate(t.updatedAt)}</div></div>
+            ${t.suspendedAt?`<div class="meta-row"><div class="mk">停止日</div><div style="color:var(--c-suspended);font-weight:600;">${fmtDate(t.suspendedAt)}</div></div>`:''}
+          </div>
+        </div>
+
+        <div class="card-box">
+          <div class="card-head"><span class="ci"><i class="bi bi-toggles"></i></span><h2>状態切替</h2><span class="api"><code>PATCH /api/tenants/${t.id}/status</code>(A-26)</span></div>
+          <div class="card-pad">
+            <div class="consequence mb-3">
+              <i class="bi bi-info-circle me-1"></i>${isActive
+                ? '停止すると所属ユーザーの業務 API アクセスが 403 で拒否されます(Keycloak ログイン自体は通過、データは無傷)。'
+                : '再有効化すると所属ユーザーの業務 API アクセスが復帰します。'}
+              実際に状態が変わった場合のみ監査ログに <span class="audit-chip">${isActive?'TENANT_SUSPENDED':'TENANT_REACTIVATED'}</span> を記録します。
+            </div>
+            ${isActive
+              ? `<button class="btn btn-outline-warning" onclick="confirmStatus(${t.id})"><i class="bi bi-pause-circle me-1"></i>このテナントを停止する</button>`
+              : `<button class="btn btn-success" onclick="confirmStatus(${t.id})"><i class="bi bi-play-circle me-1"></i>このテナントを再有効化する</button>`}
+            <div class="text-muted-2 small mt-2"><i class="bi bi-shield-check me-1"></i>操作可能なのは SaaS Admin(APP_ADMIN)のみ・<code>X-Tenant-Id</code> ヘッダ不要</div>
+          </div>
+        </div>
+      </div>
+
+      <div class="d-flex flex-column gap-3">
+        <div class="card-box">
+          <div class="card-head"><span class="ci"><i class="bi bi-bar-chart"></i></span><h2>参考メトリクス</h2><span class="api">参照のみ</span></div>
+          <div class="card-pad">
+            <div class="row g-2">
+              <div class="col-6"><div class="metric-box"><div class="m-num">${nf(t.userCount)}</div><div class="m-lbl">所属ユーザー数</div><div class="m-note">/ 最大 50 名</div><div class="gauge"><i style="width:${cap}%;"></i></div></div></div>
+              <div class="col-6"><div class="metric-box"><div class="m-num">${nf(t.taskCount)}</div><div class="m-lbl">タスク数</div><div class="m-note">業務データ</div></div></div>
+            </div>
+            <div class="consequence mt-3" style="font-size:11.5px;">
+              <i class="bi bi-shield-lock me-1"></i>これらは運営軸の参考値です。SaaS Admin は業務 API(<code>/api/tasks/**</code>)に到達できず、個々のタスク内容・visibility は参照しません。
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div style="height:24px;"></div>`;
+}
+
+/* ----- テナント名 行内編集(非同期保存)----- */
+function startNameEdit(id){
+  const t=TENANTS.find(x=>x.id===id);
+  const host=document.getElementById("nameRow");
+  host.innerHTML=`<input id="nameInput" value="${esc(t.name)}" maxlength="255" />
+    <button class="btn btn-sm btn-teal" id="nameSaveBtn" onclick="commitName(${id})"><i class="bi bi-check-lg me-1"></i>保存</button>
+    <button class="btn btn-sm btn-light" onclick="renderDetail(${id})">取消</button>`;
+  const inp=document.getElementById("nameInput"); inp.focus(); inp.select();
+  inp.addEventListener("keydown",e=>{ if(e.key==="Enter")commitName(id); if(e.key==="Escape"){e.stopPropagation();renderDetail(id);} });
+}
+function commitName(id){
+  const t=TENANTS.find(x=>x.id===id);
+  const v=(document.getElementById("nameInput").value||"").trim();
+  if(!v){ toast("テナント名を入力してください","warn"); return; }
+  const btn=document.getElementById("nameSaveBtn");
+  btn.disabled=true; btn.innerHTML=`<span class="spinner-x"></span> 保存中`;
+  setTimeout(()=>{   /* PUT /api/tenants/{id} を模擬 */
+    t.name=v; t.updatedAt="2026-06-02";
+    renderDetail(id);
+    toast(`テナント名を「${v}」に更新しました`,"success");
+  },650);
+}
+
+/* ----- 状態切替 確認(停止 = 厳格な名前入力 / 再有効化 = 簡易)----- */
+function confirmStatus(id){
+  const t=TENANTS.find(x=>x.id===id);
+  const toSuspend=t.status==="ACTIVE";
+  const body = toSuspend
+    ? `<div class="modal-header border-0 pb-0">
+         <div class="d-flex align-items-start gap-3">
+           <div class="modal-warn-icon warn-suspend"><i class="bi bi-pause-circle-fill"></i></div>
+           <div><h5 class="modal-title mb-1">テナントを停止しますか?</h5><div class="text-muted-2 small">${esc(t.name)}(ID ${t.id})</div></div>
+         </div>
+         <button type="button" class="btn-close ms-auto" data-bs-dismiss="modal"></button>
+       </div>
+       <div class="modal-body">
+         <div class="consequence mb-3">所属ユーザー <b>${nf(t.userCount)} 名</b>は当該テナントの業務 API アクセスが <b>403</b> で拒否され、ログインしても作業できなくなります。タスク <b>${nf(t.taskCount)} 件</b>を含むデータは無傷で残り、いつでも復活できます。</div>
+         <label class="form-label small fw-bold">確認のためテナント名 <code>${esc(t.name)}</code> を入力</label>
+         <input id="confirmName" class="form-control" autocomplete="off" placeholder="${esc(t.name)}" oninput="document.getElementById('doStatusBtn').disabled = this.value.trim() !== '${esc(t.name)}'" onkeydown="if(event.key==='Enter'&&!document.getElementById('doStatusBtn').disabled)applyStatus(${t.id})" />
+         <div class="form-text">監査ログに <span class="audit-chip">TENANT_SUSPENDED</span> として記録されます。</div>
+       </div>
+       <div class="modal-footer border-0 pt-0">
+         <button class="btn btn-light" data-bs-dismiss="modal">取消</button>
+         <button id="doStatusBtn" class="btn btn-warning" disabled onclick="applyStatus(${t.id})"><i class="bi bi-pause-circle me-1"></i>停止する</button>
+       </div>`
+    : `<div class="modal-header border-0 pb-0">
+         <div class="d-flex align-items-start gap-3">
+           <div class="modal-warn-icon warn-reactivate"><i class="bi bi-play-circle-fill"></i></div>
+           <div><h5 class="modal-title mb-1">テナントを再有効化しますか?</h5><div class="text-muted-2 small">${esc(t.name)}(ID ${t.id})</div></div>
+         </div>
+         <button type="button" class="btn-close ms-auto" data-bs-dismiss="modal"></button>
+       </div>
+       <div class="modal-body"><div class="consequence">所属ユーザー <b>${nf(t.userCount)} 名</b>の業務 API アクセスが復帰します。監査ログに <span class="audit-chip">TENANT_REACTIVATED</span> を記録します。</div></div>
+       <div class="modal-footer border-0 pt-0">
+         <button class="btn btn-light" data-bs-dismiss="modal">取消</button>
+         <button id="doStatusBtn" class="btn btn-success" onclick="applyStatus(${t.id})"><i class="bi bi-play-circle me-1"></i>再有効化する</button>
+       </div>`;
+  document.getElementById("statusModalContent").innerHTML=body;
+  const m=bootstrap.Modal.getOrCreateInstance(document.getElementById("statusModal"));
+  m.show();
+  setTimeout(()=>{ const c=document.getElementById("confirmName"); if(c)c.focus(); },300);
+}
+function applyStatus(id){
+  const t=TENANTS.find(x=>x.id===id);
+  const wasActive=t.status==="ACTIVE";
+  const btn=document.getElementById("doStatusBtn");
+  btn.disabled=true; btn.innerHTML=`<span class="spinner-x"></span> 処理中`;
+  setTimeout(()=>{   /* PATCH /api/tenants/{id}/status を模擬 */
+    t.status=wasActive?"SUSPENDED":"ACTIVE";
+    t.updatedAt="2026-06-02";
+    t.suspendedAt=wasActive?"2026-06-02":null;
+    bootstrap.Modal.getInstance(document.getElementById("statusModal")).hide();
+    renderDetail(id);
+    toast(wasActive?`「${t.name}」を停止しました(TENANT_SUSPENDED)`:`「${t.name}」を再有効化しました(TENANT_REACTIVATED)`, wasActive?"warn":"success");
+  },720);
+}
+
+/* ===================== エラー / フォールバック画面(access-matrix §8)===================== */
+const ERROR_DEFS = {
+  "403":{ cls:"err-403", ic:"bi-shield-lock-fill", http:"403 Forbidden",
+    code:"E_FORBIDDEN", apicode:"ROLE_BASED_DENIED", title:"この画面にはアクセスできません",
+    msg:"テナント管理コンソール(<code>/admin/tenants</code>)は <b>SaaS Admin(APP_ADMIN)専用</b>です。Tenant Admin / Member のロールでは到達できません。<code>@PreAuthorize(\"hasRole('APP_ADMIN')\")</code> 不通過。",
+    path:"/api/tenants", audit:"ROLE_BASED_DENIED",
+    actions:`<a class="btn btn-teal" href="#" onclick="return false"><i class="bi bi-speedometer2 me-1"></i>業務ダッシュボードへ戻る</a>
+             <a class="btn btn-light" href="#" onclick="return false"><i class="bi bi-box-arrow-right me-1"></i>別アカウントでログイン</a>`,
+    note:"フロント側でもナビゲーションリンクを非表示にし、API が 403 を返した場合は案内画面へ誘導します(多層防御)。" },
+  "404":{ cls:"err-404", ic:"bi-question-octagon-fill", http:"404 Not Found",
+    code:"E_NOT_FOUND", apicode:"VIEW_DENIED", title:"テナントが見つかりません",
+    msg:"指定 ID のテナントが存在しないか、参照できません(<code>GET /api/tenants/&#123;id&#125;</code> = A-25)。リソースの存在自体を漏らさないため、不可視リソースも一律 <b>404</b> を返します(NIST AC-4 整合)。",
+    path:"/api/tenants/9999", audit:"VIEW_DENIED",
+    actions:`<a class="btn btn-teal" href="#" onclick="goList();return false"><i class="bi bi-buildings me-1"></i>テナント一覧へ戻る</a>`,
+    note:"404 を受けたらリスト画面へ戻すフォールバック動線を用意します。" },
+  "401":{ cls:"err-401", ic:"bi-person-fill-lock", http:"401 Unauthorized",
+    code:"E_UNAUTHORIZED", apicode:"LOGIN_FAILED", title:"セッションの有効期限が切れました",
+    msg:"JWT が不正または期限切れです。Spring Security フィルタが最先で検出し <b>401</b> を返します(後続の 403 マッピングは発生しません)。クライアントはリフレッシュトークンで再認証 → リトライします。",
+    path:"/api/tenants", audit:"LOGIN_FAILED",
+    actions:`<a class="btn btn-teal" href="#" onclick="return false"><i class="bi bi-arrow-clockwise me-1"></i>再ログインして続行</a>`,
+    note:"期限切れは Keycloak へリダイレクトして再認証します。" },
+};
+function jsonResponse(d){
+  const lines=[
+    ['timestamp', `"${NOW_ISO}"`, 'js'],
+    ['status', d.http.split(' ')[0], 'jn'],
+    ['error', `"${d.http.split(' ').slice(1).join(' ')}"`, 'js'],
+    ['code', `"${d.code}"`, 'js'],
+    ['message', `"${d.apicode}"`, 'js'],
+    ['path', `"${d.path}"`, 'js'],
+  ];
+  const inner=lines.map((l,i)=>`  <span class="jk">"${l[0]}"</span>: <span class="${l[2]}">${l[1]}</span>${i<lines.length-1?',':''}`).join("\n");
+  return `{\n${inner}\n}`;
+}
+function renderError(code){
+  const d=ERROR_DEFS[code];
+  showOnly("error");
+  const ev=document.getElementById("errorView");
+  ev.className="fade-up";
+  ev.innerHTML=`
+    <div class="errscreen">
+      <div class="err-card">
+        <div class="err-top">
+          <div class="err-ic ${d.cls}"><i class="bi ${d.ic}"></i></div>
+          <div style="min-width:0;">
+            <div class="d-flex align-items-center gap-2">
+              <span class="err-code-badge ${d.cls==='err-403'?'b-403':''}" style="background:#f1f3f6;color:#566173;">HTTP ${d.http}</span>
+              <span class="err-code-badge" style="background:#1b212e;color:#fff;">${d.apicode}</span>
+            </div>
+            <div class="err-title">${d.title}</div>
+            <div class="err-msg">${d.msg}</div>
+          </div>
+        </div>
+        <div class="err-resp">
+          <div class="err-resp-head"><i class="bi bi-braces"></i>ErrorResponse(ADR-0011・6 フィールド)</div>
+          <pre>${jsonResponse(d)}</pre>
+        </div>
+        <div class="err-actions">${d.actions}</div>
+        <div class="err-note"><i class="bi bi-shield-check"></i>${d.note} 監査ログ action: <span class="audit-chip ms-1">${d.audit}</span></div>
+      </div>
+    </div>`;
+}
+
+/* ===================== モック状態プレビュー ===================== */
+function syncStateSeg(s){
+  [...document.querySelectorAll("#stateSeg button")].forEach(b=>b.classList.toggle("on", b.dataset.s===s));
+}
+function setState(s){
+  syncStateSeg(s);
+  if(s==="normal"){ renderList(); return; }
+  if(s==="loading"){
+    renderList();
+    document.getElementById("listBody").innerHTML=skeletonRows(6);
+    setText("listCount","読み込み中…");
+    ["kTotal","kActive","kSusp","kUsers"].forEach(id=>{const e=document.getElementById(id);if(e)e.innerHTML='<span class="sk" style="width:34px;height:20px;"></span>';});
+    return;
+  }
+  if(s==="empty"){
+    renderList();
+    document.getElementById("listBody").innerHTML=`<tr><td colspan="6"><div class="empty-state">
+      <div class="ei"><i class="bi bi-inbox"></i></div>
+      <h4>テナントがまだありません</h4>
+      <div>セルフサインアップ(<code>POST /api/tenants</code>)でテナントが作成されると、ここに表示されます。</div>
+    </div></td></tr>`;
+    setText("listCount","0 件"); setText("pagerTotal",0); setText("pagerShown",0);
+    return;
+  }
+  renderError(s); /* 403 / 404 / 401 */
+}
+
+/* ===================== toast ===================== */
+function toast(msg,kind){
+  const el=document.createElement("div");
+  el.className="ttoast";
+  const color=kind==="success"?"#207a3a":kind==="warn"?"#b8650b":"#3f4855";
+  const icon=kind==="success"?"bi-check-circle-fill":kind==="warn"?"bi-pause-circle-fill":"bi-info-circle-fill";
+  el.style.cssText=`background:#fff;border:1px solid var(--app-border);border-left:4px solid ${color};border-radius:9px;padding:11px 14px;font-size:13px;max-width:340px;display:flex;align-items:center;gap:9px;box-shadow:var(--shadow-md);`;
+  el.innerHTML=`<i class="bi ${icon}" style="color:${color};font-size:16px;"></i><span>${msg}</span>`;
+  document.getElementById("toastHost").appendChild(el);
+  setTimeout(()=>{ el.style.transition="opacity .4s,transform .4s"; el.style.opacity="0"; el.style.transform="translateY(6px)"; setTimeout(()=>el.remove(),420); },3200);
+}
+
+/* ===================== 共通 ===================== */
+let tipList=[];
+function initTooltips(){
+  tipList.forEach(t=>t.dispose&&t.dispose());
+  tipList=[...document.querySelectorAll('[data-bs-toggle="tooltip"]')].map(el=>new bootstrap.Tooltip(el));
+}
+/* Esc: 詳細/エラー → 一覧 */
+document.addEventListener("keydown",e=>{
+  if(e.key==="Escape" && (currentView==="detail"||currentView==="error")){
+    if(document.querySelector(".modal.show")) return;
+    goList();
+  }
+});
+
+/* 初期描画(軽いローディング → 一覧)*/
+function boot(){
+  document.getElementById("listView").innerHTML=listShellHTML();
+  document.getElementById("listBody").innerHTML=skeletonRows(6);
+  setText("listCount","読み込み中…");
+  setTimeout(()=>{ renderList(); }, 520);
+}
+boot();
+</script>
+</body>
+</html>

--- a/docs/specs/ui/screens/tenant-admin/option-c-master-detail.html
+++ b/docs/specs/ui/screens/tenant-admin/option-c-master-detail.html
@@ -1,0 +1,418 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>S-13 / S-14 テナント管理 — 案C マスターディテール(左一覧 + 右詳細)</title>
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous" />
+<link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet" />
+<link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet" />
+<style>
+  :root{
+    --bs-body-font-family:"Noto Sans JP", system-ui, -apple-system, "Segoe UI", sans-serif;
+    --app-bg:#f4f5f7;--app-surface:#ffffff;--app-border:#e5e7eb;--app-ink:#1f2733;--app-muted:#6b7280;
+    --app-primary:#3b5bdb;--app-primary-d:#2f49b0;
+    --c-overdue:#e03131;--c-today:#e8830c;--c-soon:#1c7ed6;--c-done:#2f9e44;
+    --admin-accent:#5a4bd6;--admin-accent-soft:#efeefb;--admin-accent-border:#ddd9f5;
+    --c-active:#2f9e44;--c-suspended:#b8650b;
+    --bs-body-bg:var(--app-bg);--bs-body-color:var(--app-ink);
+  }
+  body{font-family:var(--bs-body-font-family);font-size:14px;-webkit-font-smoothing:antialiased;}
+  .text-muted-2{color:var(--app-muted)!important;}
+  code{color:#6a44c4;background:#f1edfa;padding:1px 5px;border-radius:4px;font-size:.86em;}
+
+  .app-navbar{background:var(--app-surface);border-bottom:1px solid var(--app-border);height:56px;box-shadow:inset 0 3px 0 var(--admin-accent);}
+  .app-brand{font-weight:700;letter-spacing:.02em;color:var(--app-ink);}
+  .app-brand .bi{color:var(--app-primary);}
+  .console-chip{font-size:12px;background:var(--admin-accent-soft);color:var(--admin-accent);border:1px solid var(--admin-accent-border);padding:3px 11px;border-radius:999px;font-weight:700;display:inline-flex;align-items:center;gap:5px;}
+  .role-badge{font-size:10.5px;font-weight:700;letter-spacing:.04em;background:#2a3142;color:#fff;padding:2px 8px;border-radius:5px;}
+
+  .app-layout{display:flex;min-height:calc(100vh - 56px);}
+  .app-sidebar{width:218px;flex:0 0 218px;background:var(--app-surface);border-right:1px solid var(--app-border);padding:16px 12px;}
+  .nav-group-label{font-size:11px;font-weight:700;letter-spacing:.08em;color:#9aa1ad;text-transform:uppercase;padding:0 12px;margin:14px 0 6px;}
+  .side-link{display:flex;align-items:center;gap:10px;padding:9px 12px;border-radius:8px;color:#3f4855;text-decoration:none;font-weight:500;font-size:13.5px;margin-bottom:2px;}
+  .side-link .bi{font-size:16px;color:#7a828f;}
+  .side-link:hover{background:#f2f4f7;}
+  .side-link.active{background:var(--admin-accent-soft);color:var(--admin-accent);}
+  .side-link.active .bi{color:var(--admin-accent);}
+  .side-link.is-disabled{opacity:.55;cursor:not-allowed;}
+  .side-link .badge{margin-left:auto;}
+  .scope-note{font-size:11px;color:var(--app-muted);background:#fafaff;border:1px solid var(--admin-accent-border);border-radius:8px;padding:9px 11px;margin-top:14px;line-height:1.55;}
+
+  .app-main{flex:1 1 auto;min-width:0;padding:18px 22px 40px;display:flex;flex-direction:column;}
+  .page-title{font-weight:700;font-size:20px;margin:0;}
+  .page-sub{color:var(--app-muted);font-size:13px;}
+
+  /* ---- マスターディテール 2 分割 ---- */
+  .md-split{display:flex;gap:16px;align-items:stretch;flex:1 1 auto;min-height:0;}
+  .md-left{flex:0 0 392px;width:392px;display:flex;flex-direction:column;background:var(--app-surface);border:1px solid var(--app-border);border-radius:12px;overflow:hidden;}
+  .md-right{flex:1 1 auto;min-width:0;background:var(--app-surface);border:1px solid var(--app-border);border-radius:12px;overflow:hidden;display:flex;flex-direction:column;}
+  @media(max-width:1100px){.md-split{flex-direction:column;}.md-left{width:100%;flex-basis:auto;max-height:none;}}
+
+  .ml-head{padding:12px 14px;border-bottom:1px solid var(--app-border);background:#fafbfc;}
+  .ml-toolbar{display:flex;align-items:center;gap:8px;margin-bottom:9px;}
+  .ml-toolbar h2{font-size:14px;font-weight:700;margin:0;display:flex;align-items:center;gap:7px;}
+  .ml-toolbar .cnt{font-size:11.5px;color:var(--app-muted);}
+  .seg{display:inline-flex;border:1px solid var(--app-border);border-radius:7px;overflow:hidden;background:#fff;}
+  .seg button{border:none;background:#fff;font-size:11.5px;font-weight:600;color:#566173;padding:5px 10px;cursor:pointer;border-right:1px solid var(--app-border);}
+  .seg button:last-child{border-right:none;}
+  .seg button:hover:not(.on){background:#f4f6fb;}
+  .seg button.on{background:var(--admin-accent);color:#fff;}
+  .search-wrap{position:relative;flex:1 1 auto;}
+  .search-wrap .bi{position:absolute;left:10px;top:50%;transform:translateY(-50%);color:#9aa1ad;font-size:13px;}
+  .search-wrap input{padding-left:30px;width:100%;}
+
+  /* ---- 左: 簡易行リスト ---- */
+  .ml-list{overflow-y:auto;flex:1 1 auto;}
+  .t-item{display:flex;align-items:center;gap:11px;padding:11px 14px;border-bottom:1px solid #f1f2f4;cursor:pointer;border-left:3px solid transparent;}
+  .t-item:hover{background:#f7f8ff;}
+  .t-item.active{background:var(--admin-accent-soft);border-left-color:var(--admin-accent);}
+  .t-item.is-suspended .t-avatar{background:#fff3e2;color:#b8650b;}
+  .t-avatar{width:34px;height:34px;border-radius:9px;background:var(--admin-accent-soft);color:var(--admin-accent);display:inline-grid;place-items:center;font-size:14px;font-weight:700;flex:0 0 34px;}
+  .t-item .t-body{min-width:0;flex:1 1 auto;}
+  .t-item .t-name{font-weight:600;font-size:13.5px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
+  .t-item .t-meta{font-size:11px;color:var(--app-muted);display:flex;align-items:center;gap:8px;margin-top:1px;}
+  .t-item .t-meta .dot{width:3px;height:3px;border-radius:50%;background:#c2c7d0;}
+  .t-dot{width:9px;height:9px;border-radius:50%;flex:0 0 9px;}
+  .t-dot.d-active{background:var(--c-active);}
+  .t-dot.d-suspended{background:var(--c-suspended);}
+  .empty-list{text-align:center;color:#9aa1ad;padding:36px 14px;font-size:13px;}
+  .ml-foot{padding:8px 14px;border-top:1px solid var(--app-border);background:#fafbfc;font-size:11.5px;color:var(--app-muted);display:flex;align-items:center;gap:8px;}
+
+  /* ---- 右: 詳細 ---- */
+  .mr-scroll{overflow-y:auto;flex:1 1 auto;}
+  .mr-head{padding:18px 22px;border-bottom:1px solid var(--app-border);display:flex;align-items:flex-start;gap:14px;}
+  .mr-avatar{width:48px;height:48px;border-radius:12px;display:grid;place-items:center;font-size:20px;font-weight:700;flex:0 0 48px;background:var(--admin-accent-soft);color:var(--admin-accent);}
+  .editable-name{font-size:22px;font-weight:700;border-bottom:1px dashed #b6bcc6;cursor:text;padding-bottom:1px;}
+  .editable-name:hover{background:var(--admin-accent-soft);border-bottom-color:var(--admin-accent);}
+  .name-row input{font:inherit;font-size:20px;font-weight:700;border:1px solid var(--app-primary);border-radius:7px;padding:4px 10px;width:100%;max-width:380px;}
+  .mr-url{font-size:12px;color:var(--app-muted);font-family:ui-monospace,SFMono-Regular,Menlo,monospace;margin-top:4px;}
+  .mr-body{padding:20px 22px;}
+  .sec-label{font-size:11px;font-weight:700;color:#9aa1ad;text-transform:uppercase;letter-spacing:.05em;margin:0 0 9px;display:flex;align-items:center;gap:7px;}
+  .sec-label .api{margin-left:auto;font-weight:500;color:#b4bac4;text-transform:none;letter-spacing:0;}
+  .metric-box{background:#fff;border:1px solid var(--app-border);border-radius:10px;padding:13px;text-align:center;}
+  .metric-box .m-num{font-size:26px;font-weight:700;line-height:1.05;}
+  .metric-box .m-lbl{font-size:11.5px;color:var(--app-muted);margin-top:3px;}
+  .metric-box .m-note{font-size:10px;color:#aab0ba;margin-top:1px;}
+  .meta-row{display:flex;padding:10px 0;border-bottom:1px solid #f1f2f4;font-size:13.5px;}
+  .meta-row:last-child{border-bottom:none;}
+  .meta-row .mk{width:100px;flex:0 0 100px;color:var(--app-muted);font-size:12px;font-weight:600;}
+  .consequence{font-size:12.5px;color:#5a6270;background:#fbfbfc;border:1px solid var(--app-border);border-radius:9px;padding:11px 13px;line-height:1.65;}
+  .audit-chip{font-size:10.5px;font-weight:700;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;background:#2a3142;color:#fff;padding:2px 7px;border-radius:4px;}
+  .status-hero{display:flex;align-items:center;gap:12px;padding:13px 15px;border-radius:11px;}
+  .status-hero.s-active{background:#eef9f1;border:1px solid #c3e6cf;}
+  .status-hero.s-suspended{background:#fff6ea;border:1px solid #f3dcb6;}
+  .status-hero .sh-icon{font-size:24px;}
+  .status-hero.s-active .sh-icon{color:var(--c-active);}
+  .status-hero.s-suspended .sh-icon{color:var(--c-suspended);}
+
+  .ts-badge{font-size:11.5px;font-weight:600;padding:4px 10px;border-radius:6px;display:inline-flex;align-items:center;gap:5px;border:1px solid transparent;}
+  .ts-ACTIVE{background:#e7f5ec;color:#207a3a;border-color:#c3e6cf;}
+  .ts-SUSPENDED{background:#fff3e2;color:#b8650b;border-color:#f3dcb6;}
+  .plan-badge{font-size:10.5px;font-weight:600;padding:2px 8px;border-radius:5px;background:#eef1f6;color:#566173;}
+
+  .empty-detail{flex:1 1 auto;display:grid;place-items:center;color:#aab0ba;text-align:center;padding:40px;}
+  .empty-detail .bi{font-size:42px;color:#d3d7de;}
+
+  .modal-warn-icon{width:44px;height:44px;border-radius:50%;display:grid;place-items:center;font-size:21px;flex:0 0 44px;}
+  .warn-suspend{background:#fff3e2;color:#b8650b;}
+  .warn-reactivate{background:#e7f5ec;color:#207a3a;}
+  .toast-host{position:fixed;right:18px;bottom:18px;z-index:2000;display:flex;flex-direction:column;gap:8px;}
+
+  .design-notes{margin-top:18px;border:1px dashed #c9ccd3;border-radius:12px;background:#fcfcfd;padding:18px 22px;}
+  .design-notes h3{font-size:13px;font-weight:700;letter-spacing:.04em;color:#5a6270;margin:0 0 10px;display:flex;align-items:center;gap:7px;}
+  .design-notes dl{display:grid;grid-template-columns:96px 1fr;gap:6px 14px;margin:0;font-size:12.5px;}
+  .design-notes dt{font-weight:700;color:#404856;}
+  .design-notes dd{margin:0;color:#5a6270;}
+</style>
+</head>
+<body>
+
+<nav class="app-navbar d-flex align-items-center px-3 gap-3 sticky-top">
+  <div class="app-brand d-flex align-items-center gap-2"><i class="bi bi-check2-square fs-5"></i><span>tasks-webapi</span></div>
+  <span class="console-chip"><i class="bi bi-hdd-stack"></i>管理コンソール</span>
+  <div class="ms-auto d-flex align-items-center gap-3">
+    <span class="text-muted-2 small d-none d-md-inline"><i class="bi bi-shield-lock me-1"></i>テナント運営軸のみ・業務 API 非到達</span>
+    <div class="d-flex align-items-center gap-2">
+      <div class="rounded-circle d-grid" style="width:30px;height:30px;place-items:center;font-weight:700;font-size:12px;background:#2a3142;color:#fff;">山</div>
+      <div class="d-none d-lg-block lh-1"><div class="small fw-bold">山田 太郎</div><span class="role-badge">APP_ADMIN</span></div>
+    </div>
+  </div>
+</nav>
+
+<div class="app-layout">
+  <aside class="app-sidebar d-none d-lg-block">
+    <div class="nav-group-label">プラットフォーム運用</div>
+    <a class="side-link active" href="#" onclick="return false"><i class="bi bi-buildings"></i>テナント一覧 <span class="badge text-bg-light text-muted-2">S-13</span></a>
+    <a class="side-link is-disabled" href="#" onclick="return false" title="Sprint 1 以降"><i class="bi bi-activity"></i>監視 <span class="badge text-bg-light text-muted-2">S-12</span></a>
+    <a class="side-link is-disabled" href="#" onclick="return false" title="Tenant Admin 機能"><i class="bi bi-journal-text"></i>監査ログ</a>
+    <div class="nav-group-label">アカウント</div>
+    <a class="side-link" href="#" onclick="return false"><i class="bi bi-person-circle"></i>プロフィール</a>
+    <a class="side-link" href="#" onclick="return false"><i class="bi bi-box-arrow-right"></i>ログアウト</a>
+    <div class="scope-note"><i class="bi bi-diagram-3 me-1"></i>業務動線(S-03〜S-06)とは画面遷移として<b>直結しません</b>。業務タスク・visibility・3 役割評価はこの空間では効きません。</div>
+  </aside>
+
+  <main class="app-main">
+    <div class="d-flex align-items-center flex-wrap gap-3 mb-3">
+      <div>
+        <h1 class="page-title">テナント管理</h1>
+        <div class="page-sub"><i class="bi bi-link-45deg"></i> 左で選択 → 右に S-14 を同時表示(<code>/admin/tenants</code> ⇄ <code>/admin/tenants/{id}</code>)</div>
+      </div>
+      <div class="ms-auto d-flex align-items-center gap-2">
+        <span class="console-chip"><i class="bi bi-check-circle"></i>ACTIVE <b id="kActive">0</b></span>
+        <span class="console-chip" style="background:#fff3e2;color:#b8650b;border-color:#f3dcb6;"><i class="bi bi-pause-circle"></i>SUSPENDED <b id="kSusp">0</b></span>
+      </div>
+    </div>
+
+    <div class="md-split">
+      <!-- 左: マスター一覧 -->
+      <div class="md-left">
+        <div class="ml-head">
+          <div class="ml-toolbar">
+            <h2><i class="bi bi-buildings" style="color:var(--admin-accent);"></i>テナント</h2>
+            <span class="cnt" id="listCount">0 件</span>
+            <div class="seg ms-auto" id="statusSeg">
+              <button class="on" data-v="ALL" onclick="setStatusFilter('ALL')">すべて</button>
+              <button data-v="ACTIVE" onclick="setStatusFilter('ACTIVE')">ACTIVE</button>
+              <button data-v="SUSPENDED" onclick="setStatusFilter('SUSPENDED')">停止</button>
+            </div>
+          </div>
+          <div class="search-wrap">
+            <i class="bi bi-search"></i>
+            <input id="nameSearch" class="form-control form-control-sm" placeholder="テナント名で部分一致検索" oninput="renderList()" />
+          </div>
+        </div>
+        <div class="ml-list" id="listBody"></div>
+        <div class="ml-foot">
+          <i class="bi bi-database"></i><span><code>GET /api/tenants</code>(A-04)・createdAt DESC</span>
+          <span class="ms-auto">50 件 / ページ</span>
+        </div>
+      </div>
+
+      <!-- 右: ディテール -->
+      <div class="md-right" id="detailPane"></div>
+    </div>
+
+    <div class="design-notes">
+      <h3><i class="bi bi-clipboard-data"></i>設計判断ポイント — 案C マスターディテール(左一覧 + 右詳細)</h3>
+      <dl>
+        <dt>強み</dt><dd>一覧と詳細を常時同時表示。左で次々選択するだけで右に S-14 が即時差し替わり、複数テナントを連続して確認・状態切替するパワーユーザの操作効率が最も高い。一覧の文脈を失わずに 1 件を深掘りでき、選択行はハイライトで追跡できる。</dd>
+        <dt>弱み</dt><dd>左ペインに 392px を固定で割くため、右の詳細幅が狭まり 1 件の情報量はフルページ案に劣る。タブレット縦・狭幅では上下 2 段に折り返り、同時表示の利点が薄れる。1 件をじっくり見る用途には冗長。</dd>
+        <dt>想定読者</dt><dd>多数テナントを横断して棚卸し・一括点検する運用パワーユーザ。「次々に切り替えて状態を確認」する頻度が高い PC 中心の専任 SaaS Admin。</dd>
+      </dl>
+    </div>
+  </main>
+</div>
+
+<div class="modal fade" id="statusModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered"><div class="modal-content" id="statusModalContent"></div></div>
+</div>
+<div class="toast-host" id="toastHost"></div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
+<script>
+const CURRENT_USER = { name:"山田 太郎", role:"APP_ADMIN" };
+const TENANTS = [
+  { id:1, code:"tenant-a",  name:"テナントA株式会社",       status:"ACTIVE",    plan:"FREE", userCount:18, taskCount:421,  createdAt:"2025-12-03", updatedAt:"2026-05-20", suspendedAt:null },
+  { id:2, code:"tenant-b",  name:"テナントB商事",           status:"ACTIVE",    plan:"FREE", userCount:32, taskCount:1247, createdAt:"2025-08-15", updatedAt:"2026-05-18", suspendedAt:null },
+  { id:3, code:"tenant-c",  name:"テナントC工業",           status:"SUSPENDED", plan:"FREE", userCount:11, taskCount:283,  createdAt:"2024-11-20", updatedAt:"2026-03-12", suspendedAt:"2026-03-12" },
+  { id:4, code:"demo",      name:"デモ用テナント",           status:"ACTIVE",    plan:"FREE", userCount:3,  taskCount:12,   createdAt:"2026-05-01", updatedAt:"2026-05-01", suspendedAt:null },
+  { id:5, code:"tenant-d",  name:"テナントD物流",           status:"ACTIVE",    plan:"FREE", userCount:25, taskCount:892,  createdAt:"2025-04-10", updatedAt:"2026-04-22", suspendedAt:null },
+  { id:6, code:"tenant-e",  name:"テナントEメディア",       status:"SUSPENDED", plan:"FREE", userCount:7,  taskCount:65,   createdAt:"2024-06-01", updatedAt:"2025-09-30", suspendedAt:"2025-09-30" },
+  { id:7, code:"tenant-f",  name:"テナントF不動産",         status:"ACTIVE",    plan:"FREE", userCount:42, taskCount:2103, createdAt:"2024-02-14", updatedAt:"2026-05-12", suspendedAt:null },
+  { id:8, code:"tenant-g",  name:"テナントGスタートアップ", status:"ACTIVE",    plan:"FREE", userCount:5,  taskCount:34,   createdAt:"2026-05-28", updatedAt:"2026-05-28", suspendedAt:null },
+];
+let statusFilter="ALL";
+let selectedId=null;
+
+function statusMeta(s){ return s==="ACTIVE"
+  ? ["ACTIVE","ts-ACTIVE","bi-check-circle-fill","d-active"]
+  : ["SUSPENDED","ts-SUSPENDED","bi-pause-circle-fill","d-suspended"]; }
+function fmtDate(d){ return d ? d.replace(/-/g,"/") : "—"; }
+function initial(name){ const m=name.match(/[A-Za-zＡ-Ｚ]|[ァ-ヶ]|[一-龠]|[ぁ-ん]/); return (m?m[0]:name[0]); }
+function nf(n){ return n.toLocaleString("ja-JP"); }
+
+function visibleTenants(){
+  const kw=(document.getElementById("nameSearch").value||"").trim().toLowerCase();
+  return TENANTS
+    .filter(t=> statusFilter==="ALL" || t.status===statusFilter)
+    .filter(t=> !kw || t.name.toLowerCase().includes(kw) || (t.code||"").includes(kw))
+    .slice().sort((a,b)=> b.createdAt.localeCompare(a.createdAt));
+}
+function itemHTML(t){
+  const [sl,sc,si,dc]=statusMeta(t.status);
+  return `<div class="t-item ${t.id===selectedId?'active':''} ${t.status==='SUSPENDED'?'is-suspended':''}" onclick="selectTenant(${t.id})">
+    <span class="t-avatar">${initial(t.name)}</span>
+    <div class="t-body">
+      <div class="t-name">${t.name}</div>
+      <div class="t-meta">
+        <span>ID ${t.id}</span><span class="dot"></span>
+        <span><i class="bi bi-people"></i> ${nf(t.userCount)}</span><span class="dot"></span>
+        <span><i class="bi bi-list-check"></i> ${nf(t.taskCount)}</span>
+      </div>
+    </div>
+    <span class="t-dot ${dc}" title="${sl}"></span>
+  </div>`;
+}
+function renderList(){
+  const list=visibleTenants();
+  document.getElementById("listBody").innerHTML = list.length
+    ? list.map(itemHTML).join("")
+    : `<div class="empty-list"><i class="bi bi-inbox d-block mb-2" style="font-size:28px;"></i>該当するテナントはありません</div>`;
+  document.getElementById("listCount").textContent=`${list.length} 件`;
+  document.getElementById("kActive").textContent=TENANTS.filter(t=>t.status==="ACTIVE").length;
+  document.getElementById("kSusp").textContent=TENANTS.filter(t=>t.status==="SUSPENDED").length;
+}
+function setStatusFilter(v){
+  statusFilter=v;
+  [...document.querySelectorAll("#statusSeg button")].forEach(b=>b.classList.toggle("on", b.dataset.v===v));
+  renderList();
+}
+
+function selectTenant(id){ selectedId=id; renderList(); renderDetail(); }
+
+function renderDetail(){
+  const pane=document.getElementById("detailPane");
+  if(selectedId==null){
+    pane.innerHTML=`<div class="empty-detail"><div><i class="bi bi-arrow-left-circle d-block mb-2"></i>左の一覧からテナントを選択すると<br>ここに詳細(S-14)を表示します</div></div>`;
+    return;
+  }
+  const t=TENANTS.find(x=>x.id===selectedId);
+  const [sl,sc,si]=statusMeta(t.status);
+  const isActive=t.status==="ACTIVE";
+  pane.innerHTML=`
+    <div class="mr-head">
+      <span class="mr-avatar">${initial(t.name)}</span>
+      <div class="flex-grow-1" style="min-width:0;">
+        <div id="nameRow" class="name-row d-flex align-items-center gap-2">
+          <span class="editable-name" onclick="startNameEdit()" title="クリックで編集(SaaS Admin)">${t.name}</span>
+          <button class="btn btn-sm btn-light" onclick="startNameEdit()"><i class="bi bi-pencil"></i></button>
+        </div>
+        <div class="mr-url">/admin/tenants/${t.id} ・ <span style="color:var(--admin-accent);">${t.code}</span></div>
+      </div>
+      <span class="ts-badge ${sc}"><i class="bi ${si}"></i>${sl}</span>
+    </div>
+
+    <div class="mr-scroll"><div class="mr-body">
+      <div class="status-hero ${isActive?'s-active':'s-suspended'} mb-4">
+        <i class="bi ${si} sh-icon"></i>
+        <div style="min-width:0;">
+          <div class="fw-bold" style="font-size:14px;">現在の状態: ${sl}</div>
+          <div class="text-muted-2 small">${isActive
+            ? '所属ユーザーは業務 API を利用できます。'
+            : `${fmtDate(t.suspendedAt)} に停止・業務 API は 403 で拒否中(データ無傷)`}</div>
+        </div>
+        <div class="ms-auto">
+          ${isActive
+            ? `<button class="btn btn-sm btn-outline-warning" onclick="confirmStatus(${t.id})"><i class="bi bi-pause-circle me-1"></i>停止</button>`
+            : `<button class="btn btn-sm btn-success" onclick="confirmStatus(${t.id})"><i class="bi bi-play-circle me-1"></i>再有効化</button>`}
+        </div>
+      </div>
+
+      <div class="row g-3">
+        <div class="col-lg-7">
+          <div class="sec-label">基本情報 <span class="api"><code>PUT /api/tenants/${t.id}</code>(A-06)</span></div>
+          <div class="meta-row"><div class="mk">テナント ID</div><div>${t.id}</div></div>
+          <div class="meta-row"><div class="mk">コード</div><div><code>${t.code}</code></div></div>
+          <div class="meta-row"><div class="mk">プラン</div><div><span class="plan-badge">${t.plan}</span></div></div>
+          <div class="meta-row"><div class="mk">作成日</div><div>${fmtDate(t.createdAt)}</div></div>
+          <div class="meta-row"><div class="mk">更新日</div><div>${fmtDate(t.updatedAt)}</div></div>
+          ${t.suspendedAt?`<div class="meta-row"><div class="mk">停止日</div><div style="color:var(--c-suspended);">${fmtDate(t.suspendedAt)}</div></div>`:''}
+        </div>
+        <div class="col-lg-5">
+          <div class="sec-label">参考メトリクス <span class="api">参照のみ</span></div>
+          <div class="row g-2">
+            <div class="col-6"><div class="metric-box"><div class="m-num">${nf(t.userCount)}</div><div class="m-lbl">ユーザー数</div><div class="m-note">/ 最大 50 名</div></div></div>
+            <div class="col-6"><div class="metric-box"><div class="m-num">${nf(t.taskCount)}</div><div class="m-lbl">タスク数</div><div class="m-note">業務データ</div></div></div>
+          </div>
+        </div>
+      </div>
+
+      <div class="sec-label mt-4">状態切替 <span class="api"><code>PATCH /api/tenants/${t.id}/status</code>(A-26)</span></div>
+      <div class="consequence mb-3">
+        <i class="bi bi-info-circle me-1"></i>${isActive
+          ? '停止すると所属ユーザーの業務 API アクセスが 403 で拒否されます(ログインは通過・データ無傷)。'
+          : '再有効化すると所属ユーザーの業務 API アクセスが復帰します。'}
+        監査ログに <span class="audit-chip">${isActive?'TENANT_SUSPENDED':'TENANT_REACTIVATED'}</span> を記録。
+      </div>
+      ${isActive
+        ? `<button class="btn btn-outline-warning" onclick="confirmStatus(${t.id})"><i class="bi bi-pause-circle me-1"></i>このテナントを停止する</button>`
+        : `<button class="btn btn-success" onclick="confirmStatus(${t.id})"><i class="bi bi-play-circle me-1"></i>このテナントを再有効化する</button>`}
+      <div class="text-muted-2 small mt-2"><i class="bi bi-shield-check me-1"></i>操作可能なのは SaaS Admin(APP_ADMIN)のみ</div>
+    </div></div>`;
+}
+
+function startNameEdit(){
+  const t=TENANTS.find(x=>x.id===selectedId);
+  const host=document.getElementById("nameRow");
+  host.innerHTML=`<input id="nameInput" value="${t.name.replace(/"/g,'&quot;')}" maxlength="255" />
+    <button class="btn btn-sm btn-primary" onclick="commitName()"><i class="bi bi-check-lg"></i></button>
+    <button class="btn btn-sm btn-light" onclick="renderDetail()">取消</button>`;
+  const inp=document.getElementById("nameInput"); inp.focus(); inp.select();
+  inp.addEventListener("keydown",e=>{ if(e.key==="Enter")commitName(); if(e.key==="Escape")renderDetail(); });
+}
+function commitName(){
+  const t=TENANTS.find(x=>x.id===selectedId);
+  const v=(document.getElementById("nameInput").value||"").trim();
+  if(v){ t.name=v; t.updatedAt="2026-06-02"; toast(`テナント名を「${v}」に更新しました`,"success"); }
+  renderDetail(); renderList();
+}
+
+/* 案C: パワーユーザ向け簡易 Yes/No 確認(影響は明示)*/
+function confirmStatus(id){
+  const t=TENANTS.find(x=>x.id===id);
+  const toSuspend=t.status==="ACTIVE";
+  const body = toSuspend
+    ? `<div class="modal-header border-0 pb-0">
+         <div class="d-flex align-items-start gap-3">
+           <div class="modal-warn-icon warn-suspend"><i class="bi bi-pause-circle-fill"></i></div>
+           <div><h5 class="modal-title mb-1">停止しますか?</h5><div class="text-muted-2 small">${t.name}(ID ${t.id})</div></div>
+         </div>
+         <button type="button" class="btn-close ms-auto" data-bs-dismiss="modal"></button>
+       </div>
+       <div class="modal-body"><div class="consequence">所属ユーザー <b>${nf(t.userCount)} 名</b>はログインできなくなります(業務 API が 403)。タスク <b>${nf(t.taskCount)} 件</b>を含むデータは無傷で、いつでも再有効化できます。監査ログに <span class="audit-chip">TENANT_SUSPENDED</span> を記録します。</div></div>
+       <div class="modal-footer border-0 pt-0">
+         <button class="btn btn-light" data-bs-dismiss="modal">いいえ</button>
+         <button class="btn btn-warning" onclick="applyStatus(${t.id})"><i class="bi bi-pause-circle me-1"></i>はい、停止する</button>
+       </div>`
+    : `<div class="modal-header border-0 pb-0">
+         <div class="d-flex align-items-start gap-3">
+           <div class="modal-warn-icon warn-reactivate"><i class="bi bi-play-circle-fill"></i></div>
+           <div><h5 class="modal-title mb-1">再有効化しますか?</h5><div class="text-muted-2 small">${t.name}(ID ${t.id})</div></div>
+         </div>
+         <button type="button" class="btn-close ms-auto" data-bs-dismiss="modal"></button>
+       </div>
+       <div class="modal-body"><div class="consequence">所属ユーザー <b>${nf(t.userCount)} 名</b>の業務 API アクセスが復帰します。監査ログに <span class="audit-chip">TENANT_REACTIVATED</span> を記録します。</div></div>
+       <div class="modal-footer border-0 pt-0">
+         <button class="btn btn-light" data-bs-dismiss="modal">いいえ</button>
+         <button class="btn btn-success" onclick="applyStatus(${t.id})"><i class="bi bi-play-circle me-1"></i>はい、再有効化する</button>
+       </div>`;
+  document.getElementById("statusModalContent").innerHTML=body;
+  bootstrap.Modal.getOrCreateInstance(document.getElementById("statusModal")).show();
+}
+function applyStatus(id){
+  const t=TENANTS.find(x=>x.id===id);
+  const wasActive=t.status==="ACTIVE";
+  t.status=wasActive?"SUSPENDED":"ACTIVE";
+  t.updatedAt="2026-06-02";
+  t.suspendedAt=wasActive?"2026-06-02":null;
+  bootstrap.Modal.getInstance(document.getElementById("statusModal")).hide();
+  renderDetail(); renderList();
+  toast(wasActive?`「${t.name}」を停止しました(TENANT_SUSPENDED)`:`「${t.name}」を再有効化しました(TENANT_REACTIVATED)`, wasActive?"warn":"success");
+}
+
+function toast(msg,kind){
+  const el=document.createElement("div");
+  const color=kind==="success"?"#207a3a":kind==="warn"?"#b8650b":"#3f4855";
+  const icon=kind==="success"?"bi-check-circle-fill":kind==="warn"?"bi-pause-circle-fill":"bi-info-circle-fill";
+  el.style.cssText=`background:#fff;border:1px solid var(--app-border);border-left:4px solid ${color};border-radius:9px;padding:11px 14px;font-size:13px;max-width:340px;display:flex;align-items:center;gap:9px;box-shadow:0 6px 22px rgba(31,39,51,.12);`;
+  el.innerHTML=`<i class="bi ${icon}" style="color:${color};font-size:16px;"></i><span>${msg}</span>`;
+  document.getElementById("toastHost").appendChild(el);
+  setTimeout(()=>{ el.style.transition="opacity .4s"; el.style.opacity="0"; setTimeout(()=>el.remove(),400); },3200);
+}
+
+renderList();
+selectTenant(1); /* 初期選択 */
+</script>
+</body>
+</html>


### PR DESCRIPTION
## 概要

Issue #152(コア 4 画面の方向性検証)の **最終 PR**。SaaS Admin 専用の **S-13 テナント一覧 / S-14 テナント詳細・状態切替** を Claude Design に投入して 3 案生成、案 B(管理コンソール風 / 別空間フルページ)を採用。採用後にハイファイ化を依頼し、UI 要素を作り込み済み。

## 4 画面の進行(本 PR で完了 4/4)

| # | 画面 | 採用案 | PR |
|---|---|---|---|
| 1 | S-03 ダッシュボード | A 集約縦積み | PR #350(merged) |
| 2 | S-04 タスク一覧 | B 左サイドカレンダー | PR #351(merged) |
| 3 | S-05 / S-06 タスク詳細 | B 2 カラム(Issue 風、ハイファイ版) | PR #352(merged) |
| 4 | S-13 / S-14 テナント管理 | B 管理コンソール風(ハイファイ版) | **本 PR** |

→ **Issue #152 完了の定義 4 項目すべて達成、Closes #152**

## 決定プロセス

1. SSOT(screen-flow.md §3 / 基本設計書 §3.2 / access-matrix.md §3 / §6 / OpenAPI v1.5.0 関連 operations)+ S-03 / S-04 / S-05 採用案 HTML(デザインシステム継承元)を Claude Design に投入、3 案生成
2. 要件定義書のペルソナを再確認:**SaaS 運営者 = 数名・専任**(要件 §2.3)、業務データには触れない
3. ユーザ議論で確認した追加判断軸:
   - **視覚分離は強く表したい**(濃色 chrome / KPI / 別サイドナビ等を積極採用)
   - **主要動線は「1 件を丁寧に確認・状態切替」**(専任 SaaS Admin、誤操作防止重視)
4. 7 軸比較で案 B を採用(`decision.md` §0.1 / §1 参照)
5. 採用案をハイファイ化、UI 要素を追加実装(`decision.md` §1.1)

## 成果物

`docs/specs/ui/screens/tenant-admin/`

- `option-a-integrated-drawer.html` — 却下(業務動線統合だが視覚分離弱、Phase 2「シンプルドロワー」余地)
- `option-b-admin-console.html` — **採用(ハイファイ版)**(濃色 chrome + KPI ストリップ + 別サイドナビ + フルページ詳細)
- `option-c-master-detail.html` — 却下(棚卸し効率は高いが「1 件丁寧確認」動線と方向違い、Phase 2「棚卸しビュー」余地)
- `decision.md` — 決定プロセス + 採用理由 + ハイファイ追加要素 + 認可整合 + #153/#154 引き継ぎ論点 + §7 Issue #152 完了対応状況

## Claude Design ハイファイ版で追加された UI 要素

- モック状態プレビューバー(レビュー用、本番非表示)
- **状態切替確認モーダル**(`#statusModal`、テナント名入力 + ユーザー影響範囲表示、destructive 強調)
- トースト通知ホスト / 空状態 / ローディングスケルトン / 保存スピナー
- **エラー画面 fallback**(403 / 404 / 401):認可整合の構造的補強

これらは `decision.md` §1.1 で列挙、§4 認可整合チェックリストで 403 / 404 / 401 行を「ハイファイ版で fallback 実装」に更新済。

## Issue #152 完了の定義 対応状況

| 完了条件 | 状態 |
|---|---|
| 4 画面すべて方向性決定済み | ✓(PR #350/#351/#352/本 PR) |
| 各画面に `decision.md` あり(理由 + 却下案 + 残論点) | ✓ |
| 認可ポリシー(#151 access-matrix.md)と矛盾しない | ✓(各 decision.md §4 で確認済) |
| OpenAPI 突き合わせ Issue (#153) に必要なフィールド洗い出しを引き継いでいる | ✓(各 decision.md §3 で引き継ぎ表整備済) |

## 引き継ぎ論点

- **#154 デザインシステム素案**: 管理コンソール用 chrome 色トークン化 / KPI ストリップコンポーネント / destructive 確認ダイアログ規格化(ハイファイ版で参考実装あり)/ エラー画面 fallback コンポーネント / 状態バッジ色トークン / inline 編集パターン / disabled サイドナビ項目表示規約
- **#153 OpenAPI v1.5.0 突合**: `listTenants` / `getTenant` / `updateTenant` / `updateTenantStatus` / `getPlatformMetrics` 5 endpoints のレスポンス確認、SaaS Admin 限定 `@PreAuthorize` 完備確認

詳細は `decision.md` §3。

## 認可ポリシー整合

`decision.md` §4 にチェックリスト。`docs/specs/ui/access-matrix.md` §3 / §6 と矛盾なし。ハイファイ版では 403 / 404 / 401 エラー画面 fallback の参考実装も含む。

## 関連

- **Closes #152**(本 Issue 完了)
- Refs #149(親、Sprint 0 画面設計)
- 関連 SSOT: `docs/specs/ui/screen-flow.md` v1.1 §3 / §2 / `docs/specs/基本設計書.md` §3.2 / `docs/specs/ui/access-matrix.md` §3 / §6 / `docs/specs/要件定義書.md` §2.3
- 関連 ADR: ADR-0005(SaaS Admin の業務特権なし)
- 後続候補: S-12 プラットフォーム監視ダッシュボード(Sprint 1 以降)/ 監査ログ参照画面(Phase 2)/ #167 テナント解約(Phase 2)(前回提示した PR 本文と同じ)
