### PR TITLE
ci(infra): tasks-apply ジョブを有効化(S0Infra-7/8 条件充足)

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -44,34 +44,30 @@ jobs:
         working-directory: infra/shared/environments/dev
         run: terraform apply -auto-approve -no-color
 
-# ---------------------------------------------------------------------------
-# Uncomment when tasks resources (S0Infra-5+: SG, ECS, RDS, etc.) are ready.
-# tasks-apply depends on platform-apply (SSM outputs must exist).
-# ---------------------------------------------------------------------------
-#   tasks-apply:
-#     needs: platform-apply
-#     runs-on: ubuntu-latest
-#     environment: tasks-apply
-#
-#     steps:
-#       - uses: actions/checkout@v6
-#
-#       - name: Setup Terraform
-#         uses: hashicorp/setup-terraform@v3
-#         with:
-#           terraform_version: '1.11.4'
-#           terraform_wrapper: false
-#
-#       - name: Configure AWS credentials
-#         uses: aws-actions/configure-aws-credentials@v4
-#         with:
-#           role-to-assume: arn:aws:iam::138285070797:role/tasks-dev-apply
-#           aws-region: ap-northeast-1
-#
-#       - name: terraform init (tasks/dev)
-#         working-directory: infra/environments/dev
-#         run: terraform init -no-color
-#
-#       - name: terraform apply (tasks/dev)
-#         working-directory: infra/environments/dev
-#         run: terraform apply -auto-approve -no-color
+  tasks-apply:
+    needs: platform-apply
+    runs-on: ubuntu-latest
+    environment: tasks-apply
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: '1.11.4'
+          terraform_wrapper: false
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::138285070797:role/tasks-dev-apply
+          aws-region: ap-northeast-1
+
+      - name: terraform init (tasks/dev)
+        working-directory: infra/environments/dev
+        run: terraform init -no-color
+
+      - name: terraform apply (tasks/dev)
+        working-directory: infra/environments/dev
+        run: terraform apply -auto-approve -no-color


### PR DESCRIPTION
## Summary

- `terraform-apply.yml` の `tasks-apply` ジョブのコメントアウトを解除
- `needs: platform-apply` による順序制御(platform SSM 出力 → tasks 参照)は維持

## 背景

S0Infra-4 (platform network, #394) マージ時に "tasks resources (S0Infra-5+: SG, ECS, RDS, etc.) are ready になるまで" という条件でコメントアウトされていた。

その後、前提条件が変わり tasks スタックの最初のリソースとして以下がマージされた:
- S0Infra-7: `parameter_store` module (#408)
- S0Infra-8: `route53` PHZ (#410)

`route53` module は `/platform/dev/vpc-id`(platform apply 済み)を SSM 参照するだけで apply 可能であり、条件が満たされた。

## Test plan

- [ ] マージ後に Terraform Apply Action を手動実行
- [ ] `tasks-apply` ジョブが `platform-apply` の後に実行されることを確認
- [ ] tasks dev state に `module.parameter_store.*` + `module.route53.*` が作成されることを確認
- [ ] AWS コンソールで PHZ `tasks.internal` が共有 VPC に association されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)