### PR TITLE
[Phase 1 Sprint 1 S1Infra-3] feat(keycloak): Keycloak 独立 Gradle project 雛形(SPI 用)(Closes #320)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,4 @@
+plugins {
+    id 'com.diffplug.spotless' version '8.4.0' apply false
+    id 'net.ltgt.errorprone' version '5.1.0' apply false
+}

--- a/keycloak/build.gradle.kts
+++ b/keycloak/build.gradle.kts
@@ -1,0 +1,69 @@
+import net.ltgt.gradle.errorprone.errorprone
+
+plugins {
+    java
+    id("net.ltgt.errorprone") version "5.1.0"
+    id("com.diffplug.spotless") version "8.4.0"
+}
+
+group = "xyz.dgz48"
+version = "0.0.1-SNAPSHOT"
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+repositories {
+    mavenCentral()
+}
+
+val keycloakVersion = "26.2.5"
+
+dependencies {
+    compileOnly("org.keycloak:keycloak-core:$keycloakVersion")
+    compileOnly("org.keycloak:keycloak-server-spi:$keycloakVersion")
+    compileOnly("org.keycloak:keycloak-server-spi-private:$keycloakVersion")
+    implementation("org.jspecify:jspecify:1.0.0")
+
+    testImplementation("org.keycloak:keycloak-core:$keycloakVersion")
+    testImplementation("org.keycloak:keycloak-server-spi:$keycloakVersion")
+    testImplementation("org.keycloak:keycloak-server-spi-private:$keycloakVersion")
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+
+    errorprone("com.google.errorprone:error_prone_core:2.49.0")
+    errorprone("com.uber.nullaway:nullaway:0.13.4")
+}
+
+tasks.named<JavaCompile>("compileJava") {
+    options.errorprone {
+        error("NullAway")
+        option("NullAway:AnnotatedPackages", "xyz.dgz48")
+        option("NullAway:JSpecifyMode", "true")
+        error("BadImport")
+        error("JavaTimeDefaultTimeZone")
+    }
+}
+
+tasks.named<JavaCompile>("compileTestJava") {
+    options.errorprone {
+        disable("NullAway")
+    }
+}
+
+tasks.named<Test>("test") {
+    useJUnitPlatform()
+}
+
+spotless {
+    lineEndings = com.diffplug.spotless.LineEnding.UNIX
+    java {
+        googleJavaFormat("1.24.0")
+    }
+}
+
+tasks.named("check") {
+    dependsOn("spotlessCheck")
+}

--- a/keycloak/src/main/java/xyz/dgz48/tasks/keycloak/TasksWebApiUserStorageProvider.java
+++ b/keycloak/src/main/java/xyz/dgz48/tasks/keycloak/TasksWebApiUserStorageProvider.java
@@ -1,0 +1,107 @@
+package xyz.dgz48.tasks.keycloak;
+
+import java.util.Map;
+import java.util.stream.Stream;
+import org.jspecify.annotations.Nullable;
+import org.keycloak.component.ComponentModel;
+import org.keycloak.models.GroupModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.provider.Provider;
+import org.keycloak.storage.user.UserLookupProvider;
+import org.keycloak.storage.user.UserQueryProvider;
+import org.keycloak.storage.user.UserRegistrationProvider;
+
+/**
+ * Keycloak User Storage provider (ADR-0006).
+ *
+ * <p>Federates tasks-webapi {@code users} table as a read-only profile directory. Email is the only
+ * writable attribute (via Keycloak Update-Email flow). Credentials and MFA are owned by Keycloak
+ * ({@code CredentialInputValidator} is intentionally not implemented).
+ */
+public class TasksWebApiUserStorageProvider
+    implements Provider, UserLookupProvider, UserQueryProvider, UserRegistrationProvider {
+
+  @SuppressWarnings("unused")
+  private final KeycloakSession session;
+
+  @SuppressWarnings("unused")
+  private final ComponentModel model;
+
+  public TasksWebApiUserStorageProvider(KeycloakSession session, ComponentModel model) {
+    this.session = session;
+    this.model = model;
+  }
+
+  // --- Provider ---
+
+  @Override
+  public void close() {}
+
+  // --- UserLookupProvider (read-only federation) ---
+
+  @Override
+  public @Nullable UserModel getUserById(RealmModel realm, String id) {
+    // TODO: extract external ID via StorageId.externalId(id), look up users.id, return UserAdapter
+    return null;
+  }
+
+  @Override
+  public @Nullable UserModel getUserByUsername(RealmModel realm, String username) {
+    // email is the login-ID in Keycloak (username == email per ADR-0006 §3.1)
+    // TODO: SELECT * FROM users WHERE email = :username AND deleted_at IS NULL
+    return null;
+  }
+
+  @Override
+  public @Nullable UserModel getUserByEmail(RealmModel realm, String email) {
+    // TODO: SELECT * FROM users WHERE email = :email AND deleted_at IS NULL
+    return null;
+  }
+
+  // --- UserQueryProvider (read-only) ---
+
+  @Override
+  public Stream<UserModel> searchForUserStream(
+      RealmModel realm,
+      Map<String, String> params,
+      @Nullable Integer firstResult,
+      @Nullable Integer maxResults) {
+    // TODO: query users table with pagination; used by Admin Console user list
+    return Stream.empty();
+  }
+
+  @Override
+  public Stream<UserModel> getGroupMembersStream(
+      RealmModel realm,
+      GroupModel group,
+      @Nullable Integer firstResult,
+      @Nullable Integer maxResults) {
+    return Stream.empty();
+  }
+
+  @Override
+  public Stream<UserModel> searchForUserByUserAttributeStream(
+      RealmModel realm, String attrName, String attrValue) {
+    return Stream.empty();
+  }
+
+  // --- UserRegistrationProvider (admin / disaster-recovery path only; main path is tasks API) ---
+
+  @Override
+  public @Nullable UserModel addUser(RealmModel realm, String username) {
+    // Admin Console / recovery path: insert into users (email, full_name, full_name_kana).
+    // full_name_kana and other required fields are provided via Custom User Profile attributes.
+    // Tenant assignment is NOT performed here; created user is tenant-unassigned.
+    // TODO: implement insert + return UserAdapter
+    return null;
+  }
+
+  @Override
+  public boolean removeUser(RealmModel realm, UserModel user) {
+    // Anonymize per ADR-0006 §3.4: set deleted_at + placeholder email/oidc_sub/full_name.
+    // TODO: call UserAnonymizationDomainService in 1 transaction; return true on success
+    return false;
+  }
+}

--- a/keycloak/src/main/java/xyz/dgz48/tasks/keycloak/TasksWebApiUserStorageProviderFactory.java
+++ b/keycloak/src/main/java/xyz/dgz48/tasks/keycloak/TasksWebApiUserStorageProviderFactory.java
@@ -1,0 +1,49 @@
+package xyz.dgz48.tasks.keycloak;
+
+import java.util.List;
+import org.keycloak.Config;
+import org.keycloak.component.ComponentFactory;
+import org.keycloak.component.ComponentModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.provider.ProviderConfigProperty;
+
+/**
+ * Registers {@link TasksWebApiUserStorageProvider} as a Keycloak User Federation component.
+ *
+ * <p>Registered via {@code META-INF/services/org.keycloak.component.ComponentFactory}.
+ */
+public class TasksWebApiUserStorageProviderFactory
+    implements ComponentFactory<TasksWebApiUserStorageProvider, TasksWebApiUserStorageProvider> {
+
+  public static final String PROVIDER_ID = "tasks-webapi-user-storage";
+
+  @Override
+  public TasksWebApiUserStorageProvider create(KeycloakSession session, ComponentModel model) {
+    return new TasksWebApiUserStorageProvider(session, model);
+  }
+
+  @Override
+  public String getId() {
+    return PROVIDER_ID;
+  }
+
+  @Override
+  public String getHelpText() {
+    return "Federates tasks-webapi users table (read-only profile, email writable via Update-Email)";
+  }
+
+  @Override
+  public List<ProviderConfigProperty> getConfigProperties() {
+    return List.of();
+  }
+
+  @Override
+  public void init(Config.Scope config) {}
+
+  @Override
+  public void postInit(KeycloakSessionFactory factory) {}
+
+  @Override
+  public void close() {}
+}

--- a/keycloak/src/main/java/xyz/dgz48/tasks/keycloak/UserAdapter.java
+++ b/keycloak/src/main/java/xyz/dgz48/tasks/keycloak/UserAdapter.java
@@ -1,0 +1,59 @@
+package xyz.dgz48.tasks.keycloak;
+
+import org.keycloak.component.ComponentModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.SubjectCredentialManager;
+import org.keycloak.storage.StorageId;
+import org.keycloak.storage.adapter.AbstractInMemoryUserAdapter;
+
+/**
+ * Adapts a {@code users} table row as a Keycloak {@link org.keycloak.models.UserModel}.
+ *
+ * <p>Profile attributes (full_name, department_name, etc.) are read-only — tasks-webapi is the SoT.
+ * Email is the only writable attribute; updates are written back to {@code users.email} by the
+ * Keycloak Update-Email flow (ADR-0006 §3.1).
+ */
+public class UserAdapter extends AbstractInMemoryUserAdapter {
+
+  public UserAdapter(
+      KeycloakSession session,
+      RealmModel realm,
+      ComponentModel storageProviderModel,
+      long userId,
+      String email,
+      String fullName) {
+    super(session, realm, StorageId.keycloakId(storageProviderModel, String.valueOf(userId)));
+    setUsername(email);
+    setSingleAttribute(FIRST_NAME, fullName);
+    setSingleAttribute(EMAIL, email);
+  }
+
+  /**
+   * Credentials are owned by Keycloak's native credential store (ADR-0006 §3.3).
+   *
+   * <p>Returns the session-level credential manager for this user. TODO: wire to
+   * session.userCredentialManager() when JDBC integration is added.
+   */
+  @Override
+  public SubjectCredentialManager credentialManager() {
+    throw new UnsupportedOperationException(
+        "Credential management is delegated to Keycloak native store (ADR-0006 §3.3)");
+  }
+
+  /** Email is the only writable attribute; writes back to {@code users.email} via JDBC. */
+  @Override
+  public void setEmail(String email) {
+    // TODO: UPDATE users SET email = :email, version = version + 1 WHERE id = :userId (ADR-0006
+    // §3.4)
+    super.setEmail(email);
+  }
+
+  /** Ignored — full_name is read-only; SoT is tasks-webapi profile update API. */
+  @Override
+  public void setFirstName(String firstName) {}
+
+  /** Ignored — not stored in users table. */
+  @Override
+  public void setLastName(String lastName) {}
+}

--- a/keycloak/src/main/java/xyz/dgz48/tasks/keycloak/package-info.java
+++ b/keycloak/src/main/java/xyz/dgz48/tasks/keycloak/package-info.java
@@ -1,0 +1,5 @@
+/** Keycloak User Storage SPI — read-only federation + email-only writable (ADR-0006). */
+@NullMarked
+package xyz.dgz48.tasks.keycloak;
+
+import org.jspecify.annotations.NullMarked;

--- a/keycloak/src/main/resources/META-INF/services/org.keycloak.component.ComponentFactory
+++ b/keycloak/src/main/resources/META-INF/services/org.keycloak.component.ComponentFactory
@@ -1,0 +1,1 @@
+xyz.dgz48.tasks.keycloak.TasksWebApiUserStorageProviderFactory

--- a/keycloak/src/test/java/xyz/dgz48/tasks/keycloak/TasksWebApiUserStorageProviderFactoryTest.java
+++ b/keycloak/src/test/java/xyz/dgz48/tasks/keycloak/TasksWebApiUserStorageProviderFactoryTest.java
@@ -1,0 +1,30 @@
+package xyz.dgz48.tasks.keycloak;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ServiceLoader;
+import org.junit.jupiter.api.Test;
+import org.keycloak.component.ComponentFactory;
+
+class TasksWebApiUserStorageProviderFactoryTest {
+
+  @Test
+  void getId_returnsExpectedProviderId() {
+    var factory = new TasksWebApiUserStorageProviderFactory();
+    assertEquals(TasksWebApiUserStorageProviderFactory.PROVIDER_ID, factory.getId());
+  }
+
+  @Test
+  @SuppressWarnings("rawtypes")
+  void serviceLoader_registersProvider() {
+    var loader =
+        ServiceLoader.load(
+            ComponentFactory.class,
+            TasksWebApiUserStorageProviderFactoryTest.class.getClassLoader());
+    boolean found =
+        loader.stream().anyMatch(p -> TasksWebApiUserStorageProviderFactory.class.equals(p.type()));
+    assertTrue(
+        found, "TasksWebApiUserStorageProviderFactory must be registered in META-INF/services");
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,4 @@
 rootProject.name = 'tasks-webapi-monorepo'
 
 include 'webapi'
-// keycloak は Phase 1 Sprint 1 Infra で追加(独立 Gradle project、Custom Image 用)
+include 'keycloak'


### PR DESCRIPTION
## 概要

Issue #320 の実装。`keycloak/` 配下に Keycloak User Storage SPI 用の独立 Gradle project を構築し、`./gradlew :keycloak:build` が成功する雛形を作成した。

## 変更内容

### 新規追加

| ファイル | 役割 |
|---|---|
| `build.gradle` | ルート build file。`spotless` / `errorprone` を `apply false` で宣言しサブプロジェクト間のクラスローダー競合を解消 |
| `keycloak/build.gradle.kts` | Kotlin DSL。Keycloak 26.2.5 deps (`compileOnly`)、NullAway + Spotless を webapi 規約に合わせて設定 |
| `keycloak/src/main/java/…/package-info.java` | `@NullMarked` |
| `keycloak/src/main/java/…/TasksWebApiUserStorageProviderFactory.java` | `ComponentFactory` 実装（後述の Keycloak 26.x 対応参照） |
| `keycloak/src/main/java/…/TasksWebApiUserStorageProvider.java` | `Provider` + `UserLookupProvider` + `UserQueryProvider` + `UserRegistrationProvider` 実装。`CredentialInputValidator` は意図的に未実装 |
| `keycloak/src/main/java/…/UserAdapter.java` | `AbstractInMemoryUserAdapter` 拡張。email のみ writable、profile 属性は read-only |
| `keycloak/src/main/resources/META-INF/services/org.keycloak.component.ComponentFactory` | SPI 登録ファイル |
| `keycloak/src/test/java/…/TasksWebApiUserStorageProviderFactoryTest.java` | `getId()` と ServiceLoader 登録を検証するテスト雛形 |

### 変更

| ファイル | 変更内容 |
|---|---|
| `settings.gradle` | `include 'keycloak'` を追加 |

## Keycloak 26.x 対応メモ

ADR-0006 が参照する `UserStorageProvider` / `UserStorageProviderFactory` は **Keycloak 26.x で削除済み**。以下の新 API に対応した:

| ADR-0006 記載(旧 API) | Keycloak 26.x 実装 |
|---|---|
| `UserStorageProviderFactory` | `ComponentFactory<T, T>` |
| `AbstractUserAdapterFederatedStorage` | `AbstractInMemoryUserAdapter` |
| `META-INF/services/org.keycloak.storage.UserStorageProviderFactory` | `META-INF/services/org.keycloak.component.ComponentFactory` |

`UserLookupProvider` / `UserQueryProvider` / `UserRegistrationProvider` / `StorageId` は 26.x でも同パッケージに存在。

## 受入条件の確認

- [x] `keycloak/build.gradle.kts` 存在 + JAR ビルド成功（`./gradlew :keycloak:build` → `BUILD SUCCESSFUL`）
- [x] SPI 登録ファイル + read-only lookup/query + email-only writable の skeleton 存在（`CredentialInputValidator` 未実装）
- [x] root build から `./gradlew :keycloak:build` が成功
- [x] テスト雛形 green（`getId()` + ServiceLoader 登録検証）

## Test plan

- [ ] `./gradlew :keycloak:build` が `BUILD SUCCESSFUL` であること
- [ ] `./gradlew build` がルートから両サブプロジェクトとも成功すること
- [ ] `keycloak/build/libs/keycloak-0.0.1-SNAPSHOT.jar` が生成されること
- [ ] `TasksWebApiUserStorageProviderFactoryTest` の 2 テストが green であること

🤖 Generated with [Claude Code](https://claude.ai/claude-code)