### PR TITLE
[Phase 1 Sprint 1 D-4] feat(audit): クロステナント違反検知ログ

### DIFF
--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/adapter/package-info.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/adapter/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package xyz.dgz48.tasks.webapi.audit.adapter;
+
+import org.jspecify.annotations.NullMarked;

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/adapter/persistence/AuditLogJpaEntity.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/adapter/persistence/AuditLogJpaEntity.java
@@ -6,9 +6,6 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -70,28 +67,13 @@ class AuditLogJpaEntity {
       @Nullable Long userId,
       String action,
       @Nullable String detail,
-      LocalDateTime createdAt) {
+      LocalDateTime createdAt,
+      String hashChain) {
     this.tenantId = tenantId;
     this.userId = userId;
     this.action = action;
     this.detail = detail;
     this.createdAt = createdAt;
-    this.hashChain = computeHash(action, tenantId, userId, createdAt);
-  }
-
-  private static String computeHash(
-      String action, @Nullable Long tenantId, @Nullable Long userId, LocalDateTime createdAt) {
-    String input = action + "|" + tenantId + "|" + userId + "|" + createdAt;
-    try {
-      MessageDigest digest = MessageDigest.getInstance("SHA-256");
-      byte[] hashBytes = digest.digest(input.getBytes(StandardCharsets.UTF_8));
-      StringBuilder hex = new StringBuilder(64);
-      for (byte b : hashBytes) {
-        hex.append(String.format("%02x", b));
-      }
-      return hex.toString();
-    } catch (NoSuchAlgorithmException e) {
-      throw new IllegalStateException("SHA-256 not available", e);
-    }
+    this.hashChain = hashChain;
   }
 }

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/adapter/persistence/AuditLogJpaEntity.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/adapter/persistence/AuditLogJpaEntity.java
@@ -1,0 +1,97 @@
+package xyz.dgz48.tasks.webapi.audit.adapter.persistence;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * audit_logs テーブルの JPA エンティティ。
+ *
+ * <p>{@code tenant_id} が nullable(システム横断イベントは NULL)であり、テナント範囲を超えた参照が必要なため {@code
+ * TenantFilteredEntity} を継承しない(ADR-0010 §6.1)。
+ */
+@Entity
+@Table(name = "audit_logs")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SuppressWarnings("NullAway.Init")
+class AuditLogJpaEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Nullable
+  @Column(name = "tenant_id")
+  private Long tenantId;
+
+  @Nullable
+  @Column(name = "user_id")
+  private Long userId;
+
+  @Column(name = "action", nullable = false, length = 50)
+  private String action;
+
+  @Nullable
+  @Column(name = "entity_type", length = 50)
+  private String entityType;
+
+  @Nullable
+  @Column(name = "entity_id")
+  private Long entityId;
+
+  @Nullable
+  @Column(name = "detail", columnDefinition = "JSON")
+  private String detail;
+
+  @Nullable
+  @Column(name = "ip_address", length = 45)
+  private String ipAddress;
+
+  @Column(name = "hash_chain", nullable = false, length = 64)
+  private String hashChain;
+
+  @Column(name = "created_at", nullable = false)
+  private LocalDateTime createdAt;
+
+  AuditLogJpaEntity(
+      @Nullable Long tenantId,
+      @Nullable Long userId,
+      String action,
+      @Nullable String detail,
+      LocalDateTime createdAt) {
+    this.tenantId = tenantId;
+    this.userId = userId;
+    this.action = action;
+    this.detail = detail;
+    this.createdAt = createdAt;
+    this.hashChain = computeHash(action, tenantId, userId, createdAt);
+  }
+
+  private static String computeHash(
+      String action, @Nullable Long tenantId, @Nullable Long userId, LocalDateTime createdAt) {
+    String input = action + "|" + tenantId + "|" + userId + "|" + createdAt;
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      byte[] hashBytes = digest.digest(input.getBytes(StandardCharsets.UTF_8));
+      StringBuilder hex = new StringBuilder(64);
+      for (byte b : hashBytes) {
+        hex.append(String.format("%02x", b));
+      }
+      return hex.toString();
+    } catch (NoSuchAlgorithmException e) {
+      throw new IllegalStateException("SHA-256 not available", e);
+    }
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/adapter/persistence/AuditLogJpaRepository.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/adapter/persistence/AuditLogJpaRepository.java
@@ -1,0 +1,5 @@
+package xyz.dgz48.tasks.webapi.audit.adapter.persistence;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+interface AuditLogJpaRepository extends JpaRepository<AuditLogJpaEntity, Long> {}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/adapter/persistence/AuditLogJpaRepository.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/adapter/persistence/AuditLogJpaRepository.java
@@ -1,5 +1,9 @@
 package xyz.dgz48.tasks.webapi.audit.adapter.persistence;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-interface AuditLogJpaRepository extends JpaRepository<AuditLogJpaEntity, Long> {}
+interface AuditLogJpaRepository extends JpaRepository<AuditLogJpaEntity, Long> {
+
+  Optional<AuditLogJpaEntity> findFirstByOrderByIdDesc();
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/adapter/persistence/AuditLogPersistenceAdapter.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/adapter/persistence/AuditLogPersistenceAdapter.java
@@ -1,5 +1,8 @@
 package xyz.dgz48.tasks.webapi.audit.adapter.persistence;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.time.Clock;
 import java.time.LocalDateTime;
 import org.jspecify.annotations.Nullable;
@@ -9,6 +12,8 @@ import xyz.dgz48.tasks.webapi.audit.usecase.AuditLogPort;
 
 @Component
 class AuditLogPersistenceAdapter implements AuditLogPort {
+
+  static final String GENESIS_HASH = "0".repeat(64);
 
   private final AuditLogJpaRepository repository;
   private final Clock clock;
@@ -21,8 +26,28 @@ class AuditLogPersistenceAdapter implements AuditLogPort {
   @Override
   public void record(
       AuditEventType eventType, @Nullable Long tenantId, @Nullable Long userId, String detail) {
+    LocalDateTime createdAt = LocalDateTime.now(clock);
+    String hashChain = computeChainHash(repository.findFirstByOrderByIdDesc().orElse(null));
     var entity =
-        new AuditLogJpaEntity(tenantId, userId, eventType.name(), detail, LocalDateTime.now(clock));
+        new AuditLogJpaEntity(tenantId, userId, eventType.name(), detail, createdAt, hashChain);
     repository.save(entity);
+  }
+
+  static String computeChainHash(@Nullable AuditLogJpaEntity prev) {
+    if (prev == null) {
+      return GENESIS_HASH;
+    }
+    String input = prev.getId() + "|" + prev.getDetail() + "|" + prev.getCreatedAt();
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      byte[] hashBytes = digest.digest(input.getBytes(StandardCharsets.UTF_8));
+      StringBuilder hex = new StringBuilder(64);
+      for (byte b : hashBytes) {
+        hex.append(String.format("%02x", b));
+      }
+      return hex.toString();
+    } catch (NoSuchAlgorithmException e) {
+      throw new IllegalStateException("SHA-256 not available", e);
+    }
   }
 }

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/adapter/persistence/AuditLogPersistenceAdapter.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/adapter/persistence/AuditLogPersistenceAdapter.java
@@ -1,0 +1,28 @@
+package xyz.dgz48.tasks.webapi.audit.adapter.persistence;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import org.jspecify.annotations.Nullable;
+import org.springframework.stereotype.Component;
+import xyz.dgz48.tasks.webapi.audit.domain.AuditEventType;
+import xyz.dgz48.tasks.webapi.audit.usecase.AuditLogPort;
+
+@Component
+class AuditLogPersistenceAdapter implements AuditLogPort {
+
+  private final AuditLogJpaRepository repository;
+  private final Clock clock;
+
+  AuditLogPersistenceAdapter(AuditLogJpaRepository repository, Clock clock) {
+    this.repository = repository;
+    this.clock = clock;
+  }
+
+  @Override
+  public void record(
+      AuditEventType eventType, @Nullable Long tenantId, @Nullable Long userId, String detail) {
+    var entity =
+        new AuditLogJpaEntity(tenantId, userId, eventType.name(), detail, LocalDateTime.now(clock));
+    repository.save(entity);
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/adapter/persistence/package-info.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/adapter/persistence/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package xyz.dgz48.tasks.webapi.audit.adapter.persistence;
+
+import org.jspecify.annotations.NullMarked;

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/domain/AuditEventType.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/domain/AuditEventType.java
@@ -1,0 +1,6 @@
+package xyz.dgz48.tasks.webapi.audit.domain;
+
+/** audit_logs.action に記録するイベント種別。 */
+public enum AuditEventType {
+  CROSS_TENANT_VIOLATION_ATTEMPT
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/domain/package-info.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/domain/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package xyz.dgz48.tasks.webapi.audit.domain;
+
+import org.jspecify.annotations.NullMarked;

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/package-info.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package xyz.dgz48.tasks.webapi.audit;
+
+import org.jspecify.annotations.NullMarked;

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/usecase/AuditLogPort.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/usecase/AuditLogPort.java
@@ -1,0 +1,19 @@
+package xyz.dgz48.tasks.webapi.audit.usecase;
+
+import org.jspecify.annotations.Nullable;
+import xyz.dgz48.tasks.webapi.audit.domain.AuditEventType;
+
+/** audit_logs テーブルへの書き込み Port。 */
+public interface AuditLogPort {
+
+  /**
+   * 監査ログを記録する。
+   *
+   * @param eventType イベント種別
+   * @param tenantId テナント ID(システム横断イベントの場合は {@code null})
+   * @param userId 操作ユーザー ID(不明な場合は {@code null})
+   * @param detail JSON 形式の詳細情報
+   */
+  void record(
+      AuditEventType eventType, @Nullable Long tenantId, @Nullable Long userId, String detail);
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/usecase/CrossTenantViolationAuditService.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/usecase/CrossTenantViolationAuditService.java
@@ -1,0 +1,34 @@
+package xyz.dgz48.tasks.webapi.audit.usecase;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import xyz.dgz48.tasks.webapi.audit.domain.AuditEventType;
+import xyz.dgz48.tasks.webapi.shared.domain.CrossTenantViolationDetectedEvent;
+
+/**
+ * {@link CrossTenantViolationDetectedEvent} を受信して {@code audit_logs} に記録するサービス。
+ *
+ * <p>{@code REQUIRES_NEW} トランザクションで独立コミットするため、違反検知元のトランザクションがロールバックされても記録は保持される。 {@code
+ * CrossTenantViolationInspector} が {@code StatementInspector} 内から発火するイベントの再帰を防ぐため、 Inspector 側で
+ * {@code IN_VIOLATION_HANDLING} フラグを立ててから {@code publishEvent} を呼び出す。
+ */
+@Service
+class CrossTenantViolationAuditService {
+
+  private final AuditLogPort auditLogPort;
+
+  CrossTenantViolationAuditService(AuditLogPort auditLogPort) {
+    this.auditLogPort = auditLogPort;
+  }
+
+  @EventListener
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  public void onViolationDetected(CrossTenantViolationDetectedEvent event) {
+    String detail =
+        "{\"table\":\"" + event.tableName() + "\",\"sqlType\":\"" + event.sqlType() + "\"}";
+    auditLogPort.record(
+        AuditEventType.CROSS_TENANT_VIOLATION_ATTEMPT, event.tenantId(), event.userId(), detail);
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/usecase/CrossTenantViolationAuditService.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/usecase/CrossTenantViolationAuditService.java
@@ -4,6 +4,7 @@ import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.json.JsonMapper;
 import xyz.dgz48.tasks.webapi.audit.domain.AuditEventType;
 import xyz.dgz48.tasks.webapi.shared.domain.CrossTenantViolationDetectedEvent;
 
@@ -18,16 +19,22 @@ import xyz.dgz48.tasks.webapi.shared.domain.CrossTenantViolationDetectedEvent;
 class CrossTenantViolationAuditService {
 
   private final AuditLogPort auditLogPort;
+  private final JsonMapper jsonMapper;
 
-  CrossTenantViolationAuditService(AuditLogPort auditLogPort) {
+  CrossTenantViolationAuditService(AuditLogPort auditLogPort, JsonMapper jsonMapper) {
     this.auditLogPort = auditLogPort;
+    this.jsonMapper = jsonMapper;
   }
 
   @EventListener
   @Transactional(propagation = Propagation.REQUIRES_NEW)
   public void onViolationDetected(CrossTenantViolationDetectedEvent event) {
     String detail =
-        "{\"table\":\"" + event.tableName() + "\",\"sqlType\":\"" + event.sqlType() + "\"}";
+        jsonMapper
+            .createObjectNode()
+            .put("table", event.tableName())
+            .put("sqlType", event.sqlType())
+            .toString();
     auditLogPort.record(
         AuditEventType.CROSS_TENANT_VIOLATION_ATTEMPT, event.tenantId(), event.userId(), detail);
   }

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/usecase/package-info.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/usecase/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package xyz.dgz48.tasks.webapi.audit.usecase;
+
+import org.jspecify.annotations.NullMarked;

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/shared/domain/CrossTenantViolationDetectedEvent.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/shared/domain/CrossTenantViolationDetectedEvent.java
@@ -1,0 +1,13 @@
+package xyz.dgz48.tasks.webapi.shared.domain;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Hibernate Filter 未設定で tenant-filtered テーブルへの SQL が発行された際に {@code CrossTenantViolationInspector}
+ * が発火するドメインイベント。
+ *
+ * <p>{@code audit} feature の {@code CrossTenantViolationAuditService} が {@code REQUIRES_NEW}
+ * トランザクションで {@code audit_logs} に記録する。
+ */
+public record CrossTenantViolationDetectedEvent(
+    @Nullable Long tenantId, @Nullable Long userId, String tableName, String sqlType) {}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/shared/domain/TenantFilterBypassContext.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/shared/domain/TenantFilterBypassContext.java
@@ -1,0 +1,31 @@
+package xyz.dgz48.tasks.webapi.shared.domain;
+
+/**
+ * {@link xyz.dgz48.tasks.webapi.shared.usecase.TenantFilterBypassService} による正当な SaaS Admin bypass
+ * 実行中であることを ThreadLocal で示す。
+ *
+ * <p>{@code activate()} / {@code deactivate()} は {@link
+ * xyz.dgz48.tasks.webapi.shared.usecase.TenantFilterBypassService} からのみ呼び出す。{@code isActive()} は
+ * {@code CrossTenantViolationInspector} が false positive を除外するために参照する。
+ */
+public final class TenantFilterBypassContext {
+
+  private static final ThreadLocal<Boolean> ACTIVE = ThreadLocal.withInitial(() -> Boolean.FALSE);
+
+  private TenantFilterBypassContext() {}
+
+  /** 現在のスレッドが正当な SaaS Admin bypass 実行中かどうかを返す。 */
+  public static boolean isActive() {
+    return Boolean.TRUE.equals(ACTIVE.get());
+  }
+
+  /** bypass 開始を記録する。{@link xyz.dgz48.tasks.webapi.shared.usecase.TenantFilterBypassService} 専用。 */
+  public static void activate() {
+    ACTIVE.set(Boolean.TRUE);
+  }
+
+  /** bypass 終了を記録する。{@link xyz.dgz48.tasks.webapi.shared.usecase.TenantFilterBypassService} 専用。 */
+  public static void deactivate() {
+    ACTIVE.remove();
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/shared/infra/CrossTenantViolationInspector.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/shared/infra/CrossTenantViolationInspector.java
@@ -1,0 +1,113 @@
+package xyz.dgz48.tasks.webapi.shared.infra;
+
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+import org.hibernate.resource.jdbc.spi.StatementInspector;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.hibernate.autoconfigure.HibernatePropertiesCustomizer;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+import xyz.dgz48.tasks.webapi.shared.domain.CrossTenantViolationDetectedEvent;
+import xyz.dgz48.tasks.webapi.shared.domain.TenantContext;
+import xyz.dgz48.tasks.webapi.shared.domain.TenantFilterBypassContext;
+
+/**
+ * Hibernate Filter が未設定の状態で tenant-filtered テーブルへの SQL が発行された場合を検知する {@link StatementInspector}。
+ *
+ * <p>検知条件:
+ *
+ * <ol>
+ *   <li>{@link TenantContext#get()} が {@code null}(フィルタ未設定)
+ *   <li>{@link TenantFilterBypassContext#isActive()} が {@code false}(D-1 正当 bypass でない)
+ *   <li>SQL が {@link #TENANT_FILTERED_TABLES} に含まれるテーブル名を参照している
+ * </ol>
+ *
+ * <p>検知時は WARN ログを出力し {@link CrossTenantViolationDetectedEvent} を発火する。 イベントは {@code
+ * CrossTenantViolationAuditService} が {@code REQUIRES_NEW} トランザクションで {@code audit_logs} に記録する。
+ *
+ * <p>{@link #IN_VIOLATION_HANDLING} フラグで再帰的な発火(audit 書き込み中の Inspector 呼び出し)を防止する。
+ *
+ * <p><strong>テーブルセットの保守</strong>: {@code TenantFilteredEntity} サブクラスのテーブルが増えたら {@code
+ * TENANT_FILTERED_TABLES} に追加すること。{@code HibernateFilterEntityAuditTest} が CI でサブクラスの付与漏れを検知する。
+ */
+@Component
+class CrossTenantViolationInspector implements StatementInspector, HibernatePropertiesCustomizer {
+
+  private static final Logger log = LoggerFactory.getLogger(CrossTenantViolationInspector.class);
+
+  private static final ThreadLocal<Boolean> IN_VIOLATION_HANDLING =
+      ThreadLocal.withInitial(() -> Boolean.FALSE);
+
+  /**
+   * Hibernate Filter 対象テーブル名セット。{@code TenantFilteredEntity} サブクラスのテーブルをすべて列挙する (ADR-0010
+   * §6.1)。新規テーブル追加時はここも更新すること。
+   */
+  private static final Set<String> TENANT_FILTERED_TABLES = Set.of("tasks");
+
+  private static final Pattern TABLE_PATTERN;
+
+  static {
+    String alternation = String.join("|", TENANT_FILTERED_TABLES);
+    TABLE_PATTERN = Pattern.compile("\\b(" + alternation + ")\\b", Pattern.CASE_INSENSITIVE);
+  }
+
+  private final ApplicationEventPublisher eventPublisher;
+
+  CrossTenantViolationInspector(ApplicationEventPublisher eventPublisher) {
+    this.eventPublisher = eventPublisher;
+  }
+
+  @Override
+  public @Nullable String inspect(String sql) {
+    if (Boolean.TRUE.equals(IN_VIOLATION_HANDLING.get())) {
+      return sql;
+    }
+    if (TenantContext.get() != null) {
+      return sql;
+    }
+    if (TenantFilterBypassContext.isActive()) {
+      return sql;
+    }
+
+    var matcher = TABLE_PATTERN.matcher(sql);
+    if (!matcher.find()) {
+      return sql;
+    }
+
+    String tableName = matcher.group(1);
+    String sqlType = detectSqlType(sql);
+
+    log.warn(
+        "クロステナント違反検知: TenantContext 未設定で tenant-filtered テーブルへの SQL 発行 table={} sqlType={}",
+        tableName,
+        sqlType);
+
+    IN_VIOLATION_HANDLING.set(Boolean.TRUE);
+    try {
+      eventPublisher.publishEvent(
+          new CrossTenantViolationDetectedEvent(null, null, tableName, sqlType));
+    } finally {
+      IN_VIOLATION_HANDLING.remove();
+    }
+
+    return sql;
+  }
+
+  @Override
+  public void customize(Map<String, Object> hibernateProperties) {
+    hibernateProperties.put("hibernate.session_factory.statement_inspector", this);
+  }
+
+  private static String detectSqlType(String sql) {
+    String upper = sql.stripLeading().toUpperCase(Locale.ROOT);
+    if (upper.startsWith("SELECT")) return "SELECT";
+    if (upper.startsWith("INSERT")) return "INSERT";
+    if (upper.startsWith("UPDATE")) return "UPDATE";
+    if (upper.startsWith("DELETE")) return "DELETE";
+    return "UNKNOWN";
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/shared/usecase/TenantFilterBypassService.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/shared/usecase/TenantFilterBypassService.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import xyz.dgz48.tasks.webapi.shared.domain.TenantContext;
+import xyz.dgz48.tasks.webapi.shared.domain.TenantFilterBypassContext;
 import xyz.dgz48.tasks.webapi.shared.exception.SaasAdminRequiredException;
 
 /**
@@ -48,10 +49,12 @@ public class TenantFilterBypassService {
     checkSaasAdminRole();
     @Nullable Long previousTenantId = TenantContext.get();
     Session session = entityManager.unwrap(Session.class);
+    TenantFilterBypassContext.activate();
     session.disableFilter(TENANT_FILTER);
     try {
       return action.get();
     } finally {
+      TenantFilterBypassContext.deactivate();
       if (previousTenantId != null) {
         session.enableFilter(TENANT_FILTER).setParameter(TENANT_ID_PARAM, previousTenantId);
       }

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/audit/CrossTenantViolationDetectionIT.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/audit/CrossTenantViolationDetectionIT.java
@@ -116,6 +116,28 @@ class CrossTenantViolationDetectionIT {
     assertThat(rows).isEmpty();
   }
 
+  @Test
+  void hashChain_firstRecordUsesGenesisHash_secondRecordHasNonGenesisHash() {
+    // 1件目の違反を記録
+    taskRepository.findById(Long.MAX_VALUE);
+    // 2件目の違反を記録
+    taskRepository.findById(Long.MAX_VALUE);
+
+    List<Map<String, Object>> rows =
+        jdbcTemplate.queryForList(
+            "SELECT hash_chain FROM audit_logs"
+                + " WHERE action = 'CROSS_TENANT_VIOLATION_ATTEMPT' ORDER BY id");
+    assertThat(rows).hasSize(2);
+
+    // 1件目はジェネシスハッシュ(前レコードなし)
+    assertThat(rows.get(0).get("hash_chain")).isEqualTo("0".repeat(64));
+
+    // 2件目は前レコードを参照したチェーンハッシュ(ジェネシスハッシュではなく 64 桁の hex)
+    String second = (String) rows.get(1).get("hash_chain");
+    assertThat(second).isNotEqualTo("0".repeat(64));
+    assertThat(second).matches("[0-9a-f]{64}");
+  }
+
   private void setUpSaasAdmin() {
     var principal =
         new TasksPrincipal(1L, "admin-sub-vd", "admin-vd@example.com", "VD管理者", "ブイディーカンリシャ", null);

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/audit/CrossTenantViolationDetectionIT.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/audit/CrossTenantViolationDetectionIT.java
@@ -1,0 +1,127 @@
+package xyz.dgz48.tasks.webapi.audit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.transaction.support.TransactionTemplate;
+import xyz.dgz48.tasks.webapi.MockJwtDecoderConfiguration;
+import xyz.dgz48.tasks.webapi.TestcontainersConfiguration;
+import xyz.dgz48.tasks.webapi.security.adapter.web.TasksAuthenticationToken;
+import xyz.dgz48.tasks.webapi.security.domain.TasksPrincipal;
+import xyz.dgz48.tasks.webapi.shared.domain.TenantContext;
+import xyz.dgz48.tasks.webapi.shared.usecase.TenantFilterBypassService;
+import xyz.dgz48.tasks.webapi.task.usecase.TaskRepository;
+
+/**
+ * クロステナント違反検知ログの統合テスト。
+ *
+ * <p>TenantContext 未設定で tenant-filtered テーブルへの SQL が発行された場合に {@code audit_logs} へ {@code
+ * CROSS_TENANT_VIOLATION_ATTEMPT} が記録されること、および D-1 の正当 bypass で false positive が 発生しないことを検証する。
+ */
+@SpringBootTest
+@Import({TestcontainersConfiguration.class, MockJwtDecoderConfiguration.class})
+class CrossTenantViolationDetectionIT {
+
+  @Autowired TaskRepository taskRepository;
+  @Autowired TenantFilterBypassService bypassService;
+  @Autowired JdbcTemplate jdbcTemplate;
+  @Autowired TransactionTemplate txTemplate;
+
+  @BeforeEach
+  void setUp() {
+    TenantContext.clear();
+    SecurityContextHolder.clearContext();
+    jdbcTemplate.execute("DELETE FROM audit_logs");
+  }
+
+  @AfterEach
+  void tearDown() {
+    TenantContext.clear();
+    SecurityContextHolder.clearContext();
+    jdbcTemplate.execute("DELETE FROM audit_logs");
+  }
+
+  @Test
+  void whenTenantContextNull_andQueryTasksTable_thenViolationRecorded() {
+    // TenantContext 未設定のまま tasks テーブルを参照 → 違反として検知されるべき
+    taskRepository.findById(Long.MAX_VALUE);
+
+    List<Map<String, Object>> rows =
+        jdbcTemplate.queryForList(
+            "SELECT * FROM audit_logs WHERE action = 'CROSS_TENANT_VIOLATION_ATTEMPT'");
+    assertThat(rows).isNotEmpty();
+    assertThat(rows.get(0)).containsEntry("action", "CROSS_TENANT_VIOLATION_ATTEMPT");
+  }
+
+  @Test
+  void whenTenantContextSet_thenNoViolation() {
+    // TenantContext が設定済みの場合は Filter が有効化されるため違反ではない
+    TenantContext.set(999L);
+    try {
+      txTemplate.execute(
+          status -> {
+            taskRepository.findById(Long.MAX_VALUE);
+            return null;
+          });
+    } finally {
+      TenantContext.clear();
+    }
+
+    List<Map<String, Object>> rows =
+        jdbcTemplate.queryForList(
+            "SELECT * FROM audit_logs WHERE action = 'CROSS_TENANT_VIOLATION_ATTEMPT'");
+    assertThat(rows).isEmpty();
+  }
+
+  @Test
+  void whenSaasAdminBypass_andTenantContextNull_thenNoFalsePositive() {
+    // D-1: SaaS Admin が TenantFilterBypassService 経由で filter を解除しても false positive にならない
+    setUpSaasAdmin();
+
+    txTemplate.execute(
+        status -> {
+          bypassService.runAsSaaSAdmin(
+              () -> {
+                taskRepository.findById(Long.MAX_VALUE);
+                return null;
+              });
+          return null;
+        });
+
+    List<Map<String, Object>> rows =
+        jdbcTemplate.queryForList(
+            "SELECT * FROM audit_logs WHERE action = 'CROSS_TENANT_VIOLATION_ATTEMPT'");
+    assertThat(rows).isEmpty();
+  }
+
+  @Test
+  void whenTenantContextNull_andQueryUsersTable_thenNoViolation() {
+    // users テーブルは TenantFilteredEntity 対象外のため違反検知しない
+    // (TenantAwareJpaTransactionManager + TenantContextFilter が users を参照する正当ケース)
+    jdbcTemplate.queryForList("SELECT id FROM users LIMIT 1");
+
+    List<Map<String, Object>> rows =
+        jdbcTemplate.queryForList(
+            "SELECT * FROM audit_logs WHERE action = 'CROSS_TENANT_VIOLATION_ATTEMPT'");
+    assertThat(rows).isEmpty();
+  }
+
+  private void setUpSaasAdmin() {
+    var principal =
+        new TasksPrincipal(1L, "admin-sub-vd", "admin-vd@example.com", "VD管理者", "ブイディーカンリシャ", null);
+    var auth =
+        new TasksAuthenticationToken(
+            principal, List.of(new SimpleGrantedAuthority("ROLE_APP_ADMIN")));
+    SecurityContextHolder.getContext().setAuthentication(auth);
+  }
+}

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/audit/adapter/persistence/AuditLogPersistenceAdapterTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/audit/adapter/persistence/AuditLogPersistenceAdapterTest.java
@@ -1,0 +1,50 @@
+package xyz.dgz48.tasks.webapi.audit.adapter.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+
+/** {@link AuditLogPersistenceAdapter#computeChainHash} のユニットテスト。 */
+class AuditLogPersistenceAdapterTest {
+
+  @Test
+  void computeChainHash_whenNoPreviousRecord_returnsGenesisHash() {
+    String hash = AuditLogPersistenceAdapter.computeChainHash(null);
+    assertThat(hash).isEqualTo("0".repeat(64));
+  }
+
+  @Test
+  void computeChainHash_withPreviousRecord_computesSha256OfIdDetailCreatedAt() {
+    LocalDateTime createdAt = LocalDateTime.of(2026, 6, 6, 11, 0, 0);
+    String detail = "{\"table\":\"tasks\",\"sqlType\":\"SELECT\"}";
+    var prev =
+        new AuditLogJpaEntity(
+            null, null, "CROSS_TENANT_VIOLATION_ATTEMPT", detail, createdAt, "0".repeat(64));
+
+    String hash = AuditLogPersistenceAdapter.computeChainHash(prev);
+
+    // prev.getId() は null(未永続化エンティティ) — same behavior as null|detail|createdAt input
+    String expectedInput = prev.getId() + "|" + prev.getDetail() + "|" + prev.getCreatedAt();
+    assertThat(hash).isEqualTo(sha256Hex(expectedInput));
+    assertThat(hash).matches("[0-9a-f]{64}");
+    assertThat(hash).isNotEqualTo("0".repeat(64));
+  }
+
+  private static String sha256Hex(String input) {
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      byte[] hashBytes = digest.digest(input.getBytes(StandardCharsets.UTF_8));
+      StringBuilder hex = new StringBuilder(64);
+      for (byte b : hashBytes) {
+        hex.append(String.format("%02x", b));
+      }
+      return hex.toString();
+    } catch (NoSuchAlgorithmException e) {
+      throw new IllegalStateException("SHA-256 not available", e);
+    }
+  }
+}

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/shared/adapter/persistence/HibernateFilterEntityAuditTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/shared/adapter/persistence/HibernateFilterEntityAuditTest.java
@@ -35,7 +35,8 @@ class HibernateFilterEntityAuditTest {
           "TenantJpaEntity", // tenants: マスタテーブル、tenant_id 列なし
           "UserJpaEntity", // users: プラットフォーム横断ユーザー、tenant_id 列なし
           "UserTenantJpaEntity", // user_tenants: TenantContext 確立前にクロステナント参照が必要
-          "AppAdminUserJpaEntity" // app_admin_users: SaaS Admin ユーザー管理、tenant_id 列なし
+          "AppAdminUserJpaEntity", // app_admin_users: SaaS Admin ユーザー管理、tenant_id 列なし
+          "AuditLogJpaEntity" // audit_logs: tenant_id が nullable、テナント範囲を超えた参照が必要
           );
 
   @Autowired EntityManagerFactory emf;


### PR DESCRIPTION
Closes #317

## Summary

- **Hibernate `StatementInspector`** (`CrossTenantViolationInspector`) を `shared/infra` に新設し、全 SQL を対象に「`TenantContext == null` かつ tenant-filtered テーブルへのアクセス」を検知
- D-1 (`TenantFilterBypassService.runAsSaaSAdmin()`) による正当 bypass は `TenantFilterBypassContext` (ThreadLocal) で識別し false positive を排除
- 検知時は WARN ログ出力 + `CrossTenantViolationDetectedEvent` を発火 → `CrossTenantViolationAuditService` が `REQUIRES_NEW` トランザクションで `audit_logs` に `CROSS_TENANT_VIOLATION_ATTEMPT` を記録
- `IN_VIOLATION_HANDLING` ThreadLocal で audit 書き込み中の再帰的 Inspector 呼び出しを防止
- `audit` feature を新設（クリーンアーキ 4 層: `domain` / `usecase` / `adapter.persistence` / `package-info.java` 一式）

## 新規ファイル

| ファイル | 役割 |
|---|---|
| `shared/domain/TenantFilterBypassContext` | D-1 正当 bypass を示す ThreadLocal |
| `shared/domain/CrossTenantViolationDetectedEvent` | 違反検知イベント record |
| `shared/infra/CrossTenantViolationInspector` | 検知ポイント本体（`StatementInspector` + `HibernatePropertiesCustomizer`） |
| `audit/domain/AuditEventType` | `CROSS_TENANT_VIOLATION_ATTEMPT` enum |
| `audit/usecase/AuditLogPort` | 永続化 Port |
| `audit/usecase/CrossTenantViolationAuditService` | イベントリスナー（`REQUIRES_NEW`） |
| `audit/adapter/persistence/AuditLogJpaEntity` | `audit_logs` JPA entity（SHA-256 hash_chain 付き） |
| `audit/adapter/persistence/AuditLogJpaRepository` | Spring Data JPA リポジトリ |
| `audit/adapter/persistence/AuditLogPersistenceAdapter` | Port 実装 |
| `CrossTenantViolationDetectionIT` | 5 ケース Testcontainers IT |
| `AuditLogPersistenceAdapterTest` | computeChainHash ユニットテスト |

## 変更ファイル

- `TenantFilterBypassService` — `runAsSaaSAdmin()` に `TenantFilterBypassContext.activate/deactivate` 追加
- `HibernateFilterEntityAuditTest` — `AuditLogJpaEntity` を除外リストに追加

## Test plan

- [x] `whenTenantContextNull_andQueryTasksTable_thenViolationRecorded` — 未設定 → `audit_logs` に記録
- [x] `whenTenantContextSet_thenNoViolation` — 正常リクエスト → 記録なし
- [x] `whenSaasAdminBypass_andTenantContextNull_thenNoFalsePositive` — D-1 bypass → false positive なし
- [x] `whenTenantContextNull_andQueryUsersTable_thenNoViolation` — 除外テーブル → 記録なし
- [x] `hashChain_firstRecordUsesGenesisHash_secondRecordHasNonGenesisHash` — 1件目 genesis hash、2件目 チェーンハッシュ確認
- [x] `computeChainHash_whenNoPreviousRecord_returnsGenesisHash` — genesis hash ユニットテスト
- [x] `computeChainHash_withPreviousRecord_computesSha256OfIdDetailCreatedAt` — チェーンハッシュ計算ユニットテスト
- [x] `./gradlew :webapi:check` グリーン

## 未対応レビュー

| 指摘 | 内容 | 対応状況 |
|---|---|---|
| (なし) | — | — |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
