### PR TITLE
fix(iam): platform_apply に ec2 ENI 権限追加 + ECS/Keycloak を iam_oidc に依存

### DIFF
--- a/infra/shared/environments/dev/main.tf
+++ b/infra/shared/environments/dev/main.tf
@@ -200,6 +200,10 @@ resource "aws_ecs_cluster" "platform" {
   tags = {
     Name = "platform-dev-cluster"
   }
+
+  # iam_oidc が platform_apply に ecs:CreateCluster を付与してから作成する。
+  # 同一 apply で並列実行するとポリシー反映前に AccessDenied になるため。
+  depends_on = [module.iam_oidc]
 }
 
 resource "aws_ecs_cluster_capacity_providers" "platform" {
@@ -235,6 +239,10 @@ module "keycloak" {
   hostname             = "auth-dev.dgz48.xyz"
   account_id           = data.aws_caller_identity.current.account_id
   region               = "ap-northeast-1"
+
+  # iam_oidc が platform_apply に ECS/Logs/ELB 権限を付与してから作成する。
+  # 同一 apply で並列実行するとポリシー反映前に AccessDenied になるため。
+  depends_on = [module.iam_oidc]
 }
 
 # SG-KeycloakDB: ingress を VPC CIDR(暫定)から SG-Keycloak に tighten (#322)

--- a/infra/shared/modules/iam_oidc/main.tf
+++ b/infra/shared/modules/iam_oidc/main.tf
@@ -331,6 +331,12 @@ data "aws_iam_policy_document" "platform_apply" {
       "ec2:RevokeSecurityGroupEgress",
       "ec2:UpdateSecurityGroupRuleDescriptionsIngress",
       "ec2:UpdateSecurityGroupRuleDescriptionsEgress",
+      # SG 差し替え時に RDS 等が保持する ENI の SG 関連付けを外すために必要
+      # ec2:ModifyNetworkInterfaceAttribute: ENI の SG リストを更新して旧 SG を除去
+      # ec2:DetachNetworkInterface: ModifyNetworkInterfaceAttribute が使えない ENI の最終手段
+      # いずれも resource-level permission 非対応のため Resource:"*"
+      "ec2:ModifyNetworkInterfaceAttribute",
+      "ec2:DetachNetworkInterface",
       "ec2:CreateTags",
       "ec2:DeleteTags",
     ]


### PR DESCRIPTION
## 原因 PR

**PR #460**（feat(infra/platform): Keycloak ECS Service + ALB Listener Rule）が以下の 2 点で Terraform 規約 R3 に違反し、直後の `terraform apply` が失敗した。

## エラー内容（run #27081553926）

```
ec2:DetachNetworkInterface — AccessDenied (SG 差し替え時の ENI 切り離し)
ecs:CreateCluster          — AccessDenied (IAM ポリシー伝播タイミング)
logs:CreateLogGroup        — AccessDenied (同上)
elasticloadbalancing:CreateTargetGroup — AccessDenied (同上)
```

## 修正内容

### 1. `ec2:DetachNetworkInterface` / `ec2:ModifyNetworkInterfaceAttribute` 欠落（R3 違反）

PR #460 は `keycloak_db` の SG description を変更したため SG が差し替えられる。Terraform は旧 SG を削除する前に、RDS ENI が保持する SG 関連付けを解除しようとする。この処理に `ec2:ModifyNetworkInterfaceAttribute`（SG リスト更新）と `ec2:DetachNetworkInterface`（fallback）が必要だったが、`platform_apply` に未定義だった。

→ `infra/shared/modules/iam_oidc/main.tf` の `Ec2Write` に両アクションを追加。

### 2. `aws_ecs_cluster.platform` / `module.keycloak` に `depends_on` 欠落（R3 違反）

PR #460 は `iam_oidc` に ECS・Logs・ELB の write 権限を追加したが、同一 apply 内で `aws_ecs_cluster.platform` と `module.keycloak` が `module.iam_oidc` と並列実行されてポリシー反映前に AccessDenied となった。PR #455 で `module.keycloak_db` に適用済みの対策（`depends_on = [module.iam_oidc]`）が漏れていた。

→ `infra/shared/environments/dev/main.tf` の `aws_ecs_cluster.platform` と `module.keycloak` に `depends_on = [module.iam_oidc]` を追加。

## チェックリスト

- [x] `python3 .github/scripts/check-iam-wildcards.py` → OK
- [x] `terraform fmt -check -recursive infra/` → OK
- [x] R1: 追加アクションはいずれも書込み系として完全列挙
- [x] R2: resource-level permission 非対応のため `Resource:"*"` にコメント明記

🤖 Generated with [Claude Code](https://claude.com/claude-code)