### PR TITLE
feat(infra): S0Infra-8 — Route53 PHZ tasks.internal + 共有VPC association(SSM参照)

### DIFF
--- a/infra/environments/dev/data.tf
+++ b/infra/environments/dev/data.tf
@@ -1,0 +1,9 @@
+# ---------------------------------------------------------------------------
+# Shared data sources — platform SSM outputs (ADR-0004)
+# Centralised here so all feature .tf files in this root module can reference
+# these without re-declaring the data resource.
+# ---------------------------------------------------------------------------
+
+data "aws_ssm_parameter" "vpc_id" {
+  name = "/platform/${var.env}/vpc-id"
+}

--- a/infra/environments/dev/route53.tf
+++ b/infra/environments/dev/route53.tf
@@ -1,0 +1,11 @@
+# ---------------------------------------------------------------------------
+# Route53 Private Hosted Zone — tasks.internal (S0Infra-8 / ADR-0001)
+# VPC ID is read from shared data.tf (data.aws_ssm_parameter.vpc_id).
+# ---------------------------------------------------------------------------
+
+module "route53" {
+  source = "../../modules/route53"
+
+  env    = var.env
+  vpc_id = data.aws_ssm_parameter.vpc_id.value
+}

--- a/infra/modules/route53/main.tf
+++ b/infra/modules/route53/main.tf
@@ -1,0 +1,27 @@
+# ---------------------------------------------------------------------------
+# Private Hosted Zone — tasks.internal (ADR-0001 α案: env 毎独立 PHZ)
+# Owned by tasks stack, associated with the shared platform VPC (ADR-0004).
+# CNAME db.tasks.internal is a placeholder; replaced by actual RDS endpoint
+# in S1Infra-1 (#318).
+# ---------------------------------------------------------------------------
+
+resource "aws_route53_zone" "tasks_internal" {
+  name    = "tasks.internal"
+  comment = "Private hosted zone for ${var.env} env internal services"
+
+  vpc {
+    vpc_id = var.vpc_id
+  }
+
+  tags = {
+    Name = "tasks-${var.env}-phz"
+  }
+}
+
+resource "aws_route53_record" "db" {
+  zone_id = aws_route53_zone.tasks_internal.zone_id
+  name    = "db.tasks.internal"
+  type    = "CNAME"
+  ttl     = 300
+  records = ["placeholder.invalid"]
+}

--- a/infra/modules/route53/outputs.tf
+++ b/infra/modules/route53/outputs.tf
@@ -1,0 +1,9 @@
+output "zone_id" {
+  description = "Route53 Private Hosted Zone ID for tasks.internal"
+  value       = aws_route53_zone.tasks_internal.zone_id
+}
+
+output "zone_name" {
+  description = "Name of the Private Hosted Zone"
+  value       = aws_route53_zone.tasks_internal.name
+}

--- a/infra/modules/route53/variables.tf
+++ b/infra/modules/route53/variables.tf
@@ -1,0 +1,9 @@
+variable "env" {
+  type        = string
+  description = "Environment name (dev / stg / prd)"
+}
+
+variable "vpc_id" {
+  type        = string
+  description = "VPC ID to associate the Private Hosted Zone with (from platform SSM output)"
+}

--- a/infra/modules/route53/versions.tf
+++ b/infra/modules/route53/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.11"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- `infra/modules/route53/` を新設: `aws_route53_zone`(`tasks.internal` PHZ、共有 VPC に association) + `aws_route53_record`(`db.tasks.internal` CNAME → `placeholder.invalid`、TTL 300)
- `infra/environments/dev/route53.tf`: module 呼び出し(vpc_id は SSM 参照)
- `infra/environments/dev/data.tf`: `/platform/${env}/vpc-id` SSM data source を共有ファイルに集約(将来の SG / RDS 等で重複宣言エラーを防ぐ)
- tasks-apply / tasks-plan の Route53 権限は #246 (IAM OIDC)で既設済み — IAM 変更なし

ADR-0001 α案(env 毎独立 PHZ + 同名 record)/ ADR-0004(SSM クロス参照)準拠。

## 設計上のポイント

- PHZ 名 `tasks.internal` は env prefix なし(ADR-0001 §3 の意図: 各 env の VPC が独立 PHZ を持ち `DATASOURCE_URL` が全 env 共通になる)
- VPC ID は `data.aws_ssm_parameter.vpc_id` → `/platform/dev/vpc-id`(platform stack が publish)
- `db.tasks.internal` CNAME の実 endpoint への差替えは S1Infra-1 (#318) で実施

## Test plan

- [ ] `terraform plan`(tasks dev)で差分なし(新規リソース 2 件のみ)
- [ ] `terraform apply` 後、AWS コンソールで PHZ `tasks.internal` が作成され共有 VPC に associate されていることを確認
- [ ] `db.tasks.internal` CNAME → `placeholder.invalid` が登録されていることを確認
- [ ] 共有 VPC 内 ECS タスク or EC2 から `dig db.tasks.internal` で名前解決確認
- [ ] ADR-0001 α案との整合確認

Closes #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)