### PR TITLE
fix(infra): iam_oidc — ssm:DescribeParameters を Resource:"*" の独立 statement に分離（4ロールの apply/plan が AccessDenied）

### DIFF
--- a/infra/shared/modules/iam_oidc/main.tf
+++ b/infra/shared/modules/iam_oidc/main.tf
@@ -122,10 +122,16 @@ data "aws_iam_policy_document" "platform_plan" {
   # SSM read — platform outputs published to /platform/<env>/*
   statement {
     sid     = "SsmRead"
-    actions = ["ssm:GetParameter", "ssm:GetParametersByPath", "ssm:DescribeParameters"]
+    actions = ["ssm:GetParameter", "ssm:GetParametersByPath"]
     resources = [
       "arn:aws:ssm:${var.region}:${var.account_id}:parameter/platform/${var.env}/*",
     ]
+  }
+  # ssm:DescribeParameters does not support resource-level permissions; must use Resource:"*"
+  statement {
+    sid       = "SsmDescribe"
+    actions   = ["ssm:DescribeParameters"]
+    resources = ["*"]
   }
 }
 
@@ -279,13 +285,18 @@ data "aws_iam_policy_document" "platform_apply" {
       "ssm:GetParameter",
       "ssm:GetParametersByPath",
       "ssm:DeleteParameter",
-      "ssm:DescribeParameters",
       "ssm:AddTagsToResource",
       "ssm:RemoveTagsFromResource",
     ]
     resources = [
       "arn:aws:ssm:${var.region}:${var.account_id}:parameter/platform/${var.env}/*",
     ]
+  }
+  # ssm:DescribeParameters does not support resource-level permissions; must use Resource:"*"
+  statement {
+    sid       = "SsmDescribe"
+    actions   = ["ssm:DescribeParameters"]
+    resources = ["*"]
   }
 }
 
@@ -381,11 +392,17 @@ data "aws_iam_policy_document" "tasks_plan" {
   # SSM read — platform outputs + tasks params
   statement {
     sid     = "SsmRead"
-    actions = ["ssm:GetParameter", "ssm:GetParametersByPath", "ssm:DescribeParameters"]
+    actions = ["ssm:GetParameter", "ssm:GetParametersByPath"]
     resources = [
       "arn:aws:ssm:${var.region}:${var.account_id}:parameter/platform/${var.env}/*",
       "arn:aws:ssm:${var.region}:${var.account_id}:parameter/tasks/${var.env}/*",
     ]
+  }
+  # ssm:DescribeParameters does not support resource-level permissions; must use Resource:"*"
+  statement {
+    sid       = "SsmDescribe"
+    actions   = ["ssm:DescribeParameters"]
+    resources = ["*"]
   }
 }
 
@@ -531,7 +548,7 @@ data "aws_iam_policy_document" "tasks_apply" {
   # SSM — read platform outputs, write tasks params
   statement {
     sid     = "SsmReadPlatform"
-    actions = ["ssm:GetParameter", "ssm:GetParametersByPath", "ssm:DescribeParameters"]
+    actions = ["ssm:GetParameter", "ssm:GetParametersByPath"]
     resources = [
       "arn:aws:ssm:${var.region}:${var.account_id}:parameter/platform/${var.env}/*",
     ]
@@ -543,13 +560,18 @@ data "aws_iam_policy_document" "tasks_apply" {
       "ssm:GetParameter",
       "ssm:GetParametersByPath",
       "ssm:DeleteParameter",
-      "ssm:DescribeParameters",
       "ssm:AddTagsToResource",
       "ssm:RemoveTagsFromResource",
     ]
     resources = [
       "arn:aws:ssm:${var.region}:${var.account_id}:parameter/tasks/${var.env}/*",
     ]
+  }
+  # ssm:DescribeParameters does not support resource-level permissions; must use Resource:"*"
+  statement {
+    sid       = "SsmDescribe"
+    actions   = ["ssm:DescribeParameters"]
+    resources = ["*"]
   }
 }
 


### PR DESCRIPTION
## Summary

- `ssm:DescribeParameters` はリソースレベル権限をサポートしないため、パラメータ ARN スコープの statement に含めると常に AccessDenied になる
- 4ポリシー（`platform_plan` / `platform_apply` / `tasks_plan` / `tasks_apply`）の resource スコープ付き statement から `ssm:DescribeParameters` を削除
- 各ポリシーに `Resource: "*"` の独立 `SsmDescribe` statement を1本追加
- resource スコープが効く他の SSM アクション（GetParameter / GetParametersByPath / PutParameter / DeleteParameter / AddTagsToResource / RemoveTagsFromResource）は `parameter/<stack>/<env>/*` のまま維持

## 受入条件

- [x] 4ポリシーで `ssm:DescribeParameters` が `Resource:"*"` の独立 statement になっている
- [x] resource スコープの他 SSM アクションは `parameter/<stack>/<env>/*` のまま
- [ ] platform/dev の apply が成功し、`/platform/dev/*` パラメータと ALB スタックが作成される
- [ ] `terraform plan`（platform/tasks）が AccessDenied を出さない

## Test plan

- [ ] IAM ポリシー変更を apply し、platform/dev の Terraform Apply が成功することを確認
- [ ] `/platform/dev/*` SSM パラメータが作成されることを確認
- [ ] tasks スタックの `terraform plan` が AccessDenied を出さないことを確認

Closes #399

🤖 Generated with [Claude Code](https://claude.com/claude-code)