### PR TITLE
feat(infra): platform SES — domain identity / Easy DKIM / Custom MAIL FROM / DMARC / Config Set (S0Infra-10)

### DIFF
--- a/infra/shared/environments/dev/main.tf
+++ b/infra/shared/environments/dev/main.tf
@@ -38,6 +38,14 @@ module "alb" {
   base_domain       = "dgz48.xyz"
 }
 
+module "ses" {
+  source = "../../modules/ses"
+
+  env         = "dev"
+  base_domain = "dgz48.xyz"
+  region      = "ap-northeast-1"
+}
+
 # ---------------------------------------------------------------------------
 # SSM: publish network outputs for tasks stack (ADR-0004)
 # ---------------------------------------------------------------------------
@@ -110,4 +118,14 @@ resource "aws_ssm_parameter" "alb_base_cert_arn" {
   name  = "/platform/dev/alb-base-cert-arn"
   type  = "String"
   value = module.alb.base_cert_arn
+}
+
+# ---------------------------------------------------------------------------
+# SSM: publish SES outputs for tasks stack (ADR-0004)
+# ---------------------------------------------------------------------------
+
+resource "aws_ssm_parameter" "ses_config_set" {
+  name  = "/platform/dev/ses-config-set"
+  type  = "String"
+  value = module.ses.config_set_name
 }

--- a/infra/shared/modules/ses/main.tf
+++ b/infra/shared/modules/ses/main.tf
@@ -1,0 +1,92 @@
+# ---------------------------------------------------------------------------
+# Route53 zone lookup — shared public hosted zone (dgz48.xyz)
+# ---------------------------------------------------------------------------
+
+data "aws_route53_zone" "base" {
+  name         = "${var.base_domain}."
+  private_zone = false
+}
+
+# ---------------------------------------------------------------------------
+# SES Email Identity — mail.<base_domain> (shared sender subdomain)
+# Easy DKIM: RSA 2048-bit, SES-managed key rotation (BYODKIM not adopted)
+# ---------------------------------------------------------------------------
+
+resource "aws_sesv2_email_identity" "mail" {
+  email_identity = "mail.${var.base_domain}"
+
+  dkim_signing_attributes {
+    next_signing_key_length = "RSA_2048_BIT"
+  }
+
+  tags = {
+    Name = "platform-${var.env}-ses-identity-mail"
+  }
+}
+
+# ---------------------------------------------------------------------------
+# DKIM CNAME records ×3 — SES auto-verifies on propagation
+# Name:  <token>._domainkey.mail.<base_domain>
+# Value: <token>.dkim.amazonses.com
+# ---------------------------------------------------------------------------
+
+resource "aws_route53_record" "dkim_cname" {
+  count = 3
+
+  zone_id = data.aws_route53_zone.base.zone_id
+  name    = "${aws_sesv2_email_identity.mail.dkim_signing_attributes[0].tokens[count.index]}._domainkey.mail.${var.base_domain}"
+  type    = "CNAME"
+  ttl     = 1800
+  records = ["${aws_sesv2_email_identity.mail.dkim_signing_attributes[0].tokens[count.index]}.dkim.amazonses.com"]
+}
+
+# ---------------------------------------------------------------------------
+# Custom MAIL FROM — bounce.mail.<base_domain>
+# Enables SPF alignment; USE_DEFAULT_VALUE falls back to SES default on MX failure
+# ---------------------------------------------------------------------------
+
+resource "aws_sesv2_email_identity_mail_from_attributes" "mail" {
+  email_identity         = aws_sesv2_email_identity.mail.email_identity
+  mail_from_domain       = "bounce.mail.${var.base_domain}"
+  behavior_on_mx_failure = "USE_DEFAULT_VALUE"
+}
+
+resource "aws_route53_record" "mail_from_mx" {
+  zone_id = data.aws_route53_zone.base.zone_id
+  name    = "bounce.mail.${var.base_domain}"
+  type    = "MX"
+  ttl     = 300
+  records = ["10 feedback-smtp.${var.region}.amazonses.com"]
+}
+
+resource "aws_route53_record" "mail_from_spf" {
+  zone_id = data.aws_route53_zone.base.zone_id
+  name    = "bounce.mail.${var.base_domain}"
+  type    = "TXT"
+  ttl     = 300
+  records = ["v=spf1 include:amazonses.com -all"]
+}
+
+# ---------------------------------------------------------------------------
+# DMARC — monitoring mode (p=none); tighten to quarantine/reject after review
+# ---------------------------------------------------------------------------
+
+resource "aws_route53_record" "dmarc" {
+  zone_id = data.aws_route53_zone.base.zone_id
+  name    = "_dmarc.mail.${var.base_domain}"
+  type    = "TXT"
+  ttl     = 300
+  records = ["v=DMARC1; p=none"]
+}
+
+# ---------------------------------------------------------------------------
+# Config Set — referenced by all projects via SSM /platform/<env>/ses-config-set
+# ---------------------------------------------------------------------------
+
+resource "aws_sesv2_configuration_set" "main" {
+  configuration_set_name = "platform-${var.env}-ses"
+
+  tags = {
+    Name = "platform-${var.env}-ses-config-set"
+  }
+}

--- a/infra/shared/modules/ses/main.tf
+++ b/infra/shared/modules/ses/main.tf
@@ -68,7 +68,8 @@ resource "aws_route53_record" "mail_from_spf" {
 }
 
 # ---------------------------------------------------------------------------
-# DMARC — monitoring mode (p=none); tighten to quarantine/reject after review
+# DMARC — p=none プレースホルダー (rua 未設定のためレポート収集なし)
+# DKIM/SPF 整合確認後に rua= を追加し quarantine/reject へ段階的移行
 # ---------------------------------------------------------------------------
 
 resource "aws_route53_record" "dmarc" {

--- a/infra/shared/modules/ses/outputs.tf
+++ b/infra/shared/modules/ses/outputs.tf
@@ -1,0 +1,9 @@
+output "config_set_name" {
+  description = "SES Configuration Set name (publish to SSM /platform/<env>/ses-config-set)"
+  value       = aws_sesv2_configuration_set.main.configuration_set_name
+}
+
+output "identity_arn" {
+  description = "SES Email Identity ARN for mail.<base_domain>"
+  value       = aws_sesv2_email_identity.mail.arn
+}

--- a/infra/shared/modules/ses/variables.tf
+++ b/infra/shared/modules/ses/variables.tf
@@ -1,0 +1,14 @@
+variable "env" {
+  type        = string
+  description = "Environment name (dev / stg / prd)"
+}
+
+variable "base_domain" {
+  type        = string
+  description = "Base domain (e.g. dgz48.xyz). SES identity = mail.<base_domain>, MAIL FROM = bounce.mail.<base_domain>"
+}
+
+variable "region" {
+  type        = string
+  description = "AWS region — used for MAIL FROM MX record (e.g. ap-northeast-1)"
+}

--- a/infra/shared/modules/ses/versions.tf
+++ b/infra/shared/modules/ses/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.11"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}


### PR DESCRIPTION
## 概要

Closes #378

platform stack に SES リソース一式を追加。`infra/shared/modules/ses` モジュールを新規作成し、`environments/dev/main.tf` から呼び出す。

- **SES Email Identity**: `mail.dgz48.xyz`(メール専用サブドメイン、apex から独立)
- **Easy DKIM**: RSA 2048-bit、SES マネージドキー自動ローテーション。CNAME ×3 を共有 Route53 ゾーンに登録 → SES が自動検証
- **Custom MAIL FROM**: `bounce.mail.dgz48.xyz` — MX + SPF TXT を Route53 に登録し SPF アライメント成立
- **DMARC**: `_dmarc.mail.dgz48.xyz` に `v=DMARC1; p=none`(プレースホルダー — DKIM/SPF 整合確認後に `rua=` 追加・`quarantine`/`reject` へ段階的移行)
- **Config Set**: `platform-dev-ses` を作成し名前を SSM `/platform/dev/ses-config-set` に publish

## 変更ファイル

| ファイル | 変更 |
|---|---|
| `infra/shared/modules/ses/main.tf` | 新規 — 全 SES リソース |
| `infra/shared/modules/ses/variables.tf` | 新規 — `env` / `base_domain` / `region` |
| `infra/shared/modules/ses/outputs.tf` | 新規 — `config_set_name` / `identity_arn` |
| `infra/shared/modules/ses/versions.tf` | 新規 — Terraform >= 1.11, AWS ~> 5.0 |
| `infra/shared/environments/dev/main.tf` | `module "ses"` + `aws_ssm_parameter.ses_config_set` 追加 |

## Test plan

- [ ] `terraform validate` 通過済み(ローカル確認済み)
- [ ] `terraform plan` を実行し作成されるリソース数(1 identity + 6 Route53 records + 1 MAIL FROM attrs + 1 config set + 1 SSM param = 10 resources)を確認
- [ ] `terraform apply` 後、SES コンソールで `mail.dgz48.xyz` の DKIM 検証ステータスが `Pending` → `Success` に変わることを確認(DNS 伝播: 最大 72h)
- [ ] Route53 で CNAME ×3 / MX / SPF / DMARC レコードが作成されていることを確認
- [ ] SSM `/platform/dev/ses-config-set` に `platform-dev-ses` が書き込まれていることを確認

## 注意事項

- dev は SES sandbox 維持(production access 申請は実利用確認後)
- DKIM 検証完了後に Sprint 1 の Keycloak メール設定(#243)へ進む

🤖 Generated with [Claude Code](https://claude.com/claude-code)
