### PR TITLE
fix(ci): Trivy CLI バージョンを v0.71.0 に固定 (#384 follow-up)

### DIFF
--- a/.github/workflows/iac-security-scan.yml
+++ b/.github/workflows/iac-security-scan.yml
@@ -53,6 +53,7 @@ jobs:
           format: sarif
           output: trivy-results.sarif
           trivyignores: .trivyignore
+          version: v0.71.0
 
       - name: Upload SARIF to GitHub Security tab
         if: steps.trivy-sarif.outcome == 'success'
@@ -71,3 +72,4 @@ jobs:
           severity: HIGH,CRITICAL
           exit-code: '1'
           trivyignores: .trivyignore
+          version: v0.71.0


### PR DESCRIPTION
## 問題

#390 マージ後の CI で IaC Security Scan が異常終了。

```
aquasecurity/trivy info checking GitHub for tag 'v0.63.0'
aquasecurity/trivy info found version: 0.63.0 for v0.63.0/Linux/64bit
##[error]Process completed with exit code 1.
```

## 根本原因

`trivy-action@v0.31.0` は内部デフォルトで Trivy CLI `v0.63.0` をインストールしようとするが、**`v0.63.0` は GitHub Release が存在しない**。`install.sh` がバージョンを発見した（GitHub API は応答）後、実際のバイナリダウンロードで 404 が返り exit code 1 で失敗する。

```bash
$ gh release view v0.63.0 --repo aquasecurity/trivy
release not found   # ← リリースが存在しない
```

最新の Trivy リリースは `v0.71.0`（2026-06-01）で `Linux-64bit` バイナリアセットの存在を確認済み。

## 修正

両 Trivy ステップに `version: v0.71.0` を明示追加し、存在しないバージョンへの依存を回避。

Closes #384 (follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)