### PR TITLE
fix(infra): SG 差し替えを create_before_destroy で正しい順序に修正

### DIFF
--- a/docs/specs/Terraform規約.md
+++ b/docs/specs/Terraform規約.md
@@ -2,7 +2,7 @@
 
 タスク管理システム(tasks-webapi)
 
-Version 1.0
+Version 1.1
 
 2026-06-07
 
@@ -13,6 +13,7 @@ Version 1.0
 | 版数 | 改訂日 | 改訂内容 | 改訂者 |
 |---|---|---|---|
 | 1.0 | 2026-06-07 | 新規作成(Issue #456)。IAM ポリシー最小権限 3 ルール(R1〜R3)+ CI 機械検知 + 命名・タグ規約 pointer | 開発チーム |
+| 1.1 | 2026-06-07 | R3 補足: SG 差し替え時の `create_before_destroy` + `name_prefix` 必須ルールを追加(PR #467) | 開発チーム |
 
 ## 目次
 
@@ -118,6 +119,33 @@ module "keycloak" {
 ```
 
 参考: `module.keycloak_db`(PR #455)・`aws_ecs_cluster.platform`/`module.keycloak`(PR #465)に同じ対策を適用済み。
+
+#### SG 差し替え時の create_before_destroy 必須ルール
+
+`aws_security_group` リソースで `description` などの差し替えを伴うプロパティを変更する場合、`lifecycle { create_before_destroy = true }` と `name_prefix` をセットで設定すること。
+
+**理由**: デフォルト(destroy-first)では旧 SG の削除時に RDS などの ENI がまだ旧 SG を参照しており、`ec2:DetachNetworkInterface` が必要になる。RDS-managed ENI は `rds:ModifyDBInstance` 経由でしか SG を切り替えられないため、Terraform が ENI を直接デタッチしようとしても失敗する。`create_before_destroy = true` にすると「新 SG 作成 → DB インスタンスの SG 切替(`rds:ModifyDBInstance`) → 旧 SG 削除」の順が保証され、旧 SG 削除時には ENI が旧 SG を参照していない。
+
+**`name_prefix` も必須**: `create_before_destroy` では新旧 SG が同時存在する瞬間があるため、固定 `name`(AWS GroupName)を使うと同一 VPC 内で重複エラーになる。`name_prefix` を使うことで Terraform がユニークなサフィックスを付与する。表示名は `tags.Name` で管理すれば十分。
+
+```hcl
+# OK: SG の差し替えを安全に行う定型パターン
+resource "aws_security_group" "example" {
+  name_prefix = "platform-${var.env}-sg-example-"  # ユニーク名を自動付与
+  description = "..."
+  vpc_id      = var.vpc_id
+
+  tags = {
+    Name = "platform-${var.env}-sg-example"  # 表示名は tags.Name で管理
+  }
+
+  lifecycle {
+    create_before_destroy = true  # 新SG作成 → DB切替 → 旧SG削除 の順を保証
+  }
+}
+```
+
+参考: `infra/shared/modules/keycloak_db/main.tf`(PR #467)に同じ対策を適用済み。
 
 ### 1.4 CI による機械検知
 

--- a/infra/shared/modules/keycloak_db/main.tf
+++ b/infra/shared/modules/keycloak_db/main.tf
@@ -5,12 +5,20 @@
 # ---------------------------------------------------------------------------
 
 resource "aws_security_group" "keycloak_db" {
-  name        = "platform-${var.env}-sg-keycloak-db"
+  # name_prefix: create_before_destroy と組み合わせることで新旧 SG が同時存在できる。
+  # GroupName は VPC 内でユニークでなければならないため固定 name ではなく name_prefix を使用。
+  name_prefix = "platform-${var.env}-sg-keycloak-db-"
   description = "Keycloak DB: inbound from SG-Keycloak on :3306 (see main.tf sg rule), no outbound"
   vpc_id      = var.vpc_id
 
   tags = {
     Name = "platform-${var.env}-sg-keycloak-db"
+  }
+
+  # create_before_destroy: SG 差し替え時に「新SG作成 → RDS 切替 → 旧SG削除」の順を保証する。
+  # デフォルト(destroy-first)では旧SG削除時に RDS ENI がまだ旧SGを参照しており削除失敗する。
+  lifecycle {
+    create_before_destroy = true
   }
 }
 


### PR DESCRIPTION
## 問題

`aws_security_group.keycloak_db` で `description` が変更されると Terraform はデフォルト (destroy-first) で旧 SG を先に削除しようとする。しかし RDS ENI がまだ旧 SG を参照しているため削除できない。

AWS の RDS-managed ENI は `rds:ModifyDBInstance` 経由でしか SG を切り替えられないため、`ec2:DetachNetworkInterface` (PR #465 で追加) も直接 ENI を切り離す手段としては機能しない。

結果として 3 回の `terraform apply` を経ても `ec2:DetachNetworkInterface` の AccessDenied エラーが解消されなかった。

## 根本原因の分析

Terraform のリソース差し替えログ (run #27081999816):

```
04:47:51Z  module.iam_oidc.aws_iam_role_policy.platform_apply will be updated  ← まだ更新中
04:47:52Z  module.keycloak_db.aws_security_group.keycloak_db: Destroying...    ← 即座に旧SG削除開始
```

`module.keycloak_db` には `depends_on = [module.iam_oidc]` が設定されているが、リソース差し替えの **Destroy フェーズ** には適用されない。旧 SG の削除が IAM ポリシー更新と並列に走り、permission が反映される前に失敗していた。

## 修正内容

`aws_security_group.keycloak_db` に `lifecycle { create_before_destroy = true }` + `name_prefix` を追加。

**差し替えの新しい順序:**
1. 新 SG 作成 (`ec2:CreateSecurityGroup`) ← `depends_on` で IAM 更新後に実行
2. `aws_db_instance.keycloak` の `vpc_security_group_ids` を新 SG に切替 (`rds:ModifyDBInstance`)
3. 旧 SG 削除 (`ec2:DeleteSecurityGroup`) ← この時点で RDS ENI は新 SG を参照 → デタッチ不要

**`name_prefix` が必要な理由:** `create_before_destroy` では新旧 SG が同時存在する瞬間があるため、固定 `name` (AWS GroupName) だと同一 VPC 内で重複エラーになる。`name_prefix` を使って Terraform にユニークなサフィックスを付与させる。表示名は `tags.Name` で管理。

## 変更ファイル

- `infra/shared/modules/keycloak_db/main.tf` — `name_prefix` + `lifecycle { create_before_destroy = true }` を追加
- `docs/specs/Terraform規約.md` v1.1 — SG 差し替え時の `create_before_destroy` + `name_prefix` 必須ルールを追記

## チェックリスト

- [x] `terraform fmt -check -recursive infra/` — OK
- [x] `terraform validate` (shared/dev) — OK
- [x] IAM wildcard gate (`check-iam-wildcards.py`) — OK
- [x] `markdownlint-cli2` (`docs/specs/Terraform規約.md`) — OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)