### PR TITLE
fix(infra): iam_oidc — ssm:ListTagsForResource を4ポリシーの SSM statement に追加（platform-apply が AccessDenied）

### DIFF
--- a/infra/shared/modules/iam_oidc/main.tf
+++ b/infra/shared/modules/iam_oidc/main.tf
@@ -122,7 +122,7 @@ data "aws_iam_policy_document" "platform_plan" {
   # SSM read — platform outputs published to /platform/<env>/*
   statement {
     sid     = "SsmRead"
-    actions = ["ssm:GetParameter", "ssm:GetParametersByPath"]
+    actions = ["ssm:GetParameter", "ssm:GetParametersByPath", "ssm:ListTagsForResource"]
     resources = [
       "arn:aws:ssm:${var.region}:${var.account_id}:parameter/platform/${var.env}/*",
     ]
@@ -285,6 +285,7 @@ data "aws_iam_policy_document" "platform_apply" {
       "ssm:GetParameter",
       "ssm:GetParametersByPath",
       "ssm:DeleteParameter",
+      "ssm:ListTagsForResource",
       "ssm:AddTagsToResource",
       "ssm:RemoveTagsFromResource",
     ]
@@ -392,7 +393,7 @@ data "aws_iam_policy_document" "tasks_plan" {
   # SSM read — platform outputs + tasks params
   statement {
     sid     = "SsmRead"
-    actions = ["ssm:GetParameter", "ssm:GetParametersByPath"]
+    actions = ["ssm:GetParameter", "ssm:GetParametersByPath", "ssm:ListTagsForResource"]
     resources = [
       "arn:aws:ssm:${var.region}:${var.account_id}:parameter/platform/${var.env}/*",
       "arn:aws:ssm:${var.region}:${var.account_id}:parameter/tasks/${var.env}/*",
@@ -548,7 +549,7 @@ data "aws_iam_policy_document" "tasks_apply" {
   # SSM — read platform outputs, write tasks params
   statement {
     sid     = "SsmReadPlatform"
-    actions = ["ssm:GetParameter", "ssm:GetParametersByPath"]
+    actions = ["ssm:GetParameter", "ssm:GetParametersByPath", "ssm:ListTagsForResource"]
     resources = [
       "arn:aws:ssm:${var.region}:${var.account_id}:parameter/platform/${var.env}/*",
     ]
@@ -560,6 +561,7 @@ data "aws_iam_policy_document" "tasks_apply" {
       "ssm:GetParameter",
       "ssm:GetParametersByPath",
       "ssm:DeleteParameter",
+      "ssm:ListTagsForResource",
       "ssm:AddTagsToResource",
       "ssm:RemoveTagsFromResource",
     ]


### PR DESCRIPTION
## Summary

- Terraform AWS provider が `aws_ssm_parameter` の state refresh 時に `ssm:ListTagsForResource` を呼ぶが、4ポリシーの SSM statement に含まれていなかった
- `platform_plan` / `platform_apply` / `tasks_plan` / `tasks_apply` の各 SSM statement に `ssm:ListTagsForResource` を追加
- `ssm:ListTagsForResource` はリソースレベル権限をサポートするため `parameter/<stack>/<env>/*` スコープのまま追加

## 受入条件

- [x] 4ポリシーの SSM statement に `ssm:ListTagsForResource` が追加されている
- [ ] platform/dev の apply が成功し、`/platform/dev/alb-*` パラメータが作成される

## Test plan

- [ ] GHA で platform-apply を再実行し、apply が成功することを確認
- [ ] `/platform/dev/alb-*` SSM パラメータ（6本）が作成されることを確認

Closes #403

🤖 Generated with [Claude Code](https://claude.com/claude-code)