### PR TITLE
ci(infra): GitHub Actions OIDC + 4 IAM Role + terraform-plan CI (S0Infra-3 #246)

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -1,0 +1,99 @@
+name: Terraform Apply
+
+# Sprint 0: apply jobs are commented out pending resource implementation (S0Infra-4+).
+# Uncomment the jobs below once platform/tasks resources are ready to apply.
+# Trigger: push to main (or workflow_dispatch for manual apply).
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'infra/**/*.tf'
+      - 'infra/**/*.hcl'
+      - 'infra/**/*.tfvars'
+      - '.github/workflows/terraform-apply.yml'
+  workflow_dispatch:
+
+env:
+  LANG: ja_JP.UTF-8
+  TZ: Asia/Tokyo
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+permissions:
+  id-token: write
+  contents: read
+
+concurrency:
+  group: terraform-apply-${{ github.ref }}
+  cancel-in-progress: false
+
+# ---------------------------------------------------------------------------
+# Uncomment when platform resources (S0Infra-4: VPC, ALB, etc.) are ready.
+# ---------------------------------------------------------------------------
+# jobs:
+#   platform-apply:
+#     runs-on: ubuntu-latest
+#     environment: platform-apply
+#
+#     steps:
+#       - uses: actions/checkout@v6
+#
+#       - name: Setup Terraform
+#         uses: hashicorp/setup-terraform@v3
+#         with:
+#           terraform_version: '1.11.4'
+#           terraform_wrapper: false
+#
+#       - name: Configure AWS credentials
+#         uses: aws-actions/configure-aws-credentials@v4
+#         with:
+#           role-to-assume: arn:aws:iam::138285070797:role/platform-dev-apply
+#           aws-region: ap-northeast-1
+#
+#       - name: terraform init (platform/dev)
+#         working-directory: infra/shared/environments/dev
+#         run: terraform init -no-color
+#
+#       - name: terraform apply (platform/dev)
+#         working-directory: infra/shared/environments/dev
+#         run: terraform apply -auto-approve -no-color
+
+# ---------------------------------------------------------------------------
+# Uncomment when tasks resources (S0Infra-5+: SG, ECS, RDS, etc.) are ready.
+# tasks-apply depends on platform-apply (SSM outputs must exist).
+# ---------------------------------------------------------------------------
+#   tasks-apply:
+#     needs: platform-apply
+#     runs-on: ubuntu-latest
+#     environment: tasks-apply
+#
+#     steps:
+#       - uses: actions/checkout@v6
+#
+#       - name: Setup Terraform
+#         uses: hashicorp/setup-terraform@v3
+#         with:
+#           terraform_version: '1.11.4'
+#           terraform_wrapper: false
+#
+#       - name: Configure AWS credentials
+#         uses: aws-actions/configure-aws-credentials@v4
+#         with:
+#           role-to-assume: arn:aws:iam::138285070797:role/tasks-dev-apply
+#           aws-region: ap-northeast-1
+#
+#       - name: terraform init (tasks/dev)
+#         working-directory: infra/environments/dev
+#         run: terraform init -no-color
+#
+#       - name: terraform apply (tasks/dev)
+#         working-directory: infra/environments/dev
+#         run: terraform apply -auto-approve -no-color
+
+# Placeholder job so the workflow file is syntactically valid while jobs are
+# commented out.  Remove this once the apply jobs above are uncommented.
+jobs:
+  noop:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Apply jobs are pending resource implementation (S0Infra-4+). See comments above."

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -1,0 +1,218 @@
+name: Terraform Plan
+
+on:
+  pull_request:
+
+env:
+  LANG: ja_JP.UTF-8
+  TZ: Asia/Tokyo
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+permissions:
+  id-token: write
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: terraform-plan-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      tf: ${{ steps.filter.outputs.tf }}
+    steps:
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            tf:
+              - 'infra/**/*.tf'
+              - 'infra/**/*.hcl'
+              - 'infra/**/*.tfvars'
+              - '.github/workflows/terraform-plan.yml'
+
+  platform-plan:
+    needs: changes
+    if: needs.changes.outputs.tf == 'true'
+    runs-on: ubuntu-latest
+    environment: platform-plan
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: '1.11.4'
+          terraform_wrapper: false
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::138285070797:role/platform-dev-plan
+          aws-region: ap-northeast-1
+
+      - name: terraform init (platform/dev)
+        id: init
+        working-directory: infra/shared/environments/dev
+        run: terraform init -no-color
+        continue-on-error: true
+
+      - name: terraform plan (platform/dev)
+        id: plan
+        if: steps.init.outcome == 'success'
+        working-directory: infra/shared/environments/dev
+        run: terraform plan -no-color -lock=false 2>&1 | tee plan.txt
+        continue-on-error: true
+
+      - name: Build report
+        id: report
+        if: always() && github.event_name == 'pull_request'
+        env:
+          INIT_OUTCOME: ${{ steps.init.outcome }}
+          PLAN_OUTCOME: ${{ steps.plan.outcome }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          RUN_NUM: ${{ github.run_number }}
+          GH_SHA: ${{ github.sha }}
+        run: |
+          SHA_SHORT="${GH_SHA:0:7}"
+          NOW="$(TZ=Asia/Tokyo date '+%Y-%m-%d %H:%M JST')"
+
+          row() {
+            local label="$1" outcome="$2"
+            case "$outcome" in
+              success) echo "| ${label} | :white_check_mark: 成功 |" ;;
+              failure) echo "| ${label} | :x: 失敗(ログ参照) |" ;;
+              skipped) echo "| ${label} | :fast_forward: スキップ |" ;;
+              *)       echo "| ${label} | :grey_question: ${outcome} |" ;;
+            esac
+          }
+
+          PLAN_SUMMARY=""
+          if [ -f infra/shared/environments/dev/plan.txt ]; then
+            PLAN_SUMMARY=$(grep -E '^(Plan:|No changes\.|Error:)' infra/shared/environments/dev/plan.txt | head -3 || true)
+          fi
+
+          {
+            echo 'BODY<<__PLAN_EOF__'
+            echo "### Terraform Plan — platform/dev — Run [#${RUN_NUM}](${RUN_URL}) (\`${SHA_SHORT}\`)"
+            echo ""
+            echo "| 項目 | 結果 |"
+            echo "|------|------|"
+            row "init" "$INIT_OUTCOME"
+            row "plan" "$PLAN_OUTCOME"
+            if [ -n "$PLAN_SUMMARY" ]; then
+              echo ""
+              echo "\`\`\`"
+              echo "$PLAN_SUMMARY"
+              echo "\`\`\`"
+            fi
+            echo ""
+            echo "_最終更新: ${NOW}_"
+            echo '__PLAN_EOF__'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Post sticky comment (platform)
+        uses: marocchino/sticky-pull-request-comment@v2
+        if: always() && github.event_name == 'pull_request' && steps.report.outcome == 'success'
+        with:
+          header: terraform-plan-platform
+          message: ${{ steps.report.outputs.BODY }}
+
+      - name: Fail on errors
+        if: steps.init.outcome == 'failure' || steps.plan.outcome == 'failure'
+        run: exit 1
+
+  tasks-plan:
+    needs: changes
+    if: needs.changes.outputs.tf == 'true'
+    runs-on: ubuntu-latest
+    environment: tasks-plan
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: '1.11.4'
+          terraform_wrapper: false
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::138285070797:role/tasks-dev-plan
+          aws-region: ap-northeast-1
+
+      - name: terraform init (tasks/dev)
+        id: init
+        working-directory: infra/environments/dev
+        run: terraform init -no-color
+        continue-on-error: true
+
+      - name: terraform plan (tasks/dev)
+        id: plan
+        if: steps.init.outcome == 'success'
+        working-directory: infra/environments/dev
+        run: terraform plan -no-color -lock=false 2>&1 | tee plan.txt
+        continue-on-error: true
+
+      - name: Build report
+        id: report
+        if: always() && github.event_name == 'pull_request'
+        env:
+          INIT_OUTCOME: ${{ steps.init.outcome }}
+          PLAN_OUTCOME: ${{ steps.plan.outcome }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          RUN_NUM: ${{ github.run_number }}
+          GH_SHA: ${{ github.sha }}
+        run: |
+          SHA_SHORT="${GH_SHA:0:7}"
+          NOW="$(TZ=Asia/Tokyo date '+%Y-%m-%d %H:%M JST')"
+
+          row() {
+            local label="$1" outcome="$2"
+            case "$outcome" in
+              success) echo "| ${label} | :white_check_mark: 成功 |" ;;
+              failure) echo "| ${label} | :x: 失敗(ログ参照) |" ;;
+              skipped) echo "| ${label} | :fast_forward: スキップ |" ;;
+              *)       echo "| ${label} | :grey_question: ${outcome} |" ;;
+            esac
+          }
+
+          PLAN_SUMMARY=""
+          if [ -f infra/environments/dev/plan.txt ]; then
+            PLAN_SUMMARY=$(grep -E '^(Plan:|No changes\.|Error:)' infra/environments/dev/plan.txt | head -3 || true)
+          fi
+
+          {
+            echo 'BODY<<__PLAN_EOF__'
+            echo "### Terraform Plan — tasks/dev — Run [#${RUN_NUM}](${RUN_URL}) (\`${SHA_SHORT}\`)"
+            echo ""
+            echo "| 項目 | 結果 |"
+            echo "|------|------|"
+            row "init" "$INIT_OUTCOME"
+            row "plan" "$PLAN_OUTCOME"
+            if [ -n "$PLAN_SUMMARY" ]; then
+              echo ""
+              echo "\`\`\`"
+              echo "$PLAN_SUMMARY"
+              echo "\`\`\`"
+            fi
+            echo ""
+            echo "_最終更新: ${NOW}_"
+            echo '__PLAN_EOF__'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Post sticky comment (tasks)
+        uses: marocchino/sticky-pull-request-comment@v2
+        if: always() && github.event_name == 'pull_request' && steps.report.outcome == 'success'
+        with:
+          header: terraform-plan-tasks
+          message: ${{ steps.report.outputs.BODY }}
+
+      - name: Fail on errors
+        if: steps.init.outcome == 'failure' || steps.plan.outcome == 'failure'
+        run: exit 1

--- a/infra/shared/environments/dev/main.tf
+++ b/infra/shared/environments/dev/main.tf
@@ -1,0 +1,21 @@
+provider "aws" {
+  region = "ap-northeast-1"
+
+  default_tags {
+    tags = {
+      Project     = "platform"
+      Environment = "dev"
+      ManagedBy   = "terraform"
+    }
+  }
+}
+
+module "iam_oidc" {
+  source = "../../modules/iam_oidc"
+
+  account_id   = "138285070797"
+  repo         = "win2cot/tasks-webapi"
+  state_bucket = "dgz48-tfstate"
+  env          = "dev"
+  region       = "ap-northeast-1"
+}

--- a/infra/shared/modules/iam_oidc/main.tf
+++ b/infra/shared/modules/iam_oidc/main.tf
@@ -1,0 +1,560 @@
+# ---------------------------------------------------------------------------
+# GitHub Actions OIDC provider (one per account)
+# ---------------------------------------------------------------------------
+
+resource "aws_iam_openid_connect_provider" "github_actions" {
+  url            = "https://token.actions.githubusercontent.com"
+  client_id_list = ["sts.amazonaws.com"]
+  # AWS manages the thumbprint for GitHub Actions since 2023; value is a
+  # required placeholder that will be overwritten automatically.
+  thumbprint_list = ["6938fd4d98bab03faadb97b34396831e3780aea1"]
+}
+
+locals {
+  oidc_arn    = aws_iam_openid_connect_provider.github_actions.arn
+  oidc_issuer = "token.actions.githubusercontent.com"
+}
+
+# ---------------------------------------------------------------------------
+# Helper: trust policy factory
+# ---------------------------------------------------------------------------
+
+data "aws_iam_policy_document" "trust" {
+  for_each = {
+    platform_plan  = "platform-plan"
+    platform_apply = "platform-apply"
+    tasks_plan     = "tasks-plan"
+    tasks_apply    = "tasks-apply"
+  }
+
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = [local.oidc_arn]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "${local.oidc_issuer}:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "${local.oidc_issuer}:sub"
+      values   = ["repo:${var.repo}:environment:${each.value}"]
+    }
+  }
+}
+
+# ---------------------------------------------------------------------------
+# platform-dev-plan  (read-only; PR plan for platform/shared stack)
+# ---------------------------------------------------------------------------
+
+resource "aws_iam_role" "platform_plan" {
+  name               = "platform-${var.env}-plan"
+  assume_role_policy = data.aws_iam_policy_document.trust["platform_plan"].json
+}
+
+data "aws_iam_policy_document" "platform_plan" {
+  # State read (platform prefix only)
+  statement {
+    sid       = "StateRead"
+    actions   = ["s3:GetObject"]
+    resources = ["arn:aws:s3:::${var.state_bucket}/platform/*"]
+  }
+  statement {
+    sid       = "StateBucketList"
+    actions   = ["s3:ListBucket"]
+    resources = ["arn:aws:s3:::${var.state_bucket}"]
+    condition {
+      test     = "StringLike"
+      variable = "s3:prefix"
+      values   = ["platform/*"]
+    }
+  }
+
+  # IAM read (inspect OIDC provider + roles during plan)
+  statement {
+    sid       = "IamRead"
+    actions   = ["iam:Get*", "iam:List*"]
+    resources = ["*"]
+  }
+
+  # EC2 read (future: VPC / Subnet / IGW / RT / NAT / EIP / VPC Endpoints)
+  statement {
+    sid       = "Ec2Read"
+    actions   = ["ec2:Describe*"]
+    resources = ["*"]
+  }
+
+  # ELBv2 read (future: ALB / Listener)
+  statement {
+    sid       = "ElbRead"
+    actions   = ["elasticloadbalancing:Describe*"]
+    resources = ["*"]
+  }
+
+  # ACM read (future: base wildcard cert)
+  statement {
+    sid       = "AcmRead"
+    actions   = ["acm:Describe*", "acm:List*", "acm:GetCertificate"]
+    resources = ["*"]
+  }
+
+  # SES read (future: domain identity / DKIM / Config Set)
+  statement {
+    sid       = "SesRead"
+    actions   = ["ses:Get*", "ses:List*", "ses:Describe*"]
+    resources = ["*"]
+  }
+
+  # Route53 read (future: shared public zone)
+  statement {
+    sid       = "Route53Read"
+    actions   = ["route53:Get*", "route53:List*"]
+    resources = ["*"]
+  }
+
+  # SSM read — platform outputs published to /platform/<env>/*
+  statement {
+    sid     = "SsmRead"
+    actions = ["ssm:GetParameter", "ssm:GetParametersByPath", "ssm:DescribeParameters"]
+    resources = [
+      "arn:aws:ssm:${var.region}:${var.account_id}:parameter/platform/${var.env}/*",
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "platform_plan" {
+  name   = "platform-${var.env}-plan-policy"
+  role   = aws_iam_role.platform_plan.id
+  policy = data.aws_iam_policy_document.platform_plan.json
+}
+
+# ---------------------------------------------------------------------------
+# platform-dev-apply  (write; merge/tag apply for platform/shared stack)
+# ---------------------------------------------------------------------------
+
+resource "aws_iam_role" "platform_apply" {
+  name               = "platform-${var.env}-apply"
+  assume_role_policy = data.aws_iam_policy_document.trust["platform_apply"].json
+}
+
+data "aws_iam_policy_document" "platform_apply" {
+  # State read + write (platform prefix only; use_lockfile = PutObject/DeleteObject)
+  statement {
+    sid       = "StateReadWrite"
+    actions   = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"]
+    resources = ["arn:aws:s3:::${var.state_bucket}/platform/*"]
+  }
+  statement {
+    sid       = "StateBucketList"
+    actions   = ["s3:ListBucket"]
+    resources = ["arn:aws:s3:::${var.state_bucket}"]
+    condition {
+      test     = "StringLike"
+      variable = "s3:prefix"
+      values   = ["platform/*"]
+    }
+  }
+
+  # IAM — manage OIDC provider + 4 roles/policies in this module
+  statement {
+    sid = "OidcProvider"
+    actions = [
+      "iam:CreateOpenIDConnectProvider",
+      "iam:GetOpenIDConnectProvider",
+      "iam:DeleteOpenIDConnectProvider",
+      "iam:TagOpenIDConnectProvider",
+      "iam:UntagOpenIDConnectProvider",
+      "iam:UpdateOpenIDConnectProviderThumbprint",
+      "iam:AddClientIDToOpenIDConnectProvider",
+      "iam:RemoveClientIDFromOpenIDConnectProvider",
+    ]
+    resources = [
+      "arn:aws:iam::${var.account_id}:oidc-provider/token.actions.githubusercontent.com",
+    ]
+  }
+  statement {
+    sid = "IamRoles"
+    actions = [
+      "iam:CreateRole",
+      "iam:GetRole",
+      "iam:UpdateRole",
+      "iam:DeleteRole",
+      "iam:TagRole",
+      "iam:UntagRole",
+      "iam:UpdateAssumeRolePolicy",
+      "iam:AttachRolePolicy",
+      "iam:DetachRolePolicy",
+      "iam:ListAttachedRolePolicies",
+      "iam:ListRolePolicies",
+      "iam:PutRolePolicy",
+      "iam:GetRolePolicy",
+      "iam:DeleteRolePolicy",
+    ]
+    resources = [
+      "arn:aws:iam::${var.account_id}:role/platform-*",
+      "arn:aws:iam::${var.account_id}:role/tasks-*",
+    ]
+  }
+  statement {
+    sid = "IamPolicies"
+    actions = [
+      "iam:CreatePolicy",
+      "iam:GetPolicy",
+      "iam:GetPolicyVersion",
+      "iam:CreatePolicyVersion",
+      "iam:DeletePolicyVersion",
+      "iam:SetDefaultPolicyVersion",
+      "iam:DeletePolicy",
+      "iam:TagPolicy",
+      "iam:UntagPolicy",
+      "iam:ListPolicyVersions",
+      "iam:ListEntitiesForPolicy",
+    ]
+    resources = [
+      "arn:aws:iam::${var.account_id}:policy/platform-*",
+      "arn:aws:iam::${var.account_id}:policy/tasks-*",
+    ]
+  }
+  # iam:List* (non-resource-specific) for plan inspection
+  statement {
+    sid       = "IamList"
+    actions   = ["iam:List*", "iam:Get*"]
+    resources = ["*"]
+  }
+
+  # EC2 CRUD (future: VPC / Subnet / IGW / RT / NAT / EIP / S3 GW EP)
+  statement {
+    sid       = "Ec2Write"
+    actions   = ["ec2:*"]
+    resources = ["*"]
+  }
+
+  # ELBv2 CRUD (future: ALB / Listener / SG-ALB)
+  statement {
+    sid       = "ElbWrite"
+    actions   = ["elasticloadbalancing:*"]
+    resources = ["*"]
+  }
+
+  # Service-linked role for ELB (future)
+  statement {
+    sid       = "ElbSlr"
+    actions   = ["iam:CreateServiceLinkedRole"]
+    resources = ["arn:aws:iam::${var.account_id}:role/aws-service-role/elasticloadbalancing.amazonaws.com/*"]
+  }
+
+  # ACM CRUD (future: base wildcard cert)
+  statement {
+    sid       = "AcmWrite"
+    actions   = ["acm:*"]
+    resources = ["*"]
+  }
+
+  # SES CRUD (future: domain identity / DKIM / Config Set)
+  statement {
+    sid       = "SesWrite"
+    actions   = ["ses:*"]
+    resources = ["*"]
+  }
+
+  # Route53 CRUD (future: shared public zone records)
+  statement {
+    sid       = "Route53Write"
+    actions   = ["route53:*"]
+    resources = ["*"]
+  }
+
+  # SSM write — publish platform outputs to /platform/<env>/*
+  statement {
+    sid = "SsmWrite"
+    actions = [
+      "ssm:PutParameter",
+      "ssm:GetParameter",
+      "ssm:GetParametersByPath",
+      "ssm:DeleteParameter",
+      "ssm:DescribeParameters",
+      "ssm:AddTagsToResource",
+      "ssm:RemoveTagsFromResource",
+    ]
+    resources = [
+      "arn:aws:ssm:${var.region}:${var.account_id}:parameter/platform/${var.env}/*",
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "platform_apply" {
+  name   = "platform-${var.env}-apply-policy"
+  role   = aws_iam_role.platform_apply.id
+  policy = data.aws_iam_policy_document.platform_apply.json
+}
+
+# ---------------------------------------------------------------------------
+# tasks-dev-plan  (read-only; PR plan for tasks stack)
+# ---------------------------------------------------------------------------
+
+resource "aws_iam_role" "tasks_plan" {
+  name               = "tasks-${var.env}-plan"
+  assume_role_policy = data.aws_iam_policy_document.trust["tasks_plan"].json
+}
+
+data "aws_iam_policy_document" "tasks_plan" {
+  # State read (tasks prefix only)
+  statement {
+    sid       = "StateRead"
+    actions   = ["s3:GetObject"]
+    resources = ["arn:aws:s3:::${var.state_bucket}/tasks/*"]
+  }
+  statement {
+    sid       = "StateBucketList"
+    actions   = ["s3:ListBucket"]
+    resources = ["arn:aws:s3:::${var.state_bucket}"]
+    condition {
+      test     = "StringLike"
+      variable = "s3:prefix"
+      values   = ["tasks/*"]
+    }
+  }
+
+  # EC2 read (future: SG inspection)
+  statement {
+    sid       = "Ec2Read"
+    actions   = ["ec2:Describe*"]
+    resources = ["*"]
+  }
+
+  # ECS read (future)
+  statement {
+    sid       = "EcsRead"
+    actions   = ["ecs:Describe*", "ecs:List*"]
+    resources = ["*"]
+  }
+
+  # RDS read (future)
+  statement {
+    sid       = "RdsRead"
+    actions   = ["rds:Describe*", "rds:List*"]
+    resources = ["*"]
+  }
+
+  # ECR read (future)
+  statement {
+    sid       = "EcrRead"
+    actions   = ["ecr:Describe*", "ecr:List*", "ecr:Get*", "ecr:BatchGetImage"]
+    resources = ["*"]
+  }
+
+  # ELBv2 read (future: listener rule / TG)
+  statement {
+    sid       = "ElbRead"
+    actions   = ["elasticloadbalancing:Describe*"]
+    resources = ["*"]
+  }
+
+  # ACM read (future: deep cert)
+  statement {
+    sid       = "AcmRead"
+    actions   = ["acm:Describe*", "acm:List*", "acm:GetCertificate"]
+    resources = ["*"]
+  }
+
+  # Route53 read (future: PHZ)
+  statement {
+    sid       = "Route53Read"
+    actions   = ["route53:Get*", "route53:List*"]
+    resources = ["*"]
+  }
+
+  # IAM read (future: SMTP user / task role inspection)
+  statement {
+    sid       = "IamRead"
+    actions   = ["iam:Get*", "iam:List*"]
+    resources = ["*"]
+  }
+
+  # SSM read — platform outputs + tasks params
+  statement {
+    sid     = "SsmRead"
+    actions = ["ssm:GetParameter", "ssm:GetParametersByPath", "ssm:DescribeParameters"]
+    resources = [
+      "arn:aws:ssm:${var.region}:${var.account_id}:parameter/platform/${var.env}/*",
+      "arn:aws:ssm:${var.region}:${var.account_id}:parameter/tasks/${var.env}/*",
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "tasks_plan" {
+  name   = "tasks-${var.env}-plan-policy"
+  role   = aws_iam_role.tasks_plan.id
+  policy = data.aws_iam_policy_document.tasks_plan.json
+}
+
+# ---------------------------------------------------------------------------
+# tasks-dev-apply  (write; merge/tag apply for tasks stack)
+# ---------------------------------------------------------------------------
+
+resource "aws_iam_role" "tasks_apply" {
+  name               = "tasks-${var.env}-apply"
+  assume_role_policy = data.aws_iam_policy_document.trust["tasks_apply"].json
+}
+
+data "aws_iam_policy_document" "tasks_apply" {
+  # State read + write (tasks prefix only)
+  statement {
+    sid       = "StateReadWrite"
+    actions   = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"]
+    resources = ["arn:aws:s3:::${var.state_bucket}/tasks/*"]
+  }
+  statement {
+    sid       = "StateBucketList"
+    actions   = ["s3:ListBucket"]
+    resources = ["arn:aws:s3:::${var.state_bucket}"]
+    condition {
+      test     = "StringLike"
+      variable = "s3:prefix"
+      values   = ["tasks/*"]
+    }
+  }
+
+  # EC2 CRUD (future: SG-ECS / SG-RDS)
+  statement {
+    sid       = "Ec2Write"
+    actions   = ["ec2:*"]
+    resources = ["*"]
+  }
+
+  # ECS CRUD (future: Cluster / Service / Task Definition)
+  statement {
+    sid       = "EcsWrite"
+    actions   = ["ecs:*"]
+    resources = ["*"]
+  }
+
+  # RDS CRUD (future: DB instance)
+  statement {
+    sid       = "RdsWrite"
+    actions   = ["rds:*"]
+    resources = ["*"]
+  }
+
+  # ECR CRUD (future)
+  statement {
+    sid       = "EcrWrite"
+    actions   = ["ecr:*"]
+    resources = ["*"]
+  }
+
+  # ELBv2 write (future: listener rule / TG / cert attach to shared ALB)
+  statement {
+    sid       = "ElbWrite"
+    actions   = ["elasticloadbalancing:*"]
+    resources = ["*"]
+  }
+
+  # ACM CRUD (future: deep cert *.tasks.dgz48.xyz)
+  statement {
+    sid       = "AcmWrite"
+    actions   = ["acm:*"]
+    resources = ["*"]
+  }
+
+  # Route53 CRUD (future: PHZ tasks.internal + alias record)
+  statement {
+    sid       = "Route53Write"
+    actions   = ["route53:*"]
+    resources = ["*"]
+  }
+
+  # IAM (future: tasks ECS task role / SMTP IAM user)
+  statement {
+    sid = "IamRoles"
+    actions = [
+      "iam:CreateRole",
+      "iam:GetRole",
+      "iam:UpdateRole",
+      "iam:DeleteRole",
+      "iam:TagRole",
+      "iam:UntagRole",
+      "iam:UpdateAssumeRolePolicy",
+      "iam:AttachRolePolicy",
+      "iam:DetachRolePolicy",
+      "iam:ListAttachedRolePolicies",
+      "iam:ListRolePolicies",
+      "iam:PutRolePolicy",
+      "iam:GetRolePolicy",
+      "iam:DeleteRolePolicy",
+      "iam:PassRole",
+    ]
+    resources = [
+      "arn:aws:iam::${var.account_id}:role/tasks-*",
+    ]
+  }
+  statement {
+    sid = "IamUsers"
+    actions = [
+      "iam:CreateUser",
+      "iam:GetUser",
+      "iam:DeleteUser",
+      "iam:TagUser",
+      "iam:UntagUser",
+      "iam:CreateAccessKey",
+      "iam:DeleteAccessKey",
+      "iam:ListAccessKeys",
+      "iam:AttachUserPolicy",
+      "iam:DetachUserPolicy",
+      "iam:ListAttachedUserPolicies",
+      "iam:PutUserPolicy",
+      "iam:GetUserPolicy",
+      "iam:DeleteUserPolicy",
+    ]
+    resources = [
+      "arn:aws:iam::${var.account_id}:user/tasks-*",
+    ]
+  }
+  statement {
+    sid       = "IamList"
+    actions   = ["iam:List*", "iam:Get*"]
+    resources = ["*"]
+  }
+  statement {
+    sid       = "EcsSlr"
+    actions   = ["iam:CreateServiceLinkedRole"]
+    resources = ["arn:aws:iam::${var.account_id}:role/aws-service-role/ecs.amazonaws.com/*"]
+  }
+
+  # SSM — read platform outputs, write tasks params
+  statement {
+    sid     = "SsmReadPlatform"
+    actions = ["ssm:GetParameter", "ssm:GetParametersByPath", "ssm:DescribeParameters"]
+    resources = [
+      "arn:aws:ssm:${var.region}:${var.account_id}:parameter/platform/${var.env}/*",
+    ]
+  }
+  statement {
+    sid = "SsmWriteTasks"
+    actions = [
+      "ssm:PutParameter",
+      "ssm:GetParameter",
+      "ssm:GetParametersByPath",
+      "ssm:DeleteParameter",
+      "ssm:DescribeParameters",
+      "ssm:AddTagsToResource",
+      "ssm:RemoveTagsFromResource",
+    ]
+    resources = [
+      "arn:aws:ssm:${var.region}:${var.account_id}:parameter/tasks/${var.env}/*",
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "tasks_apply" {
+  name   = "tasks-${var.env}-apply-policy"
+  role   = aws_iam_role.tasks_apply.id
+  policy = data.aws_iam_policy_document.tasks_apply.json
+}

--- a/infra/shared/modules/iam_oidc/outputs.tf
+++ b/infra/shared/modules/iam_oidc/outputs.tf
@@ -1,0 +1,24 @@
+output "oidc_provider_arn" {
+  description = "ARN of the GitHub Actions OIDC provider"
+  value       = aws_iam_openid_connect_provider.github_actions.arn
+}
+
+output "platform_plan_role_arn" {
+  description = "ARN of the platform-dev-plan IAM role"
+  value       = aws_iam_role.platform_plan.arn
+}
+
+output "platform_apply_role_arn" {
+  description = "ARN of the platform-dev-apply IAM role"
+  value       = aws_iam_role.platform_apply.arn
+}
+
+output "tasks_plan_role_arn" {
+  description = "ARN of the tasks-dev-plan IAM role"
+  value       = aws_iam_role.tasks_plan.arn
+}
+
+output "tasks_apply_role_arn" {
+  description = "ARN of the tasks-dev-apply IAM role"
+  value       = aws_iam_role.tasks_apply.arn
+}

--- a/infra/shared/modules/iam_oidc/variables.tf
+++ b/infra/shared/modules/iam_oidc/variables.tf
@@ -1,0 +1,28 @@
+variable "account_id" {
+  type        = string
+  description = "AWS account ID (e.g. 138285070797)"
+}
+
+variable "repo" {
+  type        = string
+  default     = "win2cot/tasks-webapi"
+  description = "GitHub repository in owner/repo format"
+}
+
+variable "state_bucket" {
+  type        = string
+  default     = "dgz48-tfstate"
+  description = "S3 bucket name for Terraform state"
+}
+
+variable "env" {
+  type        = string
+  default     = "dev"
+  description = "Environment name (dev / stg / prd)"
+}
+
+variable "region" {
+  type        = string
+  default     = "ap-northeast-1"
+  description = "AWS region"
+}

--- a/infra/shared/modules/iam_oidc/versions.tf
+++ b/infra/shared/modules/iam_oidc/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.11"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- `infra/shared/modules/iam_oidc/` モジュール新設: OIDC Provider (GitHub Actions) + 4 IAM Role (platform/tasks × plan/apply) + inline policy を Terraform で管理
- `infra/shared/environments/dev/main.tf` 新設: `iam_oidc` module を呼び出し
- `.github/workflows/terraform-plan.yml` 新設: PR 時に OIDC assume → `terraform init + plan -lock=false` → sticky comment (platform / tasks 別 header)
- `.github/workflows/terraform-apply.yml` 新設: apply 雛形 (Sprint 0 では jobs コメント out、S0Infra-4+ でアンコメント)

## Bootstrap 済み

admin creds で `terraform apply` 実行済み。9 リソース作成完了:
- OIDC Provider: `arn:aws:iam::138285070797:oidc-provider/token.actions.githubusercontent.com`
- `platform-dev-plan` / `platform-dev-apply` / `tasks-dev-plan` / `tasks-dev-apply`
- GitHub Environments (4 つ) も設定済み。apply 用は `main` ブランチ限定。

## Test plan

- [ ] この PR で `terraform-plan.yml` が起動し、platform/tasks 両 plan が OIDC role assume で成功すること
- [ ] plan 結果 "No changes." が PR コメントに表示されること
- [ ] `terraform-lint.yml` / `iac-security-scan.yml` が pass すること

Closes #246

🤖 Generated with [Claude Code](https://claude.com/claude-code)