### PR TITLE
fix(ci): changes ジョブに actions/checkout を追加（push(main) で paths-filter が exit 128）

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -25,6 +25,9 @@ jobs:
     outputs:
       code: ${{ steps.filter.outputs.code }}
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: dorny/paths-filter@v3
         id: filter
         with:

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -25,6 +25,9 @@ jobs:
     outputs:
       quality: ${{ steps.filter.outputs.quality }}
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: dorny/paths-filter@v3
         id: filter
         with:

--- a/.github/workflows/iac-security-scan.yml
+++ b/.github/workflows/iac-security-scan.yml
@@ -25,6 +25,9 @@ jobs:
     outputs:
       tf: ${{ steps.filter.outputs.tf }}
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: dorny/paths-filter@v3
         id: filter
         with:

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -25,6 +25,9 @@ jobs:
     outputs:
       md: ${{ steps.filter.outputs.md }}
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: dorny/paths-filter@v3
         id: filter
         with:

--- a/.github/workflows/openapi-lint.yml
+++ b/.github/workflows/openapi-lint.yml
@@ -25,6 +25,9 @@ jobs:
     outputs:
       api: ${{ steps.filter.outputs.api }}
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: dorny/paths-filter@v3
         id: filter
         with:

--- a/.github/workflows/terraform-lint.yml
+++ b/.github/workflows/terraform-lint.yml
@@ -25,6 +25,9 @@ jobs:
     outputs:
       tf: ${{ steps.filter.outputs.tf }}
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: dorny/paths-filter@v3
         id: filter
         with:


### PR DESCRIPTION
## Summary

- `dorny/paths-filter@v3` は **push イベント**では `github.event.before..after` を git 履歴から差分計算するため、`actions/checkout` なしで実行すると `git failed exit code 128` で `changes` ジョブが失敗する
- PR イベントでは GitHub compare API で差分を取得するため checkout 不要 → PR は緑、push(main) だけ赤という症状の原因
- 対象6ワークフローの `changes` ジョブに `actions/checkout@v4`（`fetch-depth: 0`）を追加して修正

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `cicd.yml` | `changes` ジョブに checkout 追加 |
| `code-quality.yml` | 同上 |
| `openapi-lint.yml` | 同上 |
| `markdown-lint.yml` | 同上 |
| `terraform-lint.yml` | 同上 |
| `iac-security-scan.yml` | 同上 |

## Test plan

- [ ] main への push で6ワークフローが green になることを実機確認（PR 緑だけで判断しない）
- [ ] PR イベントでの skip/run 出し分けが従来どおり機能する

Closes #398

🤖 Generated with [Claude Code](https://claude.com/claude-code)