### PR TITLE
docs(logging): ログ設計正本 + ADR-0019(Boot 標準構造化ログ)+ 規約改訂

### DIFF
--- a/docs/adr/0019-structured-logging-boot-standard.md
+++ b/docs/adr/0019-structured-logging-boot-standard.md
@@ -1,0 +1,117 @@
+# ADR-0019: 構造化ログ出力は Logback + Spring Boot 標準構造化ログを採用する
+
+- **Status**: Accepted
+- **Date**: 2026-06-08
+- **Deciders**: win2cot
+- **Tags**: logging, observability, dependencies
+
+## 目次
+
+- [1. コンテキスト(Context)](#1-コンテキストcontext)
+- [2. 検討した選択肢(Options Considered)](#2-検討した選択肢options-considered)
+- [3. 決定(Decision)](#3-決定decision)
+- [4. 理由(Rationale)](#4-理由rationale)
+- [5. 影響(Consequences)](#5-影響consequences)
+- [6. 実装メモ(Implementation Notes)](#6-実装メモimplementation-notes)
+- [7. 参考リンク(References)](#7-参考リンクreferences)
+
+## 1. コンテキスト(Context)
+
+infra ADR-0005 でログ基盤を CloudWatch Logs(構造化 JSON + Logs Insights)に確定し、JSON 出力スキーマと出力実装の選定を Issue #451 に切り出した。現行実装は Logback + `net.logstash.logback:logstash-logback-encoder:8.1`(`LogstashEncoder` 素の設定のみ、デコレータ / マスカ未使用)。
+
+制約・周辺事情:
+
+- encoder 8.1 は Jackson 2 を transitive に持ち込み、Jackson 2 完全除去(#496)の残存ルートの 1 つ
+- Spring Boot 4.0.6 は標準構造化ログ(`logging.structured.format`: ecs / gelf / logstash)を持ち、Logback / Log4j2 の両 backend で利用可能(自前 JsonWriter、Jackson 非依存)
+- Native Image は判断材料にならない(Log4j 2.25.0 で GraalVM 公式対応済、Logback も Boot サポート済で両者同等)
+- 議論の過程で PII 方針を「マスクして出す」から「**そもそも出さない(参照は内部 ID のみ)**」に格上げした(コーディング規約 §7 改訂)。これにより encoder 層の正規表現マスク(safety-net)は要件から外れた
+
+調査日付: 2026-06-08。一次ソースは §7 参照。
+
+## 2. 検討した選択肢(Options Considered)
+
+### 選択肢 A: Logback + logstash-logback-encoder 9.0(現行延長)
+
+- 概要: encoder を 8.1 → 9.0(Jackson 3 ネイティブ)にアップグレードして継続
+- 利点: 移行コストほぼゼロ。`MaskingJsonGeneratorDecorator`(ValueMasker)による encoder 層 PII マスクが組み込みで使える唯一の案。StructuredArguments 等の表現力が最も豊富
+- 欠点: 追加依存 1 つを維持。9.0 は非互換 API 再編あり(`JsonStreamContext` → `TokenStreamContext` 等)。PII 方針転換により組み込みマスクの優位が消滅
+- リスク・未知数: encoder 独自機能に依存するほど将来の乗換コストが増える
+
+### 選択肢 B: Logback + Spring Boot 標準構造化ログ(採用案)
+
+- 概要: `logging.structured.format.console=logstash` による Boot 組み込みの JSON 出力。backend は Boot デフォルトの Logback を継続
+- 利点: **追加依存ゼロ**(Boot 自前 JsonWriter、Jackson 非依存)。出力は現行 LogstashEncoder と同形(標準フィールド + MDC + fluent `addKeyValue` + markers→tags)で実質無移行。カスタムは properties(`logging.structured.json.add/exclude/rename`)+ `StructuredLoggingJsonMembersCustomizer`。#496 は「encoder 依存ごと削除」に単純化。`logback-spring.xml` も削除可能見込み(env var 切替に置換)
+- 欠点: encoder 層 PII マスクの組み込みなし(PII 方針転換で要件外)。表現力は A に劣る(本プロジェクトの契約「動的 kv は string/number のみ」では差が出ない)
+- リスク・未知数: Boot の構造化ログはまだ新しい機能群で、Boot アップグレード時の挙動変化に追従が要る
+
+### 選択肢 C: Log4j2 + Spring Boot 標準構造化ログ
+
+- 概要: backend を Log4j2(`spring-boot-starter-log4j2` = log4j-slf4j2-impl + log4j-core + log4j-jul、Jackson なし)に入替、JSON は Boot 標準(`StructuredLogLayout`)
+- 利点: Async Logger(LMAX Disruptor)による高スループット。Boot 公式サポートの組み合わせ
+- 欠点: backend 入替コスト(starter 入替 + 設定書換 + SLF4J provider 競合確認)。SLF4J fluent `addKeyValue` は log4j-slf4j2-impl が `CloseableThreadContext`(MDC 相当)経由で処理するため**値が string 化**される(2.26.0 ソース確認)。Boot デフォルトから外れ、毎 upgrade で追従確認が 1 軸増える
+- リスク・未知数: セキュリティ event(`TENANT_CROSSED` 等)はクラッシュ時にも失われない同期書き込みが望ましく、Async Logger の喪失リスクと相性が悪い(per-logger 混在は可能だが運用複雑化)
+
+### 選択肢 D: Log4j2 + JsonTemplateLayout
+
+- 概要: Log4j2 ネイティブの JSON layout(`log4j-layout-template-json`、compile 依存は log4j-core + jctools-core のみ)
+- 利点: garbage-free JSON 直列化で encoder 性能は最良。template JSON による形状自由度が最高
+- 欠点: C の欠点すべて + template 学習・保守。性能優位が効くボトルネック(encoder CPU)が現負荷水準・現経路(stdout → awslogs → CloudWatch Logs)に存在しない
+- リスク・未知数: C と同じ
+
+## 3. 決定(Decision)
+
+**採用**: 選択肢 B(Logback + Spring Boot 標準構造化ログ、logstash 形式)
+
+`logging.structured.format.console=logstash` を環境別 env var(`LOGGING_STRUCTURED_FORMAT_CONSOLE`)で注入する。local / gha はテキスト出力、dev / stg / prd は JSON。スキーマ契約・環境別デフォルトは [docs/specs/ログ設計.md](../specs/ログ設計.md) が正本。
+
+## 4. 理由(Rationale)
+
+- **PII マスク要件の消滅が決定打**: 選定の決め手と位置づけていた encoder 層マスク(ValueMasker)は、PII 方針を「出力禁止(ID 参照のみ)」へ格上げしたことで要件から外れた。正規表現マスクは形式の定まるメール・電話にしか効かず、氏名・自由文には無力で、safety-net としても中途半端だった。基盤側 safety-net が必要なら CloudWatch Logs data protection policy で実現でき、アプリ実装と切り離せる(採否は S3Infra-3)
+- **依存最小**: 追加依存ゼロで Jackson 2 残存ルート(#496)が依存削除で消える。脆弱性追従対象も減る
+- **移行実質ゼロ**: Boot logstash 形式の出力は現行 LogstashEncoder と同形。MDC・fluent addKeyValue・markers の経路もすべて維持される
+- **性能差は顕在化していない**: 現構成のボトルネックは stdout → awslogs → CloudWatch Logs 経路と取り込み従量(ADR-0005)であり、C / D の encoder 性能優位(garbage-free / Async Logger)が効く局面にない。捨てた利点として認識し、再評価トリガを §5 に明記する
+- **同期書き込みの安全性**: セキュリティ event の確実な記録を優先し、Async Logger 前提の構成を避ける
+
+## 5. 影響(Consequences)
+
+### 良い影響(Positive)
+
+- `net.logstash.logback:logstash-logback-encoder` を依存から削除でき、#496 のやること 1 が「9.0 アップグレード + 非互換確認」から「依存削除」に単純化される
+- `logback-spring.xml` を削除し、出力形式・レベルとも env var 切替に一本化できる見込み(全環境共通イメージの原則と整合)
+- JSON フィールド追加は properties 1 行(静的)/ fluent `addKeyValue`(動的)で完結する
+
+### 悪い影響・制約(Negative)
+
+- encoder 独自の表現力(StructuredArguments、ネスト構造、組み込みマスク)を放棄する。ログ設計.md の契約(string/number のみ・ネスト禁止)の範囲では実害なし
+- Boot の構造化ログ機能へのロックイン。Boot アップグレード時に出力形の回帰確認が必要
+
+### 既存ドキュメント・規約への波及
+
+- [docs/specs/ログ設計.md](../specs/ログ設計.md) 新設(本 ADR と同 PR)
+- コーディング規約 §7 改訂(PII 出力禁止への格上げ + 非意図的漏洩経路への対策)
+- 設計規約 §4.2 からログ設計.md への参照追加
+- #496: やること 1 を「logstash-logback-encoder の依存削除」に変更(Issue 本文に折込済の分岐)
+
+### 再評価トリガ
+
+以下のいずれかが観測されたら C / D(Log4j2 系)を再評価する:
+
+1. ログ出力(encoder CPU / アロケーション)がプロファイル計測で有意なボトルネックとして顕在化した場合 → D(JsonTemplateLayout)が第一候補
+2. Boot 標準構造化ログの機能不足(必要なカスタムが properties / Customizer で実現不能)が具体的に発生した場合 → A(logstash-logback-encoder)復帰を含めて再評価
+
+## 6. 実装メモ(Implementation Notes)
+
+- `webapi/build.gradle` から `logstash-logback-encoder` を削除(#496 と同期)
+- `logback-spring.xml` / `logback-test.xml` の扱い: 標準構造化ログへの移行で削除できるか、`CONSOLE_LOG_STRUCTURED_FORMAT` 尊重の最小設定が要るかを実装時に確認
+- ECS task definition(dev)に `LOGGING_STRUCTURED_FORMAT_CONSOLE=logstash` を追加(S3Infra-3 / S2Infra-2 の管轄)
+- 出力 JSON が現行 LogstashEncoder と同形であることをテストで確認(フィールド名・MDC・addKeyValue・stack_trace)
+
+## 7. 参考リンク(References)
+
+- Issue #451 / infra ADR-0005(ログ基盤)/ #496(Jackson 2 除去)
+- [docs/specs/ログ設計.md](../specs/ログ設計.md)(スキーマ契約の正本)
+- Spring Boot 4.0.6 Reference: Structured Logging(`logging.structured.format`、ecs / gelf / logstash、MDC + fluent addKeyValue 同梱を明記)— 2026-06-08 参照
+- spring-boot v4.0.6 `starter/spring-boot-starter-log4j2/build.gradle`(starter 構成 = slf4j2-impl + core + jul)— 2026-06-08 参照
+- apache/logging-log4j2 rel/2.26.0 `Log4jEventBuilder#log()`(fluent kv → CloseableThreadContext 経由で string 化)— 2026-06-08 参照
+- logfellow/logstash-logback-encoder 9.0 release notes(2025-10-27、Jackson 3 移行・非互換 API 再編)— 2026-06-08 参照
+- apache/logging-log4j2 releases(2.26.0 = 2026-05-07)/ `log4j-layout-template-json` 2.26.0 pom(compile 依存 = log4j-core + jctools-core)— 2026-06-08 参照

--- a/docs/specs/コーディング規約.md
+++ b/docs/specs/コーディング規約.md
@@ -2,9 +2,9 @@
 
 タスク管理システム(tasks-webapi)
 
-Version 1.7
+Version 1.8
 
-2026-06-05
+2026-06-08
 
 作成者: 開発チーム
 
@@ -21,6 +21,7 @@ Version 1.7
 | 1.5 | 2026-05-31 | Issue #287: §5 を「DTO / record」から「型選択(record / class)」へ拡張。層 × 部品マトリクス + 判断軸 4 つを追加、既存「REST 入出力 DTO」記述は §5.3 へ subsection 化。[ADR-0011](../adr/0011-error-response-record.md) と相互参照 | 開発チーム |
 | 1.6 | 2026-06-01 | Issue #331 / [ADR-0014](../adr/0014-jsonnullable-for-patch-dto.md): §5.3 末尾に PATCH 部分更新 DTO の `JsonNullable<T>` 採用 pointer 追加(ADR を SSOT、規約は参照のみ) | 開発チーム |
 | 1.7 | 2026-06-05 | §18 レビューチェックリストに IAM ポリシーの resource スコープ確認項目を追加(Issue #399 事後改善) | 開発チーム |
+| 1.8 | 2026-06-08 | Issue #451 / [ADR-0019](../adr/0019-structured-logging-boot-standard.md): §7 全面改訂。PII を出力禁止に格上げ(非意図的漏洩経路 4 点を含む)、MDC 項目の出力条件明確化、fluent `addKeyValue` 作法追加、[ログ設計](./ログ設計.md) への参照追加 | 開発チーム |
 
 ## 目次
 
@@ -399,12 +400,20 @@ public record TaskCreateRequest(
 
 ## 7. ログ
 
+出力スキーマ・相関キー・event タクソノミ・環境別レベルの正本は [ログ設計](./ログ設計.md)(Issue #451 / ADR-0019)。本節はコードの書き方を定める。
+
 - `org.slf4j.Logger` を `@Slf4j` で取得し、変数名 `log` で統一。
 - `System.out.println` / `e.printStackTrace()` / `Throwable#getStackTrace` を直接出力する書き方は禁止。
-- **MDC 必須項目**: `tenantId` / `userId` / `requestId`(設計規約 §4.2)。
+- **MDC 項目**: `requestId`(全リクエスト)/ `userId`(認証後)/ `tenantId`(TenantContext 構築時のみ)/ `apiScope`(プラットフォーム API のみ)/ `batchId`(バッチのみ)。フィルタで自動セットし、業務コードで直接操作しない(設計規約 §4.2、ログ設計 §3.1)。
 - フォーマットは SLF4J プレースホルダ(`log.info("Task {} updated by {}", taskId, userId)`)を使う。文字列連結禁止。
+- 構造化フィールドの動的付与は SLF4J fluent API(`log.atWarn().addKeyValue("event", "TENANT_CROSSED").log(...)`)を使う。値は **string / number のみ、ネスト禁止**(ログ設計 §3.2)。`event` の値はログ設計 §5 のタクソノミに従う。
 - 例外を再ラップする場合、`cause` を保持する(`new XException("msg", e)`)。
-- **PII(氏名・メール・電話番号)を直接出さない**。マスク化(`example@***.com`)するか、`userId`(内部 ID)で代替する。
+- **PII(氏名・メール・電話番号等)はログに出力しない**。マスクして出すことも不可(マスクは漏洩経路とのいたちごっこになる)。参照は内部 ID(`userId` / `taskId` 等)のみ。
+- PII の**非意図的な漏洩経路**にも対策する:
+  - **例外メッセージ**: 入力値を含む既知の例外(MySQL `Duplicate entry '...'`、Bean Validation の rejected value 等)は、そのままログに出さず sanitize してから記録する(`@RestControllerAdvice` での変換と同じ場所で対処)。
+  - **toString 経由**: エンティティ / DTO / record をプレースホルダに直接渡さない(record は全 component が toString に出る)。渡すのは ID。
+  - **リクエスト body / query 文字列の生ログ禁止**(検索キーワード等に PII が入り得る)。
+  - **フレームワーク設定**: Hibernate のパラメータバインドログ(TRACE)等、値を吐く設定を prod 系環境で有効化しない。
 
 ---
 

--- a/docs/specs/ログ設計.md
+++ b/docs/specs/ログ設計.md
@@ -1,0 +1,123 @@
+# ログ設計
+
+タスク管理システム(tasks-webapi)
+
+Version 1.0
+
+2026-06-08
+
+作成者: 開発チーム
+
+## 改訂履歴
+
+| 版数 | 改訂日 | 改訂内容 | 改訂者 |
+|---|---|---|---|
+| 1.0 | 2026-06-08 | Issue #451: 新規作成(JSON スキーマ契約・相関キー設計・event タクソノミ・レベル運用) | 開発チーム |
+
+## 1. 目的・スコープ
+
+本ドキュメントは **tasks-webapi プロセスが stdout に出力するログ**(アプリログ・アプリ層アクセスログ・バッチログ)の出力契約を定める正本である。
+
+**対象外**(それぞれの正本を参照):
+
+- ログ基盤・収集対象カタログ・保持期間 → [infra ADR-0005](../../infra/docs/adr/0005-logging-platform.md) §3
+- Keycloak / RDS / ALB / CloudFront 等のログ形式(既製品の形式を受容し、本ドキュメントは §4 の相関のみ扱う)
+- ログ実装の作法(PII 出力禁止・プレースホルダ等)→ [コーディング規約 §7](./コーディング規約.md)
+- 出力実装の選定経緯 → ADR-0019(Logback + Spring Boot 標準構造化ログ)
+
+## 2. 出力実装と環境別デフォルト
+
+出力実装は **Logback + Spring Boot 標準構造化ログ(`logging.structured.format`、logstash 形式)** を採用する(ADR-0019)。追加依存ゼロ、JSON 直列化は Boot 自前の JsonWriter(Jackson 非依存)。
+
+環境差は env var のみで吸収する(infrastructure-plan 確定前提 #5「Spring プロファイル不使用」/ #6「全環境共通イメージ」と整合)。
+
+| 環境 | 出力形式 | root | `xyz.dgz48` | 設定方法 |
+|---|---|---|---|---|
+| local | テキスト(Boot デフォルト) | INFO | DEBUG | 開発者のシェル / docker-compose で env var |
+| gha | テキスト | INFO | DEBUG | workflow env |
+| dev | JSON(logstash)→ CloudWatch Logs | INFO | DEBUG | ECS task definition の env var |
+| stg | JSON → CloudWatch Logs | INFO | INFO | 同上(未構築、構築時に適用) |
+| prd | JSON → CloudWatch Logs | INFO | INFO | 同上(未構築、構築時に適用) |
+
+- JSON 化: `LOGGING_STRUCTURED_FORMAT_CONSOLE=logstash` を注入(未設定ならテキスト)
+- レベル変更: `LOGGING_LEVEL_<package>` を注入。一時調査は task definition 更新のみで再ビルド・再リリース不要
+- Native Image 化後もこの env var 経路が機能するかは Sprint 0/1 の実行時設定検証(JAVA_TOOL_OPTIONS 系)と同枠で確認する
+
+## 3. JSON スキーマ契約
+
+### 3.1 フィールド一覧
+
+| フィールド | 由来 | 出力条件 | 説明 |
+|---|---|---|---|
+| `@timestamp` `@version` `message` `logger_name` `thread_name` `level` `level_value` | Boot logstash 形式標準 | 常時 | Boot が出力する標準フィールド |
+| `stack_trace` | 同上 | 例外時 | スタックトレース。出力量の制御(`logging.structured.json.stacktrace.*`)は S3Infra-3 実装時に調整 |
+| `requestId` | MDC(フィルタで生成) | 全 HTTP リクエスト | app 生成 UUID。認証より前にセットされる(§4.1) |
+| `userId` | MDC | 認証済リクエスト | JWT `sub`。テナントユーザー・SaaS Admin 共通 |
+| `tenantId` | MDC | TenantContext 構築時のみ | 業務 API のみ。プラットフォーム API・認証系・セルフサインアップでは出力されない(正常) |
+| `apiScope` | MDC | プラットフォーム API のみ | 固定値 `platform`。SaaS Admin 操作の横断抽出用。業務 API では出力しない |
+| `traceId` | MDC(ALB ヘッダ由来) | ヘッダ受領時 | `X-Amzn-Trace-Id` の Root 部(§4.2) |
+| `event` | fluent `addKeyValue` | 該当事象時 | タクソノミは §5 |
+| `batchId` | MDC | バッチ実行中 | バッチ実行単位の識別子 |
+
+`service` / `env` のような自己記述フィールドは MVP では出力しない(ロググループ名 `/tasks/<env>/webapi` と冗長)。複数ロググループ横断クエリや S3 export の需要が顕在化したら `logging.structured.json.add` で追加する(契約上、将来追加されうる)。
+
+### 3.2 型・命名規約
+
+- 動的 key-value(`event` 等)は **SLF4J fluent API(`log.atInfo().addKeyValue(...)`)** で付与する。値は **string / number のみ、ネスト禁止**(Logs Insights の検索性と実装乗換耐性のため)
+- 命名: Boot 標準フィールドは logstash 形式の snake_case のまま受容し、自前フィールドは MDC キーと同じ camelCase とする。`rename` による統一はしない(設定が契約の一部になり保守が増えるため)
+- ログメッセージ(`message`)に構造化すべき値を文字列連結で埋め込まない(コーディング規約 §7)
+
+## 4. 相関キー設計
+
+### 4.1 requestId(app 内の主キー)
+
+- servlet filter で **app が UUID を生成**し、認証処理より前に MDC にセットする
+- レスポンスヘッダ `X-Request-Id` で呼び出し元へエコーする(サポート問い合わせ → ログ特定の経路)
+- 信頼できる一意性が保証された追跡主キー。外部入力をこのフィールドに採用しない
+
+### 4.2 traceId(ALB ログとの join 専用)
+
+- ALB が付与する `X-Amzn-Trace-Id` ヘッダの `Root=` 部を**形式検証のうえ** MDC にセットする(不正形式・欠落時は出力しない)
+- ALB アクセスログの `trace_id` フィールドと join するためだけに記録する
+- このヘッダは**クライアントが偽装可能**(ALB は既存値を素通しする)ため、requestId とは分離する。偽装されても join が壊れるだけで、追跡主キーは無傷
+
+### 4.3 相関マトリクス
+
+| 相手 | 方式 | 備考 |
+|---|---|---|
+| ALB アクセスログ | `traceId` ↔ `trace_id` | アプリ層アクセスログ行(`HTTP_REQUEST`)が requestId / traceId / tenantId / userId を全部持つ相関ハブ |
+| Keycloak events | `userId`(= Keycloak `sub`)+ 時間窓 | requestId の伝播は行わない(カスタム SPI は作らない) |
+| RDS error / slow query | 時間ベースのみ | 直接相関なしを受容 |
+| CloudFront | **相関なし** | フロント静的配信専用で API 経路を通らない(infrastructure-plan §3.2 で DNS 分離) |
+
+**再評価トリガ**: API を CloudFront 配下に入れる構成変更(edge WAF 等)を行う場合、CloudFront request id の伝播を含めて本節を再設計する(API 前段構成の Issue を参照)。
+
+## 5. event タクソノミ
+
+`event` は「機械処理(CloudWatch metric filter・アラート・定型クエリ)の対象になる運用・セキュリティ事象」にのみ付与する任意フィールド。**業務操作の証跡は `audit_logs`(ADR-0013)が正本**であり、業務イベントをログ event として二重管理しない。通常のアプリログに event は不要。
+
+### 5.1 値の語彙
+
+- **セキュリティ系**: `audit_logs.action` の標準値(基本設計書 §4.2.6 / §6.2.3)を**そのまま流用**し、新語を作らない。代表値: 違反系 8 件(`VIEW_DENIED` 等の `*_DENIED` 7 件 + `TENANT_CROSSED`)と `LOGIN_FAILED`。audit_logs(証跡)と ログ行(機械検知シグナル)の二重記録になるが、語彙が単一なので二重管理ではない
+- **運用系**(ログ専用、本ドキュメントが所有): `HTTP_REQUEST`(アクセスログ行)/ `BATCH_START` / `BATCH_END` / `BATCH_FAILED`(batchId とセット)
+
+> **注**: infra ADR-0005 §6 実装メモの `CROSS_TENANT_VIOLATION` は例示であり、正式な値は `TENANT_CROSSED`(本節)とする。metric filter は `event = "TENANT_CROSSED"` に張る。
+
+### 5.2 追加ルール
+
+- 本節のレジストリが正本。追加は「metric filter・アラート・定型クエリで使う具体的予定があること」を条件に PR レビューで判断する。予定がなければ素のログメッセージで足りる
+- 命名は SCREAMING_SNAKE。セキュリティ系は必ず audit_logs action 値との整合を確認する
+
+## 6. レベル・サンプリング運用
+
+- レベル基準は設計規約 §4.2 の既定(ERROR=復旧操作要 / WARN=性能劣化・認可拒否 / INFO=ビジネスイベント / DEBUG=開発詳細)を維持。環境別デフォルトは §2 の表
+- **サンプリングは導入しない**。取り込み従量の制御は retention(ADR-0005)+ レベル運用 + ヘルスチェック除外の 3 点で行う
+  - 再評価トリガ: CloudWatch Logs 取り込みコストが顕在化し、かつ `HTTP_REQUEST` 行が支配的な場合に**アクセスログ行のみ**サンプリングを検討する。セキュリティ系 event 行は恒久的にサンプリング対象外
+- `/actuator/health` 系エンドポイントはアクセスログ(`HTTP_REQUEST`)の出力対象外(ALB ヘルスチェックが行数を支配するため)
+- WARN/ERROR の metric filter → アラート実装は S3Infra-3 が担当
+
+## 7. PII・機微情報
+
+**PII はログに出力しない(マスクではなく不出力)。参照は内部 ID のみ**。詳細な作法(非意図的漏洩経路への対策を含む)はコーディング規約 §7 が正本。
+
+基盤側 safety-net(CloudWatch Logs data protection policy: managed identifier によるメール・電話の検出・閲覧時マスク)の採否は、スキャン従量コストを含めて S3Infra-3 で判断する。アプリの出力実装には依存しない。

--- a/docs/specs/設計規約.md
+++ b/docs/specs/設計規約.md
@@ -2,9 +2,9 @@
 
 タスク管理システム(tasks-webapi)
 
-Version 1.6
+Version 1.8
 
-2026-06-05
+2026-06-08
 
 作成者: 開発チーム
 
@@ -21,6 +21,7 @@ Version 1.6
 | 1.5 | 2026-05-31 | §1.1 末尾に `docs/dev/feature-template.md` への cross-ref 追記(Issue #274) | 開発チーム |
 | 1.6 | 2026-06-05 | Issue #315 / [ADR-0010](../adr/0010-tenant-isolation-hibernate-filter.md): §3.3.1「Hibernate Filter 除外テーブル」追加、付与基準の明文化 | 開発チーム |
 | 1.7 | 2026-06-06 | Issue #309 / [ADR-0016](../adr/0016-initial-tenant-selection-policy.md): §3.3 に `X-Tenant-Id` ヘッダ未指定時の初期テナント自動解決フロー(`UserTenantsResolverService`)を追記 | 開発チーム |
+| 1.8 | 2026-06-08 | Issue #451 / [ADR-0019](../adr/0019-structured-logging-boot-standard.md): §4.2 改訂。Spring Boot 標準構造化ログ採用の反映、MDC 項目の出力条件明確化、PII 出力禁止への格上げ、[ログ設計](./ログ設計.md) への参照追加 | 開発チーム |
 
 ## 目次
 
@@ -386,10 +387,12 @@ dev 環境への tasks-webapi 初回デプロイ前(Flyway 履歴テーブル `f
 
 ### 4.2 ログ
 
-- 出力: SLF4J(Lombok `@Slf4j`)。`System.out.println` / `e.printStackTrace()` 禁止。
-- レベル: `ERROR` は復旧操作が必要な状況、`WARN` は性能劣化や認可拒否、`INFO` はビジネスイベント、`DEBUG` は開発時の詳細。
-- **MDC 必須項目**: `tenantId` / `userId` / `requestId`。フィルタで自動セットする(実装は別 PR)。
-- PII(氏名・メール・電話番号)を直接ログに出さない。出力する場合はマスク(`example@***.com`)。
+出力スキーマ(JSON フィールド契約)・相関キー設計・event タクソノミ・環境別デフォルトの正本は [ログ設計](./ログ設計.md)(Issue #451 / ADR-0019)。
+
+- 出力: SLF4J(Lombok `@Slf4j`)+ Spring Boot 標準構造化ログ(logstash 形式、ADR-0019)。`System.out.println` / `e.printStackTrace()` 禁止。
+- レベル: `ERROR` は復旧操作が必要な状況、`WARN` は性能劣化や認可拒否、`INFO` はビジネスイベント、`DEBUG` は開発時の詳細。環境別デフォルトと一時変更手順はログ設計 §2 / §6。
+- **MDC 項目**: `requestId`(全リクエスト)/ `userId`(認証後)/ `tenantId`(TenantContext 構築時のみ)/ `apiScope`(プラットフォーム API のみ)/ `batchId`(バッチのみ)。フィルタで自動セットする(実装は別 PR)。
+- **PII(氏名・メール・電話番号等)はログに出力しない**(マスクして出すことも不可)。参照は内部 ID のみ。非意図的漏洩経路への対策を含む作法はコーディング規約 §7。
 - 例外スタックは1回だけ出力する。再ラップ時は原例外を `cause` に保持。
 
 ### 4.3 監査ログ(基本設計書 §6.7)


### PR DESCRIPTION
## 概要

Issue #451 の議論結論を文書化する。

- `docs/specs/ログ設計.md` 新設: webapi が stdout に出すログの JSON スキーマ契約・相関キー設計(requestId/traceId 分離)・event タクソノミ(audit_logs action 語彙流用)・5 環境別デフォルト・サンプリング方針の正本
- ADR-0019: 出力実装 = Logback + Spring Boot 標準構造化ログ(logstash 形式)採用。logstash-logback-encoder 9.0 / Log4j2 系 2 案は棄却(再評価トリガ付き)
- コーディング規約 §7 / 設計規約 §4.2: PII を「マスクして出す」から「出力禁止(ID 参照のみ)」へ格上げ、非意図的漏洩経路 4 点(例外メッセージ / toString / body・query / FW 設定)を規約化

## 影響

- #496: やること 1 は「encoder 依存ごと削除」に変更(Issue 本文の分岐どおり)
- S3Infra-3: 本 doc を参照して実装。CWL data protection policy 採否も S3Infra-3 で判断

Closes #451
