### PR TITLE
fix(infra): iam_oidc — ssm:GetParameters を4ポリシーの SSM statement に追加（platform-apply が AccessDenied）

### DIFF
--- a/infra/shared/modules/iam_oidc/main.tf
+++ b/infra/shared/modules/iam_oidc/main.tf
@@ -122,7 +122,7 @@ data "aws_iam_policy_document" "platform_plan" {
   # SSM read — platform outputs published to /platform/<env>/*
   statement {
     sid     = "SsmRead"
-    actions = ["ssm:GetParameter", "ssm:GetParametersByPath", "ssm:ListTagsForResource"]
+    actions = ["ssm:GetParameter", "ssm:GetParameters", "ssm:GetParametersByPath", "ssm:ListTagsForResource"]
     resources = [
       "arn:aws:ssm:${var.region}:${var.account_id}:parameter/platform/${var.env}/*",
     ]
@@ -283,6 +283,7 @@ data "aws_iam_policy_document" "platform_apply" {
     actions = [
       "ssm:PutParameter",
       "ssm:GetParameter",
+      "ssm:GetParameters",
       "ssm:GetParametersByPath",
       "ssm:DeleteParameter",
       "ssm:ListTagsForResource",
@@ -393,7 +394,7 @@ data "aws_iam_policy_document" "tasks_plan" {
   # SSM read — platform outputs + tasks params
   statement {
     sid     = "SsmRead"
-    actions = ["ssm:GetParameter", "ssm:GetParametersByPath", "ssm:ListTagsForResource"]
+    actions = ["ssm:GetParameter", "ssm:GetParameters", "ssm:GetParametersByPath", "ssm:ListTagsForResource"]
     resources = [
       "arn:aws:ssm:${var.region}:${var.account_id}:parameter/platform/${var.env}/*",
       "arn:aws:ssm:${var.region}:${var.account_id}:parameter/tasks/${var.env}/*",
@@ -549,7 +550,7 @@ data "aws_iam_policy_document" "tasks_apply" {
   # SSM — read platform outputs, write tasks params
   statement {
     sid     = "SsmReadPlatform"
-    actions = ["ssm:GetParameter", "ssm:GetParametersByPath", "ssm:ListTagsForResource"]
+    actions = ["ssm:GetParameter", "ssm:GetParameters", "ssm:GetParametersByPath", "ssm:ListTagsForResource"]
     resources = [
       "arn:aws:ssm:${var.region}:${var.account_id}:parameter/platform/${var.env}/*",
     ]
@@ -559,6 +560,7 @@ data "aws_iam_policy_document" "tasks_apply" {
     actions = [
       "ssm:PutParameter",
       "ssm:GetParameter",
+      "ssm:GetParameters",
       "ssm:GetParametersByPath",
       "ssm:DeleteParameter",
       "ssm:ListTagsForResource",


### PR DESCRIPTION
## Summary

- `ssm:GetParameter`（単数）と `ssm:GetParameters`（複数・バッチ版）は別々の IAM アクション
- Terraform AWS provider が `aws_ssm_parameter` の state refresh 時にバッチ API `ssm:GetParameters` を呼ぶが、4ポリシーの SSM statement に含まれていなかった
- `platform_plan` / `platform_apply` / `tasks_plan` / `tasks_apply` の全 SSM statement に `ssm:GetParameters` を追加

## 受入条件

- [x] 4ポリシーの SSM statement に `ssm:GetParameters` が追加されている
- [ ] platform/dev の apply が成功し、`/platform/dev/alb-*` パラメータが作成される

## Test plan

- [ ] GHA で platform-apply を再実行し、apply が成功することを確認
- [ ] `/platform/dev/alb-*` SSM パラメータ（6本）が作成されることを確認

Closes #405

🤖 Generated with [Claude Code](https://claude.com/claude-code)