### PR TITLE
fix(infra): ALB HTTPS listener に HSTS ヘッダーを追加 (#242)

### DIFF
--- a/infra/shared/modules/alb/main.tf
+++ b/infra/shared/modules/alb/main.tf
@@ -137,6 +137,9 @@ resource "aws_lb_listener" "https" {
   ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
   certificate_arn   = aws_acm_certificate_validation.base.certificate_arn
 
+  # preload は付けない — 共有 apex dgz48.xyz を preload 登録すると全 subdomain が HTTPS 強制になり取消困難
+  routing_http_response_strict_transport_security_header_value = var.hsts_header_value
+
   default_action {
     type = "fixed-response"
 
@@ -151,10 +154,6 @@ resource "aws_lb_listener" "https" {
     Name = "platform-${var.env}-listener-https"
   }
 }
-
-# HSTS: aws_lb_listener_attribute is not available in locked provider v5.100.0.
-# Track upgrade and HSTS injection in a follow-up issue.
-# Do NOT add preload — shared apex dgz48.xyz must not be preload-registered.
 
 # ---------------------------------------------------------------------------
 # HTTP Listener :80 — redirect to HTTPS 301

--- a/infra/shared/modules/alb/variables.tf
+++ b/infra/shared/modules/alb/variables.tf
@@ -23,3 +23,9 @@ variable "enable_deletion_protection" {
   description = "Enable ALB deletion protection. Set to true for stg/prd environments."
   default     = false
 }
+
+variable "hsts_header_value" {
+  type        = string
+  description = "Strict-Transport-Security header value. Do NOT include preload (shared apex domain). dev: short max-age; prd: max-age=31536000."
+  default     = "max-age=300; includeSubDomains"
+}


### PR DESCRIPTION
## Summary

- `aws_lb_listener.https` に `routing_http_response_strict_transport_security_header_value` を追加
- `hsts_header_value` variable を新設(dev デフォルト: `max-age=300; includeSubDomains`)
- 誤ったコメント(「aws_lb_listener_attribute は v5.100.0 で未サポート」)を削除

## 背景

#395 マージ時に HSTS を TODO コメントで先送りしていた。調査の結果、`aws_lb_listener_attribute` という別リソースは存在せず、`aws_lb_listener` の直接引数 `routing_http_response_strict_transport_security_header_value` として v5.100.0 で利用可能であることを確認。

## preload を付けない理由

共有 apex ドメイン `dgz48.xyz` を preload リストに登録すると、全プロジェクト・全サブドメインが HTTPS 強制になり取消困難。そのため意図的に省略。

## Test plan

- [ ] terraform plan (platform/dev) で `aws_lb_listener.https` の in-place update のみ差分確認

Closes #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)