### PR TITLE
feat(infra): platform network — VPC+Subnets+IGW+RT+NAT+S3 GW EP+SSM publish (S0Infra-4 #240)

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -1,9 +1,5 @@
 name: Terraform Apply
 
-# Sprint 0: apply jobs are commented out pending resource implementation (S0Infra-4+).
-# Uncomment the jobs below once platform/tasks resources are ready to apply.
-# Trigger: push to main (or workflow_dispatch for manual apply).
-
 on:
   push:
     branches: [main]
@@ -27,36 +23,33 @@ concurrency:
   group: terraform-apply-${{ github.ref }}
   cancel-in-progress: false
 
-# ---------------------------------------------------------------------------
-# Uncomment when platform resources (S0Infra-4: VPC, ALB, etc.) are ready.
-# ---------------------------------------------------------------------------
-# jobs:
-#   platform-apply:
-#     runs-on: ubuntu-latest
-#     environment: platform-apply
-#
-#     steps:
-#       - uses: actions/checkout@v6
-#
-#       - name: Setup Terraform
-#         uses: hashicorp/setup-terraform@v3
-#         with:
-#           terraform_version: '1.11.4'
-#           terraform_wrapper: false
-#
-#       - name: Configure AWS credentials
-#         uses: aws-actions/configure-aws-credentials@v4
-#         with:
-#           role-to-assume: arn:aws:iam::138285070797:role/platform-dev-apply
-#           aws-region: ap-northeast-1
-#
-#       - name: terraform init (platform/dev)
-#         working-directory: infra/shared/environments/dev
-#         run: terraform init -no-color
-#
-#       - name: terraform apply (platform/dev)
-#         working-directory: infra/shared/environments/dev
-#         run: terraform apply -auto-approve -no-color
+jobs:
+  platform-apply:
+    runs-on: ubuntu-latest
+    environment: platform-apply
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: '1.11.4'
+          terraform_wrapper: false
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::138285070797:role/platform-dev-apply
+          aws-region: ap-northeast-1
+
+      - name: terraform init (platform/dev)
+        working-directory: infra/shared/environments/dev
+        run: terraform init -no-color
+
+      - name: terraform apply (platform/dev)
+        working-directory: infra/shared/environments/dev
+        run: terraform apply -auto-approve -no-color
 
 # ---------------------------------------------------------------------------
 # Uncomment when tasks resources (S0Infra-5+: SG, ECS, RDS, etc.) are ready.
@@ -89,11 +82,3 @@ concurrency:
 #       - name: terraform apply (tasks/dev)
 #         working-directory: infra/environments/dev
 #         run: terraform apply -auto-approve -no-color
-
-# Placeholder job so the workflow file is syntactically valid while jobs are
-# commented out.  Remove this once the apply jobs above are uncommented.
-jobs:
-  noop:
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "Apply jobs are pending resource implementation (S0Infra-4+). See comments above."

--- a/infra/shared/environments/dev/main.tf
+++ b/infra/shared/environments/dev/main.tf
@@ -19,3 +19,46 @@ module "iam_oidc" {
   env          = "dev"
   region       = "ap-northeast-1"
 }
+
+module "network" {
+  source = "../../modules/network"
+
+  env    = "dev"
+  region = "ap-northeast-1"
+
+  availability_zones = ["ap-northeast-1a", "ap-northeast-1c"]
+}
+
+# ---------------------------------------------------------------------------
+# SSM: publish network outputs for tasks stack (ADR-0004)
+# ---------------------------------------------------------------------------
+
+resource "aws_ssm_parameter" "vpc_id" {
+  name  = "/platform/dev/vpc-id"
+  type  = "String"
+  value = module.network.vpc_id
+}
+
+resource "aws_ssm_parameter" "vpc_cidr" {
+  name  = "/platform/dev/vpc-cidr"
+  type  = "String"
+  value = module.network.vpc_cidr
+}
+
+resource "aws_ssm_parameter" "public_subnet_ids" {
+  name  = "/platform/dev/public-subnet-ids"
+  type  = "StringList"
+  value = join(",", module.network.public_subnet_ids)
+}
+
+resource "aws_ssm_parameter" "private_subnet_ids" {
+  name  = "/platform/dev/private-subnet-ids"
+  type  = "StringList"
+  value = join(",", module.network.private_subnet_ids)
+}
+
+resource "aws_ssm_parameter" "private_route_table_ids" {
+  name  = "/platform/dev/private-route-table-ids"
+  type  = "String"
+  value = module.network.private_route_table_id
+}

--- a/infra/shared/modules/network/main.tf
+++ b/infra/shared/modules/network/main.tf
@@ -1,0 +1,139 @@
+# ---------------------------------------------------------------------------
+# VPC
+# ---------------------------------------------------------------------------
+
+resource "aws_vpc" "main" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = {
+    Name = "platform-${var.env}-vpc"
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Public Subnets
+# ---------------------------------------------------------------------------
+
+resource "aws_subnet" "public" {
+  count             = length(var.public_subnet_cidrs)
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = var.public_subnet_cidrs[count.index]
+  availability_zone = var.availability_zones[count.index]
+
+  tags = {
+    Name = "platform-${var.env}-public-${count.index + 1}"
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Private Subnets
+# ---------------------------------------------------------------------------
+
+resource "aws_subnet" "private" {
+  count             = length(var.private_subnet_cidrs)
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = var.private_subnet_cidrs[count.index]
+  availability_zone = var.availability_zones[count.index]
+
+  tags = {
+    Name = "platform-${var.env}-private-${count.index + 1}"
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Internet Gateway
+# ---------------------------------------------------------------------------
+
+resource "aws_internet_gateway" "main" {
+  vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name = "platform-${var.env}-igw"
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Public Route Table
+# ---------------------------------------------------------------------------
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.main.id
+  }
+
+  tags = {
+    Name = "platform-${var.env}-rt-public"
+  }
+}
+
+resource "aws_route_table_association" "public" {
+  count          = length(aws_subnet.public)
+  subnet_id      = aws_subnet.public[count.index].id
+  route_table_id = aws_route_table.public.id
+}
+
+# ---------------------------------------------------------------------------
+# NAT Gateway — single-AZ (dev cost-optimal; ADR-0003)
+# ---------------------------------------------------------------------------
+
+resource "aws_eip" "nat" {
+  domain = "vpc"
+
+  tags = {
+    Name = "platform-${var.env}-eip-nat"
+  }
+}
+
+resource "aws_nat_gateway" "main" {
+  allocation_id = aws_eip.nat.id
+  subnet_id     = aws_subnet.public[0].id
+
+  tags = {
+    Name = "platform-${var.env}-nat"
+  }
+
+  depends_on = [aws_internet_gateway.main]
+}
+
+# ---------------------------------------------------------------------------
+# Private Route Table
+# ---------------------------------------------------------------------------
+
+resource "aws_route_table" "private" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.main.id
+  }
+
+  tags = {
+    Name = "platform-${var.env}-rt-private"
+  }
+}
+
+resource "aws_route_table_association" "private" {
+  count          = length(aws_subnet.private)
+  subnet_id      = aws_subnet.private[count.index].id
+  route_table_id = aws_route_table.private.id
+}
+
+# ---------------------------------------------------------------------------
+# S3 Gateway Endpoint — free; bypasses NAT for S3/ECR layer pulls (ADR-0003)
+# ---------------------------------------------------------------------------
+
+resource "aws_vpc_endpoint" "s3" {
+  vpc_id            = aws_vpc.main.id
+  service_name      = "com.amazonaws.${var.region}.s3"
+  vpc_endpoint_type = "Gateway"
+  route_table_ids   = [aws_route_table.private.id]
+
+  tags = {
+    Name = "platform-${var.env}-vpce-s3"
+  }
+}

--- a/infra/shared/modules/network/outputs.tf
+++ b/infra/shared/modules/network/outputs.tf
@@ -1,0 +1,24 @@
+output "vpc_id" {
+  description = "VPC ID"
+  value       = aws_vpc.main.id
+}
+
+output "vpc_cidr" {
+  description = "VPC CIDR block"
+  value       = aws_vpc.main.cidr_block
+}
+
+output "public_subnet_ids" {
+  description = "List of public subnet IDs"
+  value       = [for s in aws_subnet.public : s.id]
+}
+
+output "private_subnet_ids" {
+  description = "List of private subnet IDs"
+  value       = [for s in aws_subnet.private : s.id]
+}
+
+output "private_route_table_id" {
+  description = "Private route table ID"
+  value       = aws_route_table.private.id
+}

--- a/infra/shared/modules/network/variables.tf
+++ b/infra/shared/modules/network/variables.tf
@@ -1,0 +1,32 @@
+variable "env" {
+  type        = string
+  description = "Environment name (dev / stg / prd)"
+}
+
+variable "region" {
+  type        = string
+  description = "AWS region"
+}
+
+variable "vpc_cidr" {
+  type        = string
+  default     = "10.0.0.0/16"
+  description = "VPC CIDR block"
+}
+
+variable "public_subnet_cidrs" {
+  type        = list(string)
+  default     = ["10.0.0.0/24", "10.0.1.0/24"]
+  description = "CIDR blocks for public subnets (must match availability_zones count)"
+}
+
+variable "private_subnet_cidrs" {
+  type        = list(string)
+  default     = ["10.0.10.0/24", "10.0.11.0/24"]
+  description = "CIDR blocks for private subnets (must match availability_zones count)"
+}
+
+variable "availability_zones" {
+  type        = list(string)
+  description = "Availability zones for subnets (must match subnet CIDR counts)"
+}

--- a/infra/shared/modules/network/versions.tf
+++ b/infra/shared/modules/network/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.11"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- **新規** `infra/shared/modules/network/` — platform network モジュール
  - VPC `10.0.0.0/16` (dns_support/hostnames=true)
  - Public Subnet ×2: `10.0.0.0/24` / `10.0.1.0/24` (ap-northeast-1a/1c)
  - Private Subnet ×2: `10.0.10.0/24` / `10.0.11.0/24` (ap-northeast-1a/1c)
  - Internet Gateway + Public Route Table (`0.0.0.0/0` → IGW)
  - NAT Gateway (single-AZ, ADR-0003) + EIP
  - Private Route Table (`0.0.0.0/0` → NAT GW)
  - S3 Gateway Endpoint — Private RT に関連付け (無料、ADR-0003)
- **更新** `infra/shared/environments/dev/main.tf` — network module 呼び出し + SSM publish
  - `/platform/dev/vpc-id`, `/platform/dev/vpc-cidr`
  - `/platform/dev/public-subnet-ids` (StringList)
  - `/platform/dev/private-subnet-ids` (StringList)
  - `/platform/dev/private-route-table-ids`
- **更新** `.github/workflows/terraform-apply.yml` — `platform-apply` ジョブを有効化 (S0Infra-4 apply トリガー条件を達成); `tasks-apply` は S0Infra-5+ 完成まで引き続きコメントアウト

## 関連

- Closes #240
- ADR: ADR-0003 (outbound 経路) / ADR-0004 (platform/tasks 分離・SSM パス)
- 後続ブロッカー: platform ALB (#242) → tasks SG (#241) / PHZ (#244)

## Test plan

- [ ] `terraform plan` (platform/dev) が差分として VPC + 4 Subnet + IGW + 2 RT + NAT GW + EIP + S3 GW EP + 5 SSM params を表示すること
- [ ] `terraform apply` 後、受入条件 (Issue #240) をすべて満たすこと
- [ ] `/platform/dev/vpc-id` 等 SSM パラメータが publish 済みであること

🤖 Generated with [Claude Code](https://claude.ai/claude-code)