### PR TITLE
refactor(db): 初期マイグレーション 3 ファイルを 1 ファイルに統合

### DIFF
--- a/webapi/src/main/resources/db/migration/V1.0.0_01__create_tables.sql
+++ b/webapi/src/main/resources/db/migration/V1.0.0_01__create_tables.sql
@@ -37,6 +37,16 @@ CREATE TABLE user_tenants (
     CONSTRAINT fk_ut_tenant FOREIGN KEY (tenant_id) REFERENCES tenants(id) ON DELETE RESTRICT
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
+-- SaaS Admin の正本テーブル。tenant_id を持たない例外テーブル(ADR-0010: Hibernate Filter 適用外)。
+-- JWT.sub (oidc_sub) と突合してセッション開始時に ROLE_APP_ADMIN を付与する。
+CREATE TABLE app_admin_users (
+    id         BIGINT       NOT NULL AUTO_INCREMENT,
+    oidc_sub   VARCHAR(255) NOT NULL COMMENT 'Keycloak Subject (JWT sub claim)',
+    created_at DATETIME     NOT NULL COMMENT '登録日時',
+    PRIMARY KEY (id),
+    UNIQUE KEY uq_app_admin_users_oidc_sub (oidc_sub)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
 CREATE TABLE tasks (
     id           BIGINT                                              NOT NULL AUTO_INCREMENT,
     tenant_id    BIGINT                                              NOT NULL COMMENT 'テナント分離キー',
@@ -50,6 +60,7 @@ CREATE TABLE tasks (
     due_date     DATE                                                NOT NULL COMMENT '期限日',
     completed_at DATETIME                                            NULL     COMMENT '完了日時',
     deleted_at   DATETIME                                            NULL     COMMENT '論理削除日時(NULL=有効)',
+    version      BIGINT                                              NOT NULL DEFAULT 0 COMMENT 'JPA @Version 楽観排他用(ADR-0012)',
     created_at   DATETIME                                            NOT NULL COMMENT '作成日時',
     updated_at   DATETIME                                            NOT NULL COMMENT '更新日時',
     created_by   BIGINT                                              NOT NULL COMMENT '作成ユーザーID(users.id)',

--- a/webapi/src/main/resources/db/migration/V1.0.0_02__create_app_admin_users.sql
+++ b/webapi/src/main/resources/db/migration/V1.0.0_02__create_app_admin_users.sql
@@ -1,9 +1,0 @@
--- SaaS Admin の正本テーブル。tenant_id を持たない例外テーブル(ADR-0010: Hibernate Filter 適用外)。
--- JWT.sub (oidc_sub) と突合してセッション開始時に ROLE_APP_ADMIN を付与する。
-CREATE TABLE app_admin_users (
-    id         BIGINT       NOT NULL AUTO_INCREMENT,
-    oidc_sub   VARCHAR(255) NOT NULL COMMENT 'Keycloak Subject (JWT sub claim)',
-    created_at DATETIME     NOT NULL COMMENT '登録日時',
-    PRIMARY KEY (id),
-    UNIQUE KEY uq_app_admin_users_oidc_sub (oidc_sub)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/webapi/src/main/resources/db/migration/V1.0.0_03__add_tasks_version.sql
+++ b/webapi/src/main/resources/db/migration/V1.0.0_03__add_tasks_version.sql
@@ -1,2 +1,0 @@
-ALTER TABLE tasks
-    ADD COLUMN version BIGINT NOT NULL DEFAULT 0 COMMENT 'JPA @Version 楽観排他用(ADR-0012)';


### PR DESCRIPTION
## Summary

- `V1.0.0_02__create_app_admin_users.sql`（`app_admin_users` テーブル作成）と `V1.0.0_03__add_tasks_version.sql`（`tasks.version` 列追加）を `V1.0.0_01__create_tables.sql` に統合し、3 ファイルを 1 ファイルに削減
- `tasks.version` は `ALTER TABLE` ではなく `CREATE TABLE` 定義に直接組み込み
- Sprint 0 着手前でいずれのスクリプトも未適用のため、破壊的変更なし

## Test plan

- [x] `./gradlew :webapi:check` 全パス（Flyway + Testcontainers による実 MySQL での migration 適用確認を含む）

🤖 Generated with [Claude Code](https://claude.com/claude-code)