### PR TITLE
fix(iam/infra): IAM 権限不足・実行順序問題の包括修正 (platform + tasks)

### DIFF
--- a/infra/shared/environments/dev/main.tf
+++ b/infra/shared/environments/dev/main.tf
@@ -144,6 +144,10 @@ module "keycloak_db" {
   vpc_cidr           = module.network.vpc_cidr
   private_subnet_ids = module.network.private_subnet_ids
   db_password        = "CHANGE_ME"
+
+  # iam_oidc が platform_apply ロールポリシー(rds:*)を更新してから RDS を作成する。
+  # 同一 apply で並列実行するとポリシー反映前に rds:CreateDBSubnetGroup が失敗するため。
+  depends_on = [module.iam_oidc]
 }
 
 # ---------------------------------------------------------------------------

--- a/infra/shared/modules/iam_oidc/main.tf
+++ b/infra/shared/modules/iam_oidc/main.tf
@@ -573,13 +573,12 @@ data "aws_iam_policy_document" "tasks_apply" {
     resources = ["arn:aws:iam::${var.account_id}:role/aws-service-role/ecs.amazonaws.com/*"]
   }
 
-  # CloudWatch Logs CRUD (ECS cluster log groups: /ecs/tasks-<env>/*)
+  # CloudWatch Logs CRUD scoped to ECS task log groups
   statement {
     sid = "LogsWrite"
     actions = [
       "logs:CreateLogGroup",
       "logs:DeleteLogGroup",
-      "logs:DescribeLogGroups",
       "logs:PutRetentionPolicy",
       "logs:DeleteRetentionPolicy",
       "logs:TagLogGroup",
@@ -589,6 +588,14 @@ data "aws_iam_policy_document" "tasks_apply" {
       "logs:ListTagsLogGroup",
       "logs:ListTagsForResource",
     ]
+    resources = [
+      "arn:aws:logs:${var.region}:${var.account_id}:log-group:/ecs/tasks-${var.env}/*",
+    ]
+  }
+  # logs:DescribeLogGroups does not support resource-level permissions; must use Resource:"*"
+  statement {
+    sid       = "LogsDescribe"
+    actions   = ["logs:DescribeLogGroups"]
     resources = ["*"]
   }
 

--- a/infra/shared/modules/iam_oidc/main.tf
+++ b/infra/shared/modules/iam_oidc/main.tf
@@ -410,6 +410,13 @@ data "aws_iam_policy_document" "tasks_plan" {
     resources = ["*"]
   }
 
+  # CloudWatch Logs read (ECS cluster log groups inspection during plan)
+  statement {
+    sid       = "LogsRead"
+    actions   = ["logs:DescribeLogGroups", "logs:ListTagsLogGroup", "logs:ListTagsForResource"]
+    resources = ["*"]
+  }
+
   # SSM read — platform outputs + tasks params
   statement {
     sid     = "SsmRead"
@@ -564,6 +571,25 @@ data "aws_iam_policy_document" "tasks_apply" {
     sid       = "EcsSlr"
     actions   = ["iam:CreateServiceLinkedRole"]
     resources = ["arn:aws:iam::${var.account_id}:role/aws-service-role/ecs.amazonaws.com/*"]
+  }
+
+  # CloudWatch Logs CRUD (ECS cluster log groups: /ecs/tasks-<env>/*)
+  statement {
+    sid = "LogsWrite"
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:DeleteLogGroup",
+      "logs:DescribeLogGroups",
+      "logs:PutRetentionPolicy",
+      "logs:DeleteRetentionPolicy",
+      "logs:TagLogGroup",
+      "logs:UntagLogGroup",
+      "logs:TagResource",
+      "logs:UntagResource",
+      "logs:ListTagsLogGroup",
+      "logs:ListTagsForResource",
+    ]
+    resources = ["*"]
   }
 
   # SSM — read platform outputs, write tasks params


### PR DESCRIPTION
## 問題の全体像

### 1. platform スタック — RDS 権限レースコンディション (今回の 403 エラー)

`module.keycloak_db` と `module.iam_oidc` に依存関係がなく Terraform が並列実行するため、
IAM ポリシー (`rds:*`) 反映前に `rds:CreateDBSubnetGroup` が呼ばれて 403 になっていた。

```
module.iam_oidc  → aws_iam_role_policy.platform_apply (rds:* 追加) ─┐
module.keycloak_db → aws_db_subnet_group.keycloak ← 並列で先に実行 → 403
```

**修正**: `module.keycloak_db` に `depends_on = [module.iam_oidc]` を追加。
IAM ポリシー更新後に RDS リソース作成が開始されるよう順序保証。

### 2. tasks スタック — CloudWatch Logs 権限不足 (潜在的エラー)

`ecs_cluster` モジュールが `aws_cloudwatch_log_group` を作成するが、
`tasks_apply` / `tasks_plan` ポリシーに `logs:*` 権限がなかった。

**修正**: 具体的な CloudWatch Logs アクションをポリシーに追加。
`LogsWrite` は `/ecs/tasks-<env>/*` にスコープ、`LogsDescribe` は `*`（リソースレベル非サポート）として分離。

## 権限の全体確認（platform + tasks 両スタック）

### platform スタック (`platform_apply`)

| リソース | 権限 | 状態 |
|---|---|---|
| VPC / Subnet / IGW / RT / EIP / NAT / VPC Endpoint / SG | `ec2:*` | ✓ |
| ALB / Listener | `elasticloadbalancing:*` | ✓ |
| ACM | `acm:*` | ✓ |
| Route53 | `route53:*` | ✓ |
| SES v2 | `ses:*` | ✓ |
| RDS Subnet Group / DB Instance | `rds:*` + RDS SLR | ✓ (PR #454) |
| SSM String/SecureString | `ssm:PutParameter` 等 | ✓ |

### tasks スタック (`tasks_apply`)

| リソース | 権限 | 状態 |
|---|---|---|
| ECS Cluster / Capacity Providers | `ecs:*` | ✓ |
| **CloudWatch Log Groups** | `logs:CreateLogGroup` 等 10 アクション (スコープ制限) + `logs:DescribeLogGroups` (`*`) | **本 PR で追加・修正** |
| ECR Repository / Lifecycle Policy | `ecr:*` | ✓ |
| RDS Subnet Group / DB Instance | `rds:*` | ✓ |
| Security Group | `ec2:*` | ✓ |
| Route53 Zone / Record / ACM / ALB TG / Listener Rule | 各 CRUD | ✓ |
| SSM Parameter (String/SecureString) | `ssm:PutParameter` 等 | ✓ |
| IAM Role / Policy (webapi_task) | 各 IAM アクション on `tasks-*` | ✓ |

## 変更ファイル

- `infra/shared/environments/dev/main.tf` — `module.keycloak_db` に `depends_on = [module.iam_oidc]`
- `infra/shared/modules/iam_oidc/main.tf` — `tasks_plan`: `LogsRead` 追加 / `tasks_apply`: `LogsWrite`(スコープ制限) + `LogsDescribe`(分離) 追加

## 緊急対応コマンド（手動でポリシーのみ先行 apply する場合）

```bash
cd infra/shared/environments/dev
terraform apply -target=module.iam_oidc
```

## Test plan

- [ ] platform terraform plan が 403 なしで通ること
- [ ] platform terraform apply で `aws_db_subnet_group` / `aws_db_instance` が正常作成されること
- [ ] tasks terraform plan が `logs:DescribeLogGroups` 403 なしで通ること
- [ ] tasks terraform apply で `aws_cloudwatch_log_group` が正常作成されること

## 未対応レビュー

| 指摘 | 内容 | 状態 |
|---|---|---|
| [#PRR_kwDOSGmllM8AAAABCNQa2Q](https://github.com/win2cot/tasks-webapi/pull/455#pullrequestreview-8067249497) | `tasks_apply` の `LogsWrite` — `resources = ["*"]` が broad すぎる | 対応済 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
