### PR TITLE
[Phase 1 Sprint 1 A-3] feat(security): JWT.sub → users.oidc_sub 照合エラーパターン整備 (Closes #305)

### DIFF
--- a/docs/specs/基本設計書.md
+++ b/docs/specs/基本設計書.md
@@ -2,9 +2,9 @@
 
 タスク管理システム(マルチテナントSaaS)
 
-Version 1.5.2
+Version 1.5.4
 
-2026-06-01
+2026-06-06
 
 作成者: 開発チーム
 
@@ -35,6 +35,7 @@ Version 1.5.2
 | 1.5.1 | 2026-06-01 | Issue #334: OpenAPI v1.5.0 反映。§5.1 API 一覧の A-14 `PUT /api/tasks/{id}` を廃止(行削除)し A-29 `PATCH /api/tasks/{id}` を新設(期限 / 担当者 / 優先度 / タイトル / 説明 5 項目の部分更新、`JsonNullable<T>` セマンティクス ADR-0014、楽観ロック If-Match/ETag ADR-0012)。§3.3.2 S-06 の API 番号参照を A-29 に更新 | 開発チーム |
 | 1.5.2 | 2026-06-03 | Issue #358: §5.3.2 に `Tenant` オブジェクトフィールド表を追加。`userCount` / `taskCount` は `tenants` テーブルカラムではなくサーバ側集計の読み取り専用フィールドであるため DB スキーマ §4.2.2 から暗黙解決不可として明示 | 開発チーム |
 | 1.5.3 | 2026-06-05 | Issue #345: ADR-0012 派生。§4.2.4 tasks テーブルに `version BIGINT NOT NULL DEFAULT 0`(楽観ロック用 JPA `@Version`)を追加。§5.1 API 一覧 A-15 DELETE に楽観ロック If-Match 必須を追記。OpenAPI v1.7.1 と整合 | 開発チーム |
+| 1.5.4 | 2026-06-06 | Issue #305: §4.2.1 users テーブルに `status ENUM('ACTIVE','INACTIVE') NOT NULL DEFAULT 'ACTIVE'` 列を追記(DDL と整合)。アカウント状態管理(Tenant Admin による無効化)と匿名化(`deleted_at`)の独立概念であることを明示 | 開発チーム |
 
 ## 目次
 
@@ -397,6 +398,7 @@ users テーブルは本システム DB 内に保有する新規テーブル(将
 | full_name | VARCHAR(255) |   | ○ | 氏名。匿名化時は `__deleted__` に置換 |
 | full_name_kana | VARCHAR(255) |   | ○ | 氏名カナ。匿名化時は `__deleted__` に置換 |
 | department_name | VARCHAR(255) |   |   | 部署名。匿名化時は NULL に置換 |
+| status | ENUM('ACTIVE','INACTIVE') |   | ○ DEFAULT 'ACTIVE' | アカウント状態。`INACTIVE` は Tenant Admin による無効化。匿名化済み(`deleted_at IS NOT NULL`)とは独立した概念 (Issue #305) |
 | version | BIGINT |   | ○ DEFAULT 0 | JPA `@Version` 楽観排他用(ADR-0006 §3.4) |
 | deleted_at | DATETIME |   |   | 論理削除日時。NULL = 有効、NOT NULL = 匿名化済み(ADR-0006 §3.4) |
 

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/security/adapter/web/TasksAuthenticationEntryPoint.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/security/adapter/web/TasksAuthenticationEntryPoint.java
@@ -7,6 +7,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.AuthenticationException;
@@ -17,6 +18,7 @@ import xyz.dgz48.tasks.webapi.shared.web.ErrorCode;
 import xyz.dgz48.tasks.webapi.shared.web.ErrorResponse;
 
 /** 認証失敗(401)時に {@link ErrorResponse} 形式の JSON を返す(ADR-0011 / 設計規約 §2.3)。 */
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class TasksAuthenticationEntryPoint implements AuthenticationEntryPoint {
@@ -31,6 +33,8 @@ public class TasksAuthenticationEntryPoint implements AuthenticationEntryPoint {
       HttpServletResponse response,
       AuthenticationException authException)
       throws IOException {
+    auditLog(authException, request);
+
     response.setStatus(HttpStatus.UNAUTHORIZED.value());
     response.setContentType(MediaType.APPLICATION_JSON_VALUE);
     response.setCharacterEncoding(StandardCharsets.UTF_8.name());
@@ -43,5 +47,18 @@ public class TasksAuthenticationEntryPoint implements AuthenticationEntryPoint {
             "認証が必要です",
             request.getRequestURI());
     objectMapper.writeValue(response.getWriter(), errorResponse);
+  }
+
+  private void auditLog(AuthenticationException authException, HttpServletRequest request) {
+    if (authException instanceof UserNotRegisteredException) {
+      // TODO(#144): audit_logs に action='LOGIN_FAILED', detail='USER_NOT_REGISTERED' を記録する
+      log.warn("USER_NOT_REGISTERED: JWT sub に対応するユーザーが存在しません path={}", request.getRequestURI());
+    } else if (authException instanceof UserInactiveException) {
+      // TODO(#144): audit_logs に action='LOGIN_FAILED', detail='USER_INACTIVE' を記録する
+      log.warn("USER_INACTIVE: 無効化済みユーザーの認証試行 path={}", request.getRequestURI());
+    } else if (authException instanceof UserAnonymizedException) {
+      // TODO(#144): audit_logs に action='LOGIN_FAILED', detail='USER_ANONYMIZED' を記録する(監査必須)
+      log.warn("USER_ANONYMIZED: 匿名化済みユーザーの認証試行 path={}", request.getRequestURI());
+    }
   }
 }

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/security/adapter/web/TasksJwtAuthenticationConverter.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/security/adapter/web/TasksJwtAuthenticationConverter.java
@@ -33,10 +33,13 @@ public class TasksJwtAuthenticationConverter
       throw new InvalidBearerTokenException("JWT missing sub claim");
     }
     UserJpaEntity user =
-        userRepository
-            .findByOidcSub(sub)
-            .orElseThrow(
-                () -> new InvalidBearerTokenException("User not found for provided sub claim"));
+        userRepository.findByOidcSub(sub).orElseThrow(UserNotRegisteredException::new);
+    if (user.isAnonymized()) {
+      throw new UserAnonymizedException();
+    }
+    if (user.isInactive()) {
+      throw new UserInactiveException();
+    }
     TasksPrincipal principal =
         new TasksPrincipal(
             user.getId(),

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/security/adapter/web/UserAnonymizedException.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/security/adapter/web/UserAnonymizedException.java
@@ -1,0 +1,11 @@
+package xyz.dgz48.tasks.webapi.security.adapter.web;
+
+import org.springframework.security.core.AuthenticationException;
+
+/** users.deleted_at IS NOT NULL のユーザーが認証試行した(Issue #305 / USER_ANONYMIZED)。 */
+public class UserAnonymizedException extends AuthenticationException {
+
+  public UserAnonymizedException() {
+    super("ユーザーアカウントは削除済みです");
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/security/adapter/web/UserInactiveException.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/security/adapter/web/UserInactiveException.java
@@ -1,0 +1,11 @@
+package xyz.dgz48.tasks.webapi.security.adapter.web;
+
+import org.springframework.security.core.AuthenticationException;
+
+/** users.status = INACTIVE のユーザーが認証試行した(Issue #305 / USER_INACTIVE)。 */
+public class UserInactiveException extends AuthenticationException {
+
+  public UserInactiveException() {
+    super("ユーザーアカウントが無効化されています");
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/security/adapter/web/UserNotRegisteredException.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/security/adapter/web/UserNotRegisteredException.java
@@ -1,0 +1,11 @@
+package xyz.dgz48.tasks.webapi.security.adapter.web;
+
+import org.springframework.security.core.AuthenticationException;
+
+/** JWT.sub に対応する users レコードが存在しない(Issue #305 / USER_NOT_REGISTERED)。 */
+public class UserNotRegisteredException extends AuthenticationException {
+
+  public UserNotRegisteredException() {
+    super("JWT sub に対応するユーザーが登録されていません");
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/adapter/persistence/UserJpaEntity.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/adapter/persistence/UserJpaEntity.java
@@ -2,6 +2,8 @@ package xyz.dgz48.tasks.webapi.user.adapter.persistence;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -12,6 +14,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.jspecify.annotations.Nullable;
+import xyz.dgz48.tasks.webapi.user.domain.UserStatus;
 
 @Entity
 @Table(name = "users")
@@ -44,9 +47,21 @@ public class UserJpaEntity {
   @Column(nullable = false)
   private Long version;
 
+  @Enumerated(EnumType.STRING)
+  @Column(name = "status", nullable = false, columnDefinition = "ENUM('ACTIVE','INACTIVE')")
+  private UserStatus status;
+
   @Nullable
   @Column(name = "deleted_at")
   private LocalDateTime deletedAt;
+
+  public boolean isAnonymized() {
+    return this.deletedAt != null;
+  }
+
+  public boolean isInactive() {
+    return this.status == UserStatus.INACTIVE;
+  }
 
   public UserJpaEntity(
       String oidcSub,
@@ -59,5 +74,6 @@ public class UserJpaEntity {
     this.fullName = fullName;
     this.fullNameKana = fullNameKana;
     this.departmentName = departmentName;
+    this.status = UserStatus.ACTIVE;
   }
 }

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/domain/User.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/domain/User.java
@@ -19,6 +19,7 @@ public class User {
   private String fullName;
   private String fullNameKana;
   @Nullable private String departmentName;
+  private UserStatus status;
   private long version;
   @Nullable private LocalDateTime deletedAt;
 
@@ -29,6 +30,7 @@ public class User {
       String fullName,
       String fullNameKana,
       @Nullable String departmentName,
+      UserStatus status,
       long version,
       @Nullable LocalDateTime deletedAt) {
     this.id = id;
@@ -37,6 +39,7 @@ public class User {
     this.fullName = fullName;
     this.fullNameKana = fullNameKana;
     this.departmentName = departmentName;
+    this.status = status;
     this.version = version;
     this.deletedAt = deletedAt;
   }

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/domain/UserStatus.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/domain/UserStatus.java
@@ -1,0 +1,7 @@
+package xyz.dgz48.tasks.webapi.user.domain;
+
+/** ユーザーアカウント状態(Issue #305)。 */
+public enum UserStatus {
+  ACTIVE,
+  INACTIVE
+}

--- a/webapi/src/main/resources/db/migration/V1.0.0_01__create_tables.sql
+++ b/webapi/src/main/resources/db/migration/V1.0.0_01__create_tables.sql
@@ -5,6 +5,7 @@ CREATE TABLE users (
     full_name       VARCHAR(255) NOT NULL COMMENT '氏名。匿名化時は __deleted__ に置換',
     full_name_kana  VARCHAR(255) NOT NULL COMMENT '氏名カナ。匿名化時は __deleted__ に置換',
     department_name VARCHAR(255) NULL     COMMENT '部署名。匿名化時は NULL に置換',
+    status          ENUM('ACTIVE','INACTIVE') NOT NULL DEFAULT 'ACTIVE' COMMENT 'アカウント状態(ACTIVE=有効, INACTIVE=無効化)',
     version         BIGINT       NOT NULL DEFAULT 0 COMMENT 'JPA @Version 楽観排他用(ADR-0006 §3.4)',
     deleted_at      DATETIME     NULL     COMMENT '論理削除日時。NULL=有効、NOT NULL=匿名化済み(ADR-0006 §3.4)',
     PRIMARY KEY (id),

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/SecurityConfigTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/SecurityConfigTest.java
@@ -9,8 +9,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.time.Instant;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.context.annotation.Import;
@@ -18,6 +22,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.security.oauth2.core.OAuth2Error;
 import org.springframework.security.oauth2.jwt.BadJwtException;
+import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.JwtValidationException;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -31,6 +36,7 @@ import xyz.dgz48.tasks.webapi.tenant.usecase.ChangeMemberRoleUseCase;
 import xyz.dgz48.tasks.webapi.tenant.usecase.RemoveMemberUseCase;
 import xyz.dgz48.tasks.webapi.tenant.usecase.SwitchTenantUseCase;
 import xyz.dgz48.tasks.webapi.tenant.usecase.TenantMembershipPort;
+import xyz.dgz48.tasks.webapi.user.adapter.persistence.UserJpaEntity;
 import xyz.dgz48.tasks.webapi.user.adapter.persistence.UserRepository;
 
 @WebMvcTest
@@ -138,5 +144,63 @@ class SecurityConfigTest {
     mockMvc
         .perform(get("/api/tasks").header("Authorization", "Bearer malformed.token"))
         .andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  void userNotRegisteredReturns401() throws Exception {
+    given(jwtDecoder.decode(any())).willReturn(buildMockJwt("unregistered-sub"));
+    given(userRepository.findByOidcSub("unregistered-sub")).willReturn(Optional.empty());
+
+    mockMvc
+        .perform(get("/api/tasks").header(HttpHeaders.AUTHORIZATION, "Bearer mock.token"))
+        .andExpect(status().isUnauthorized())
+        .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.status").value(401))
+        .andExpect(jsonPath("$.code").value("E_UNAUTHORIZED"))
+        .andExpect(jsonPath("$.message").value("認証が必要です"));
+  }
+
+  @Test
+  void inactiveUserReturns401() throws Exception {
+    UserJpaEntity inactiveUser = Mockito.mock(UserJpaEntity.class);
+    Mockito.when(inactiveUser.isAnonymized()).thenReturn(false);
+    Mockito.when(inactiveUser.isInactive()).thenReturn(true);
+
+    given(jwtDecoder.decode(any())).willReturn(buildMockJwt("inactive-sub"));
+    given(userRepository.findByOidcSub("inactive-sub")).willReturn(Optional.of(inactiveUser));
+
+    mockMvc
+        .perform(get("/api/tasks").header(HttpHeaders.AUTHORIZATION, "Bearer mock.token"))
+        .andExpect(status().isUnauthorized())
+        .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.status").value(401))
+        .andExpect(jsonPath("$.code").value("E_UNAUTHORIZED"))
+        .andExpect(jsonPath("$.message").value("認証が必要です"));
+  }
+
+  @Test
+  void anonymizedUserReturns401() throws Exception {
+    UserJpaEntity anonymizedUser = Mockito.mock(UserJpaEntity.class);
+    Mockito.when(anonymizedUser.isAnonymized()).thenReturn(true);
+
+    given(jwtDecoder.decode(any())).willReturn(buildMockJwt("anonymized-sub"));
+    given(userRepository.findByOidcSub("anonymized-sub")).willReturn(Optional.of(anonymizedUser));
+
+    mockMvc
+        .perform(get("/api/tasks").header(HttpHeaders.AUTHORIZATION, "Bearer mock.token"))
+        .andExpect(status().isUnauthorized())
+        .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.status").value(401))
+        .andExpect(jsonPath("$.code").value("E_UNAUTHORIZED"))
+        .andExpect(jsonPath("$.message").value("認証が必要です"));
+  }
+
+  private static Jwt buildMockJwt(String sub) {
+    return new Jwt(
+        "mock-token-value",
+        Instant.now(),
+        Instant.now().plusSeconds(3600),
+        Map.of("alg", "RS256"),
+        Map.of("sub", sub));
   }
 }

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/TasksJwtAuthenticationConverterTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/TasksJwtAuthenticationConverterTest.java
@@ -31,6 +31,8 @@ class TasksJwtAuthenticationConverterTest {
   private void stubValidUser() {
     when(jwt.getSubject()).thenReturn("sub123");
     when(userRepository.findByOidcSub("sub123")).thenReturn(Optional.of(user));
+    when(user.isAnonymized()).thenReturn(false);
+    when(user.isInactive()).thenReturn(false);
     when(user.getId()).thenReturn(1L);
     when(user.getOidcSub()).thenReturn("sub123");
     when(user.getEmail()).thenReturn("user@example.com");
@@ -78,12 +80,11 @@ class TasksJwtAuthenticationConverterTest {
   }
 
   @Test
-  void throwsWhenUserNotFound() {
+  void throwsUserNotRegisteredWhenUserNotFound() {
     when(jwt.getSubject()).thenReturn("unknown-sub");
     when(userRepository.findByOidcSub("unknown-sub")).thenReturn(Optional.empty());
 
-    assertThatThrownBy(() -> converter.convert(jwt))
-        .isInstanceOf(InvalidBearerTokenException.class);
+    assertThatThrownBy(() -> converter.convert(jwt)).isInstanceOf(UserNotRegisteredException.class);
   }
 
   @Test
@@ -92,5 +93,37 @@ class TasksJwtAuthenticationConverterTest {
 
     assertThatThrownBy(() -> converter.convert(jwt))
         .isInstanceOf(InvalidBearerTokenException.class);
+  }
+
+  @Test
+  void throwsUserAnonymizedWhenDeletedAtIsSet() {
+    when(jwt.getSubject()).thenReturn("sub-anon");
+    when(userRepository.findByOidcSub("sub-anon")).thenReturn(Optional.of(user));
+    when(user.isAnonymized()).thenReturn(true);
+
+    assertThatThrownBy(() -> converter.convert(jwt))
+        .isInstanceOf(UserAnonymizedException.class)
+        .hasMessage("ユーザーアカウントは削除済みです");
+  }
+
+  @Test
+  void throwsUserInactiveWhenStatusIsInactive() {
+    when(jwt.getSubject()).thenReturn("sub-inactive");
+    when(userRepository.findByOidcSub("sub-inactive")).thenReturn(Optional.of(user));
+    when(user.isAnonymized()).thenReturn(false);
+    when(user.isInactive()).thenReturn(true);
+
+    assertThatThrownBy(() -> converter.convert(jwt))
+        .isInstanceOf(UserInactiveException.class)
+        .hasMessage("ユーザーアカウントが無効化されています");
+  }
+
+  @Test
+  void anonymizedCheckTakesPriorityOverInactiveCheck() {
+    when(jwt.getSubject()).thenReturn("sub-both");
+    when(userRepository.findByOidcSub("sub-both")).thenReturn(Optional.of(user));
+    when(user.isAnonymized()).thenReturn(true);
+
+    assertThatThrownBy(() -> converter.convert(jwt)).isInstanceOf(UserAnonymizedException.class);
   }
 }

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/user/domain/UserAnonymizationDomainServiceTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/user/domain/UserAnonymizationDomainServiceTest.java
@@ -13,7 +13,15 @@ class UserAnonymizationDomainServiceTest {
 
   private User buildActiveUser(long id) {
     return new User(
-        id, "sub-" + id, "user" + id + "@example.com", "山田 太郎", "ヤマダ タロウ", "開発部", 0L, null);
+        id,
+        "sub-" + id,
+        "user" + id + "@example.com",
+        "山田 太郎",
+        "ヤマダ タロウ",
+        "開発部",
+        UserStatus.ACTIVE,
+        0L,
+        null);
   }
 
   @Test


### PR DESCRIPTION
Closes #305

## Summary

- **Issue**: #305 (Phase 1 Sprint 1 A-3)
- **3エラーパターン** (USER_NOT_REGISTERED / USER_INACTIVE / USER_ANONYMIZED) を網羅し、それぞれの 401 応答・ログ出力・audit_logs 記録方針を実装

## 変更内容

### DDL
- `V1.0.0_01__create_tables.sql`: `users` テーブルに `status ENUM('ACTIVE','INACTIVE') NOT NULL DEFAULT 'ACTIVE'` 追加(設計規約 §3.1 Sprint 1 直接追記例外)

### Domain / Persistence
- `UserStatus` enum 新規追加 (`user.domain`)
- `UserJpaEntity`: `status` フィールド追加 + `isAnonymized()` / `isInactive()` ヘルパー追加
  - `@Column(columnDefinition = "ENUM('ACTIVE','INACTIVE')")` で他エンティティの規約に統一
- `User` ドメイン: `status` フィールド追加(ドメインモデルとの整合)

### Security
- `UserNotRegisteredException` / `UserInactiveException` / `UserAnonymizedException` 追加(各 `AuthenticationException` サブクラス)
- `TasksJwtAuthenticationConverter`: 匿名化済み(deleted_at) → INACTIVE(status) の順で検査し各例外を throw
- `TasksAuthenticationEntryPoint`:
  - HTTP レスポンスは全 401 で `"認証が必要です"` に統一(**NIST AC-4** / 設計規約 §2.3 準拠 — アカウント状態列挙を防止)
  - `USER_NOT_REGISTERED` / `USER_INACTIVE` / `USER_ANONYMIZED` は WARN ログ出力
  - `TODO(#144)` コメントで audit_logs 記録の将来実装を明示
  - `@Slf4j` を使用(コーディング規約 §3 / §7 に準拠)

### ドキュメント
- `docs/specs/基本設計書.md` §4.2.1: `users` テーブル定義に `status` 列を追記(設計規約 §2.1 3点一貫性対応。v1.5.4 に改訂)

### テスト
- `TasksJwtAuthenticationConverterTest`: 4ケース追加 (USER_NOT_REGISTERED / ANONYMIZED / INACTIVE / 優先順)
- `SecurityConfigTest`: 3ケース追加 (各エラーで 401 + E_UNAUTHORIZED + "認証が必要です")

## セルフレビューで修正した点

セルフレビューで以下を修正してから PR 化:

| # | 指摘 | 対応 |
|---|------|------|
| HIGH | 3種のメッセージがアカウント列挙オラクルになる(NIST AC-4 違反) | 全 401 を "認証が必要です" に統一、識別情報はログのみ |
| MEDIUM | `UserInactiveException` が `auditLog()` から漏れていた | WARN ログ追加 |
| LOW | 手動 `LoggerFactory.getLogger` (コーディング規約 §7 違反) | `@Slf4j` に変更 |
| LOW | `@Column(length = 8)` が他エンティティの `columnDefinition` 規約と不整合 | `columnDefinition = "ENUM('ACTIVE','INACTIVE')"` に統一 |

## 未対応レビュー

| 指摘 | 内容 | 状態 |
|---|---|---|
| [HIGH] 基本設計書 §4.2.1 status 列未追記 | 設計規約 §2.1 3点一貫性違反 | 対応済(39831c7) |

## Test plan

- [ ] `./gradlew :webapi:check` グリーン確認済み
- [ ] `TasksJwtAuthenticationConverterTest` — 3エラーパターン + 正常系 + 優先順 テスト
- [ ] `SecurityConfigTest` — 各エラーで 401 + `E_UNAUTHORIZED` + `"認証が必要です"` を WebMvc レベルで確認
- [ ] audit_logs への記録は #144 実装後に完全実装(TODO コメントで連携済み)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
