### PR TITLE
feat: Renovate PR auto-approve を有効化(shim + renovate.json packageRules)

### DIFF
--- a/.github/workflows/claude-renovate-approve.yml
+++ b/.github/workflows/claude-renovate-approve.yml
@@ -1,0 +1,47 @@
+# Renovate Auto Approve shim
+# Renovate が生成した PR を機械判定で claude-automation-review[bot] として approve する。
+# LLM 推論不使用、独立補助 workflow。
+# 本体は win2cot/claude-automation の reusable-renovate-approve.yml@v1。
+#
+# 動作:
+# (1) pull_request: 投稿主が renovate[bot] のとき起動
+# (2) check_suite: CI 完了かつ紐付き PR が存在するとき起動
+# reusable 側で受入条件(label / file / package / CI status 等)を再判定し、
+# 満たさなければ no-op で終了する。
+#
+# 受入条件詳細: win2cot/claude-automation docs/automation/renovate-approve.md
+
+name: Renovate Auto Approve
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review]
+  check_suite:
+    types: [completed]
+
+# reusable workflow が要求する権限を呼び出し側でも明示(GitHub Actions の仕様)。
+# reusable-renovate-approve.yml の jobs.approve.permissions と subset 整合が必要。
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: renovate-approve-shim-${{ github.event.pull_request.number || github.event.check_suite.pull_requests[0].number }}
+  cancel-in-progress: false
+
+jobs:
+  approve:
+    if: >-
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.user.login == 'renovate[bot]') ||
+      (github.event_name == 'check_suite' &&
+       github.event.check_suite.conclusion == 'success' &&
+       github.event.check_suite.pull_requests[0] != null)
+    uses: win2cot/claude-automation/.github/workflows/reusable-renovate-approve.yml@v1
+    with:
+      pr_number: >-
+        ${{ github.event.pull_request.number ||
+            github.event.check_suite.pull_requests[0].number }}
+    secrets:
+      CLAUDE_REVIEW_APP_ID: ${{ secrets.CLAUDE_REVIEW_APP_ID }}
+      CLAUDE_REVIEW_PRIVATE_KEY: ${{ secrets.CLAUDE_REVIEW_PRIVATE_KEY }}

--- a/renovate.json
+++ b/renovate.json
@@ -50,6 +50,18 @@
     {
       "matchFileNames": [".github/**"],
       "addLabels": ["area/ci", "renovate"]
+    },
+    {
+      "matchUpdateTypes": ["patch"],
+      "addLabels": ["update:patch"]
+    },
+    {
+      "matchUpdateTypes": ["minor"],
+      "addLabels": ["update:minor"]
+    },
+    {
+      "matchUpdateTypes": ["major"],
+      "addLabels": ["update:major"]
     }
   ]
 }


### PR DESCRIPTION
## 概要

claude-automation `reusable-renovate-approve.yml@v1`(Issue #101 / PR #102 で merge 済、v1 retag 済 2026-06-07)を tasks-webapi で使うため、shim と `renovate.json` packageRules を同一 PR で投入。

## 変更内容

| ファイル | 内容 |
|---|---|
| `.github/workflows/claude-renovate-approve.yml`(新規) | `reusable-renovate-approve.yml@v1` を呼ぶ shim |
| `renovate.json` | packageRules 末尾に `update:patch` / `update:minor` / `update:major` 自動付与を追加(既存 `automerge: true` patch ルールは残置) |

## 受入条件

- [ ] CI green
- [ ] 動作確認: 既存 Renovate PR(#157 等)に Renovate force-push が走ったとき `update:patch` ラベルが付くこと
- [ ] 同 PR で `claude-automation-review[bot]` が機械 approve すること
- [ ] 同 PR の auto-merge が完走すること

## 未対応(open)

| # | 指摘 | 状態 |
|---|---|---|

(初期状態は空)

## 関連

- Closes #461
- 基盤: win2cot/claude-automation#101 / #102
- 契機: #157
- docs: win2cot/claude-automation `docs/automation/renovate-approve.md`

## 非対象(別 Issue)

- minor / major 更新の機械承認(本 PR では label 付与のみ)
- 機械承認できなかった Renovate PR の集約 dashboard
