### PR TITLE
ci(native): nativeCompile CI job を追加(#490 S2Infra-8)

### DIFF
--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -43,6 +43,7 @@ jobs:
               - 'gradle/**'
               - 'gradlew'
               - 'gradlew.bat'
+              - '.github/workflows/native-build.yml'
 
   nativeCompile:
     needs: changes

--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -1,0 +1,98 @@
+# Native Image compile check – PR validation only (no deployable image produced).
+# Role: nativeCompile のみ実行し native build 破壊を PR で検知する(#490)。
+#       bootBuildImage(フルコンテナイメージ生成)は #481 が担当 — ADR-0018 §3 役割分担参照。
+# Estimated duration: 5–15 min (with -Ob quick build mode).
+# ADR references: ADR-0018 (bootBuildImage 役割分担), ADR-0021 (JDK 25 baseline).
+
+name: Native Build
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+env:
+  LANG: ja_JP.UTF-8
+  TZ: Asia/Tokyo
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      native: ${{ steps.filter.outputs.native }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            native:
+              - 'webapi/**'
+              - '*.gradle*'
+              - 'settings.gradle*'
+              - 'gradle/**'
+              - 'gradlew'
+              - 'gradlew.bat'
+
+  nativeCompile:
+    needs: changes
+    if: needs.changes.outputs.native == 'true' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    services:
+      mysql:
+        image: mysql:8.4
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: tasks
+          MYSQL_USER: tasks_webapi
+          MYSQL_PASSWORD: tasks_webapi
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping --silent"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=10
+
+    env:
+      # processAot starts the production Spring context (Flyway + Hibernate validate).
+      # These env vars are picked up by the aotEnv() fallback in webapi/build.gradle.
+      DATASOURCE_URL: "jdbc:mysql://localhost:3306/tasks?useSSL=false&allowPublicKeyRetrieval=true&connectionTimeZone=SERVER&forceConnectionTimeZoneToSession=true"
+      DATASOURCE_USERNAME: tasks_webapi
+      DATASOURCE_PASSWORD: tasks_webapi
+      # Spring Security JwtDecoder is lazy (no network call at context startup).
+      OIDC_ISSUER_URI: "http://localhost:18080/realms/tasks"
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up GraalVM 25 (Community)
+        uses: graalvm/setup-graalvm@v1
+        with:
+          java-version: '25'
+          distribution: 'graalvm-community'
+          cache: 'gradle'
+
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+
+      - name: Native compile
+        # -PciNativeBuild activates GHA-only memory-reduction flags in webapi/build.gradle:
+        #   -Ob           quick build mode (less optimization, lower memory + time)
+        #   -J-Xmx12g     cap native-image JVM heap on the 16 GB GHA standard runner
+        #   --parallelism=2  reduce concurrent compilation threads
+        # These flags are PR-check-only and do NOT affect bootBuildImage (#481).
+        run: ./gradlew :webapi:nativeCompile -PciNativeBuild=true

--- a/webapi/build.gradle
+++ b/webapi/build.gradle
@@ -170,6 +170,12 @@ graalvmNative {
     binaries {
         main {
             imageName = 'tasks-webapi'
+            // CI-only memory flags activated by -PciNativeBuild=true (native-build.yml).
+            // -Ob reduces optimization level to cut build time/memory on 16 GB GHA runners.
+            // Does NOT affect bootBuildImage (#481) which bypasses this Gradle config.
+            if (project.hasProperty('ciNativeBuild')) {
+                buildArgs.addAll(['-Ob', '-J-Xmx12g', '--parallelism=2'])
+            }
         }
     }
     toolchainDetection = false


### PR DESCRIPTION
## 概要

Issue #490(S2Infra-8)の実装。PR トリガーで GraalVM 25 Native Image の `nativeCompile` を検証する GitHub Actions job を追加する。

**本 PR の最重要ゴール**: ローカルでは 16GB メモリ制約により AOT 解析到達までしか確認できていなかった、**Java 25 + GraalVM での `nativeCompile` 完遂を GHA で実証する**。

Closes #490

---

## Workflow 構成 (`.github/workflows/native-build.yml`)

| 項目 | 内容 |
|------|------|
| トリガー | `pull_request` (branches: main) + `workflow_dispatch` |
| concurrency | `${{ github.workflow }}-${{ github.ref }}` / cancel-in-progress: true |
| changes ゲート | `dorny/paths-filter@v3` — `webapi/**` / `*.gradle*` / `settings.gradle*` / `gradle/**` / `gradlew*` / `.github/workflows/native-build.yml` |
| nativeCompile job | GraalVM 25 Community、MySQL 8.4 サービスコンテナ付き |
| permissions | `contents: read` のみ(changes job のみ `pull-requests: read` 追加) |
| ADR 参照 | ADR-0018(役割分担: #490=nativeCompile 単体、#481=bootBuildImage フル)、ADR-0021(JDK 25 baseline) |

## メモリ調整 (`webapi/build.gradle`)

GHA 標準ランナー(ubuntu-latest, 16GB)で完遂させるため `-PciNativeBuild=true` プロパティで以下を有効化:

| フラグ | 目的 |
|--------|------|
| `-Ob` | Quick build mode — 最適化を落としてメモリ・時間を削減(PR 検証限定、本番性能には影響しない) |
| `-J-Xmx12g` | native-image JVM のヒープ上限を明示(デフォルトは最大 32GB を要求し OOM の原因) |
| `--parallelism=2` | 並列スレッド数を絞りメモリ使用量を削減 |

**bootBuildImage(#481)には波及しない**: `graalvmNative.binaries.main.buildArgs` は `nativeCompile` のみに影響し、Paketo buildpacks を使う `bootBuildImage` パスは別経路。

## `processAot` のサービス依存

`nativeCompile` は事前に `processAot` を実行する。`processAot` は本番 Spring コンテキストを起動するため:
- **MySQL**: `ddl-auto: validate` + Flyway が接続を必要とする → MySQL 8.4 サービスコンテナを追加
- **Keycloak**: Spring Security の `JwtDecoder`(`issuer-uri` ベース)は lazy 初期化のため起動時に OIDC エンドポイントへの接続不要 → ダミー URI で対応

## changes ゲート動作確認

本 PR は `webapi/build.gradle`(= `*.gradle*` フィルタ対象)を含むため、`nativeCompile` job が自動トリガーされた。✅ 確認済み。

## Native compile 完遂結果

| 項目 | 結果 |
|------|------|
| 完遂可否 | ✅ **成功**([Run #1](https://github.com/win2cot/tasks-webapi/actions/runs/27201668710/job/80306991490)) |
| 所要時間 | 約 **9 分 20 秒**(11:01:45 → 11:11:05 UTC) |
| 適用メモリフラグ | `-Ob` / `-J-Xmx12g` / `--parallelism=2` |
| OOM の有無 | **なし** — GHA 標準ランナー(ubuntu-latest, 16GB)で完遂 |

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)