### PR TITLE
fix(iam): RDS 権限を platform apply/plan ロールに追加

### DIFF
--- a/infra/shared/modules/iam_oidc/main.tf
+++ b/infra/shared/modules/iam_oidc/main.tf
@@ -119,6 +119,13 @@ data "aws_iam_policy_document" "platform_plan" {
     resources = ["*"]
   }
 
+  # RDS read (Keycloak DB subnet group / instance inspection during plan)
+  statement {
+    sid       = "RdsRead"
+    actions   = ["rds:Describe*", "rds:List*"]
+    resources = ["*"]
+  }
+
   # SSM read — platform outputs published to /platform/<env>/*
   statement {
     sid     = "SsmRead"
@@ -275,6 +282,18 @@ data "aws_iam_policy_document" "platform_apply" {
     sid       = "Route53Write"
     actions   = ["route53:*"]
     resources = ["*"]
+  }
+
+  # RDS CRUD (Keycloak DB: subnet group / parameter group / DB instance)
+  statement {
+    sid       = "RdsWrite"
+    actions   = ["rds:*"]
+    resources = ["*"]
+  }
+  statement {
+    sid       = "RdsSlr"
+    actions   = ["iam:CreateServiceLinkedRole"]
+    resources = ["arn:aws:iam::${var.account_id}:role/aws-service-role/rds.amazonaws.com/*"]
   }
 
   # SSM write — publish platform outputs to /platform/<env>/*


### PR DESCRIPTION
## Summary

- `platform-dev-apply` ロールに `rds:CreateDBSubnetGroup` が含まれておらず、Keycloak DB の Subnet Group 作成時に 403 が発生していた
- `platform_apply` ポリシーに `RdsWrite (rds:*)` と RDS 用 Service-Linked Role 作成権限を追加
- `platform_plan` ポリシーに `RdsRead (rds:Describe*, rds:List*)` を追加(plan 時の状態読み取り)

## Root cause

Keycloak 専用 DB (`shared/modules/keycloak_db`) は platform スタックで管理されているが、`iam_oidc` モジュールの `platform_apply` ポリシーに RDS ステートメントが存在しなかった。`tasks_apply` には `rds:*` があったため、tasks スタック側のみ意識されていた。

## Test plan

- [ ] `terraform plan` (platform stack) が 403 なしで通ること
- [ ] `terraform apply` (platform stack) で `aws_db_subnet_group` が作成されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)