### PR TITLE
ci(infra): terraform-apply.yml を workflow_dispatch-only 化（auto-apply-on-merge 停止）(#396)

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -1,13 +1,6 @@
 name: Terraform Apply
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'infra/**/*.tf'
-      - 'infra/**/*.hcl'
-      - 'infra/**/*.tfvars'
-      - '.github/workflows/terraform-apply.yml'
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
## Summary

- `on: push` ブロックを削除し、`on: workflow_dispatch` のみに変更
- main への infra 変更マージで auto-apply が走るリスクを排除
- Sprint 0–1 は Actions 画面からの手動 apply のみ許可
- tag 駆動の本実装は Sprint 2（#396 記載の通り別 Issue で起票予定）

## Test plan

- [ ] `terraform-apply.yml` のトリガが `workflow_dispatch` のみであることを確認
- [ ] main への infra 変更マージで apply ジョブが起動しないことを確認（CI ログ確認）
- [ ] Actions 画面から `workflow_dispatch` で手動 apply が実行できることを確認

Closes #396

🤖 Generated with [Claude Code](https://claude.com/claude-code)