### PR TITLE
refactor(webapi): タイムゾーンを AppZones.JST に集約

### DIFF
--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/security/adapter/web/LogoutExceptionHandler.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/security/adapter/web/LogoutExceptionHandler.java
@@ -3,26 +3,24 @@ package xyz.dgz48.tasks.webapi.security.adapter.web;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolationException;
 import java.time.OffsetDateTime;
-import java.time.ZoneId;
 import java.util.Objects;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.HandlerMethodValidationException;
+import xyz.dgz48.tasks.webapi.shared.infra.AppZones;
 import xyz.dgz48.tasks.webapi.shared.web.ErrorCode;
 import xyz.dgz48.tasks.webapi.shared.web.ErrorResponse;
 
 @RestControllerAdvice(assignableTypes = LogoutController.class)
 class LogoutExceptionHandler {
 
-  private static final ZoneId JST = ZoneId.of("Asia/Tokyo");
-
   @ExceptionHandler({ConstraintViolationException.class, HandlerMethodValidationException.class})
   @ResponseStatus(HttpStatus.BAD_REQUEST)
   public ErrorResponse handleValidation(Exception ex, HttpServletRequest request) {
     return new ErrorResponse(
-        OffsetDateTime.now(JST),
+        OffsetDateTime.now(AppZones.JST),
         HttpStatus.BAD_REQUEST.value(),
         HttpStatus.BAD_REQUEST.getReasonPhrase(),
         ErrorCode.E_VALIDATION,

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/security/adapter/web/TasksAccessDeniedHandler.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/security/adapter/web/TasksAccessDeniedHandler.java
@@ -5,7 +5,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.OffsetDateTime;
-import java.time.ZoneId;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -13,6 +12,7 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.stereotype.Component;
 import tools.jackson.databind.json.JsonMapper;
+import xyz.dgz48.tasks.webapi.shared.infra.AppZones;
 import xyz.dgz48.tasks.webapi.shared.web.ErrorCode;
 import xyz.dgz48.tasks.webapi.shared.web.ErrorResponse;
 
@@ -20,8 +20,6 @@ import xyz.dgz48.tasks.webapi.shared.web.ErrorResponse;
 @Component
 @RequiredArgsConstructor
 public class TasksAccessDeniedHandler implements AccessDeniedHandler {
-
-  private static final ZoneId JST = ZoneId.of("Asia/Tokyo");
 
   private final JsonMapper objectMapper;
 
@@ -36,7 +34,7 @@ public class TasksAccessDeniedHandler implements AccessDeniedHandler {
     response.setCharacterEncoding(StandardCharsets.UTF_8.name());
     ErrorResponse errorResponse =
         new ErrorResponse(
-            OffsetDateTime.now(JST),
+            OffsetDateTime.now(AppZones.JST),
             HttpStatus.FORBIDDEN.value(),
             HttpStatus.FORBIDDEN.getReasonPhrase(),
             ErrorCode.E_FORBIDDEN,

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/security/adapter/web/TasksAuthenticationEntryPoint.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/security/adapter/web/TasksAuthenticationEntryPoint.java
@@ -5,7 +5,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.OffsetDateTime;
-import java.time.ZoneId;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -14,6 +13,7 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
 import tools.jackson.databind.json.JsonMapper;
+import xyz.dgz48.tasks.webapi.shared.infra.AppZones;
 import xyz.dgz48.tasks.webapi.shared.web.ErrorCode;
 import xyz.dgz48.tasks.webapi.shared.web.ErrorResponse;
 
@@ -22,8 +22,6 @@ import xyz.dgz48.tasks.webapi.shared.web.ErrorResponse;
 @Component
 @RequiredArgsConstructor
 public class TasksAuthenticationEntryPoint implements AuthenticationEntryPoint {
-
-  private static final ZoneId JST = ZoneId.of("Asia/Tokyo");
 
   private final JsonMapper objectMapper;
 
@@ -40,7 +38,7 @@ public class TasksAuthenticationEntryPoint implements AuthenticationEntryPoint {
     response.setCharacterEncoding(StandardCharsets.UTF_8.name());
     ErrorResponse errorResponse =
         new ErrorResponse(
-            OffsetDateTime.now(JST),
+            OffsetDateTime.now(AppZones.JST),
             HttpStatus.UNAUTHORIZED.value(),
             HttpStatus.UNAUTHORIZED.getReasonPhrase(),
             ErrorCode.E_UNAUTHORIZED,

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/security/adapter/web/TenantContextFilter.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/security/adapter/web/TenantContextFilter.java
@@ -7,7 +7,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.OffsetDateTime;
-import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -22,6 +21,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 import tools.jackson.databind.json.JsonMapper;
 import xyz.dgz48.tasks.webapi.shared.domain.TenantContext;
+import xyz.dgz48.tasks.webapi.shared.infra.AppZones;
 import xyz.dgz48.tasks.webapi.shared.web.ErrorCode;
 import xyz.dgz48.tasks.webapi.shared.web.ErrorResponse;
 import xyz.dgz48.tasks.webapi.tenant.domain.TenantMembership;
@@ -46,8 +46,6 @@ import xyz.dgz48.tasks.webapi.tenant.usecase.UserTenantsResolverService;
 public class TenantContextFilter extends OncePerRequestFilter {
 
   static final String HEADER_X_TENANT_ID = "X-Tenant-Id";
-
-  private static final ZoneId JST = ZoneId.of("Asia/Tokyo");
 
   private final TenantMembershipPort tenantMembershipPort;
   private final UserTenantsResolverService userTenantsResolverService;
@@ -146,7 +144,7 @@ public class TenantContextFilter extends OncePerRequestFilter {
     response.setCharacterEncoding(StandardCharsets.UTF_8.name());
     ErrorResponse errorResponse =
         new ErrorResponse(
-            OffsetDateTime.now(JST),
+            OffsetDateTime.now(AppZones.JST),
             status.value(),
             status.getReasonPhrase(),
             code,

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/shared/infra/AppZones.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/shared/infra/AppZones.java
@@ -1,0 +1,12 @@
+package xyz.dgz48.tasks.webapi.shared.infra;
+
+import java.time.ZoneId;
+
+/** アプリケーション全体で使用するタイムゾーン定数(JST 全層統一: #265 / ADR-0009)。 */
+public final class AppZones {
+
+  /** アプリケーション標準タイムゾーン(Asia/Tokyo)。 */
+  public static final ZoneId JST = ZoneId.of("Asia/Tokyo");
+
+  private AppZones() {}
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/shared/infra/ClockConfig.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/shared/infra/ClockConfig.java
@@ -2,7 +2,6 @@ package xyz.dgz48.tasks.webapi.shared.infra;
 
 import java.time.Clock;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.util.Optional;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
@@ -19,7 +18,7 @@ class ClockConfig {
   @Bean
   @ConditionalOnMissingBean
   Clock clock() {
-    return Clock.system(ZoneId.of("Asia/Tokyo"));
+    return Clock.system(AppZones.JST);
   }
 
   @Bean

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/shared/web/SharedExceptionHandler.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/shared/web/SharedExceptionHandler.java
@@ -2,7 +2,6 @@ package xyz.dgz48.tasks.webapi.shared.web;
 
 import jakarta.servlet.http.HttpServletRequest;
 import java.time.OffsetDateTime;
-import java.time.ZoneId;
 import java.util.Objects;
 import org.jspecify.annotations.Nullable;
 import org.springframework.http.HttpHeaders;
@@ -18,12 +17,11 @@ import org.springframework.web.context.request.ServletWebRequest;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 import xyz.dgz48.tasks.webapi.shared.exception.SaasAdminRequiredException;
+import xyz.dgz48.tasks.webapi.shared.infra.AppZones;
 
 /** 共通業務例外を HTTP レスポンスにマップするグローバル例外ハンドラ。 */
 @RestControllerAdvice
 class SharedExceptionHandler extends ResponseEntityExceptionHandler {
-
-  private static final ZoneId JST = ZoneId.of("Asia/Tokyo");
 
   @Override
   protected ResponseEntity<Object> createResponseEntity(
@@ -49,7 +47,7 @@ class SharedExceptionHandler extends ResponseEntityExceptionHandler {
         .headers(headers)
         .body(
             new ErrorResponse(
-                OffsetDateTime.now(JST),
+                OffsetDateTime.now(AppZones.JST),
                 HttpStatus.BAD_REQUEST.value(),
                 HttpStatus.BAD_REQUEST.getReasonPhrase(),
                 ErrorCode.E_VALIDATION,
@@ -67,7 +65,7 @@ class SharedExceptionHandler extends ResponseEntityExceptionHandler {
         .headers(headers)
         .body(
             new ErrorResponse(
-                OffsetDateTime.now(JST),
+                OffsetDateTime.now(AppZones.JST),
                 statusCode.value(),
                 reasonPhrase,
                 code,
@@ -99,7 +97,7 @@ class SharedExceptionHandler extends ResponseEntityExceptionHandler {
   public ErrorResponse handleSaasAdminRequired(
       SaasAdminRequiredException ex, HttpServletRequest request) {
     return new ErrorResponse(
-        OffsetDateTime.now(JST),
+        OffsetDateTime.now(AppZones.JST),
         HttpStatus.FORBIDDEN.value(),
         HttpStatus.FORBIDDEN.getReasonPhrase(),
         ErrorCode.E_FORBIDDEN,

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/adapter/web/TaskExceptionHandler.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/adapter/web/TaskExceptionHandler.java
@@ -2,7 +2,6 @@ package xyz.dgz48.tasks.webapi.task.adapter.web;
 
 import jakarta.servlet.http.HttpServletRequest;
 import java.time.OffsetDateTime;
-import java.time.ZoneId;
 import java.util.Objects;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.MissingRequestHeaderException;
@@ -11,6 +10,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import xyz.dgz48.tasks.webapi.shared.exception.DomainException;
 import xyz.dgz48.tasks.webapi.shared.exception.PreconditionFailedException;
+import xyz.dgz48.tasks.webapi.shared.infra.AppZones;
 import xyz.dgz48.tasks.webapi.shared.web.ErrorCode;
 import xyz.dgz48.tasks.webapi.shared.web.ErrorResponse;
 import xyz.dgz48.tasks.webapi.task.domain.StakeholderAlreadyExistsException;
@@ -22,8 +22,6 @@ import xyz.dgz48.tasks.webapi.task.domain.TaskOwnershipException;
 @RestControllerAdvice(assignableTypes = TaskController.class)
 public class TaskExceptionHandler {
 
-  private static final ZoneId JST = ZoneId.of("Asia/Tokyo");
-
   @ExceptionHandler({
     TaskNotFoundException.class,
     TaskNotViewableException.class,
@@ -32,7 +30,7 @@ public class TaskExceptionHandler {
   @ResponseStatus(HttpStatus.NOT_FOUND)
   public ErrorResponse handleNotFound(DomainException ex, HttpServletRequest request) {
     return new ErrorResponse(
-        OffsetDateTime.now(JST),
+        OffsetDateTime.now(AppZones.JST),
         HttpStatus.NOT_FOUND.value(),
         HttpStatus.NOT_FOUND.getReasonPhrase(),
         ErrorCode.E_NOT_FOUND,
@@ -44,7 +42,7 @@ public class TaskExceptionHandler {
   @ResponseStatus(HttpStatus.FORBIDDEN)
   public ErrorResponse handleForbidden(DomainException ex, HttpServletRequest request) {
     return new ErrorResponse(
-        OffsetDateTime.now(JST),
+        OffsetDateTime.now(AppZones.JST),
         HttpStatus.FORBIDDEN.value(),
         HttpStatus.FORBIDDEN.getReasonPhrase(),
         ErrorCode.E_FORBIDDEN,
@@ -57,7 +55,7 @@ public class TaskExceptionHandler {
   public ErrorResponse handlePreconditionFailed(
       PreconditionFailedException ex, HttpServletRequest request) {
     return new ErrorResponse(
-        OffsetDateTime.now(JST),
+        OffsetDateTime.now(AppZones.JST),
         HttpStatus.PRECONDITION_FAILED.value(),
         HttpStatus.PRECONDITION_FAILED.getReasonPhrase(),
         ErrorCode.E_PRECONDITION_FAILED,
@@ -70,7 +68,7 @@ public class TaskExceptionHandler {
   public ErrorResponse handleMissingHeader(
       MissingRequestHeaderException ex, HttpServletRequest request) {
     return new ErrorResponse(
-        OffsetDateTime.now(JST),
+        OffsetDateTime.now(AppZones.JST),
         HttpStatus.BAD_REQUEST.value(),
         HttpStatus.BAD_REQUEST.getReasonPhrase(),
         ErrorCode.E_VALIDATION,
@@ -82,7 +80,7 @@ public class TaskExceptionHandler {
   @ResponseStatus(HttpStatus.CONFLICT)
   public ErrorResponse handleConflict(DomainException ex, HttpServletRequest request) {
     return new ErrorResponse(
-        OffsetDateTime.now(JST),
+        OffsetDateTime.now(AppZones.JST),
         HttpStatus.CONFLICT.value(),
         HttpStatus.CONFLICT.getReasonPhrase(),
         ErrorCode.E_CONFLICT,
@@ -95,7 +93,7 @@ public class TaskExceptionHandler {
   public ErrorResponse handleInvalidIfMatchFormat(
       InvalidIfMatchFormatException ex, HttpServletRequest request) {
     return new ErrorResponse(
-        OffsetDateTime.now(JST),
+        OffsetDateTime.now(AppZones.JST),
         HttpStatus.BAD_REQUEST.value(),
         HttpStatus.BAD_REQUEST.getReasonPhrase(),
         ErrorCode.E_VALIDATION,

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/adapter/web/dto/StakeholderResponse.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/adapter/web/dto/StakeholderResponse.java
@@ -1,13 +1,11 @@
 package xyz.dgz48.tasks.webapi.task.adapter.web.dto;
 
 import java.time.OffsetDateTime;
-import java.time.ZoneId;
+import xyz.dgz48.tasks.webapi.shared.infra.AppZones;
 import xyz.dgz48.tasks.webapi.task.domain.TaskStakeholder;
 
 public record StakeholderResponse(
     Long userId, String fullName, String email, UserSummary addedBy, OffsetDateTime addedAt) {
-
-  private static final ZoneId JST = ZoneId.of("Asia/Tokyo");
 
   public record UserSummary(Long id, String fullName) {}
 
@@ -17,6 +15,6 @@ public record StakeholderResponse(
         s.getFullName(),
         s.getEmail(),
         new UserSummary(s.getAddedById(), s.getAddedByFullName()),
-        s.getAddedAt().atZone(JST).toOffsetDateTime());
+        s.getAddedAt().atZone(AppZones.JST).toOffsetDateTime());
   }
 }

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/adapter/web/dto/TaskListItemResponse.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/adapter/web/dto/TaskListItemResponse.java
@@ -2,9 +2,9 @@ package xyz.dgz48.tasks.webapi.task.adapter.web.dto;
 
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
-import java.time.ZoneId;
 import java.util.Map;
 import org.jspecify.annotations.Nullable;
+import xyz.dgz48.tasks.webapi.shared.infra.AppZones;
 import xyz.dgz48.tasks.webapi.task.domain.Priority;
 import xyz.dgz48.tasks.webapi.task.domain.Task;
 import xyz.dgz48.tasks.webapi.task.domain.TaskStatus;
@@ -28,8 +28,6 @@ public record TaskListItemResponse(
     OffsetDateTime updatedAt,
     boolean editable,
     boolean deletable) {
-
-  private static final ZoneId JST = ZoneId.of("Asia/Tokyo");
 
   public static TaskListItemResponse from(
       Task task, Long currentUserId, Map<Long, UserJpaEntity> userMap) {
@@ -61,9 +59,11 @@ public record TaskListItemResponse(
         owner,
         assignee,
         task.getDueDate(),
-        task.getCompletedAt() != null ? task.getCompletedAt().atZone(JST).toOffsetDateTime() : null,
-        task.getCreatedAt().atZone(JST).toOffsetDateTime(),
-        task.getUpdatedAt().atZone(JST).toOffsetDateTime(),
+        task.getCompletedAt() != null
+            ? task.getCompletedAt().atZone(AppZones.JST).toOffsetDateTime()
+            : null,
+        task.getCreatedAt().atZone(AppZones.JST).toOffsetDateTime(),
+        task.getUpdatedAt().atZone(AppZones.JST).toOffsetDateTime(),
         isOwner,
         isOwner);
   }

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/adapter/web/dto/TaskResponse.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/adapter/web/dto/TaskResponse.java
@@ -2,8 +2,8 @@ package xyz.dgz48.tasks.webapi.task.adapter.web.dto;
 
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
-import java.time.ZoneId;
 import org.jspecify.annotations.Nullable;
+import xyz.dgz48.tasks.webapi.shared.infra.AppZones;
 import xyz.dgz48.tasks.webapi.task.domain.Priority;
 import xyz.dgz48.tasks.webapi.task.domain.Task;
 import xyz.dgz48.tasks.webapi.task.domain.TaskStatus;
@@ -24,8 +24,6 @@ public record TaskResponse(
     OffsetDateTime updatedAt,
     Long version) {
 
-  private static final ZoneId JST = ZoneId.of("Asia/Tokyo");
-
   public static TaskResponse from(Task task) {
     return new TaskResponse(
         task.getId(),
@@ -37,9 +35,11 @@ public record TaskResponse(
         task.getVisibility(),
         task.getAssigneeId(),
         task.getDueDate(),
-        task.getCompletedAt() != null ? task.getCompletedAt().atZone(JST).toOffsetDateTime() : null,
-        task.getCreatedAt().atZone(JST).toOffsetDateTime(),
-        task.getUpdatedAt().atZone(JST).toOffsetDateTime(),
+        task.getCompletedAt() != null
+            ? task.getCompletedAt().atZone(AppZones.JST).toOffsetDateTime()
+            : null,
+        task.getCreatedAt().atZone(AppZones.JST).toOffsetDateTime(),
+        task.getUpdatedAt().atZone(AppZones.JST).toOffsetDateTime(),
         task.getVersion());
   }
 }

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/adapter/web/SelectTenantExceptionHandler.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/adapter/web/SelectTenantExceptionHandler.java
@@ -2,12 +2,12 @@ package xyz.dgz48.tasks.webapi.tenant.adapter.web;
 
 import jakarta.servlet.http.HttpServletRequest;
 import java.time.OffsetDateTime;
-import java.time.ZoneId;
 import java.util.Objects;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import xyz.dgz48.tasks.webapi.shared.infra.AppZones;
 import xyz.dgz48.tasks.webapi.shared.web.ErrorCode;
 import xyz.dgz48.tasks.webapi.shared.web.ErrorResponse;
 import xyz.dgz48.tasks.webapi.tenant.domain.TenantNotMemberException;
@@ -15,13 +15,11 @@ import xyz.dgz48.tasks.webapi.tenant.domain.TenantNotMemberException;
 @RestControllerAdvice(assignableTypes = SelectTenantController.class)
 public class SelectTenantExceptionHandler {
 
-  private static final ZoneId JST = ZoneId.of("Asia/Tokyo");
-
   @ExceptionHandler(TenantNotMemberException.class)
   @ResponseStatus(HttpStatus.FORBIDDEN)
   public ErrorResponse handleNotMember(TenantNotMemberException ex, HttpServletRequest request) {
     return new ErrorResponse(
-        OffsetDateTime.now(JST),
+        OffsetDateTime.now(AppZones.JST),
         HttpStatus.FORBIDDEN.value(),
         HttpStatus.FORBIDDEN.getReasonPhrase(),
         ErrorCode.E_FORBIDDEN,

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/adapter/web/TenantMemberExceptionHandler.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/adapter/web/TenantMemberExceptionHandler.java
@@ -2,13 +2,13 @@ package xyz.dgz48.tasks.webapi.tenant.adapter.web;
 
 import jakarta.servlet.http.HttpServletRequest;
 import java.time.OffsetDateTime;
-import java.time.ZoneId;
 import java.util.Objects;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import xyz.dgz48.tasks.webapi.shared.infra.AppZones;
 import xyz.dgz48.tasks.webapi.shared.web.ErrorCode;
 import xyz.dgz48.tasks.webapi.shared.web.ErrorResponse;
 import xyz.dgz48.tasks.webapi.tenant.domain.TenantCrossBoundaryException;
@@ -18,8 +18,6 @@ import xyz.dgz48.tasks.webapi.tenant.domain.UserTenantSelfOperationException;
 
 @RestControllerAdvice(assignableTypes = TenantMemberController.class)
 public class TenantMemberExceptionHandler {
-
-  private static final ZoneId JST = ZoneId.of("Asia/Tokyo");
 
   @ExceptionHandler(UserTenantNotFoundException.class)
   @ResponseStatus(HttpStatus.NOT_FOUND)
@@ -62,7 +60,7 @@ public class TenantMemberExceptionHandler {
   private static ErrorResponse error(
       HttpStatus status, ErrorCode code, String message, HttpServletRequest request) {
     return new ErrorResponse(
-        OffsetDateTime.now(JST),
+        OffsetDateTime.now(AppZones.JST),
         status.value(),
         status.getReasonPhrase(),
         code,

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/adapter/web/StakeholderIT.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/adapter/web/StakeholderIT.java
@@ -28,6 +28,7 @@ import xyz.dgz48.tasks.webapi.MockJwtDecoderConfiguration;
 import xyz.dgz48.tasks.webapi.TestcontainersConfiguration;
 import xyz.dgz48.tasks.webapi.security.adapter.web.TasksAuthenticationToken;
 import xyz.dgz48.tasks.webapi.security.domain.TasksPrincipal;
+import xyz.dgz48.tasks.webapi.shared.infra.AppZones;
 import xyz.dgz48.tasks.webapi.task.adapter.persistence.TaskJpaEntity;
 import xyz.dgz48.tasks.webapi.task.domain.Priority;
 import xyz.dgz48.tasks.webapi.task.domain.TaskStatus;
@@ -147,8 +148,8 @@ class StakeholderIT {
               .setParameter(7, "STAKEHOLDERS")
               .setParameter(8, LocalDate.of(2026, 12, 31))
               .setParameter(9, 0L)
-              .setParameter(10, LocalDateTime.now())
-              .setParameter(11, LocalDateTime.now())
+              .setParameter(10, LocalDateTime.now(AppZones.JST))
+              .setParameter(11, LocalDateTime.now(AppZones.JST))
               .setParameter(12, ownerId)
               .setParameter(13, ownerId)
               .executeUpdate();
@@ -170,8 +171,8 @@ class StakeholderIT {
               .setParameter(7, "PRIVATE")
               .setParameter(8, LocalDate.of(2026, 12, 31))
               .setParameter(9, 0L)
-              .setParameter(10, LocalDateTime.now())
-              .setParameter(11, LocalDateTime.now())
+              .setParameter(10, LocalDateTime.now(AppZones.JST))
+              .setParameter(11, LocalDateTime.now(AppZones.JST))
               .setParameter(12, ownerId)
               .setParameter(13, ownerId)
               .executeUpdate();
@@ -462,7 +463,7 @@ class StakeholderIT {
               .setParameter(2, userId)
               .setParameter(3, tenantId)
               .setParameter(4, addedBy)
-              .setParameter(5, LocalDateTime.now())
+              .setParameter(5, LocalDateTime.now(AppZones.JST))
               .executeUpdate();
           return null;
         });

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/usecase/AddStakeholderUseCaseTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/usecase/AddStakeholderUseCaseTest.java
@@ -12,7 +12,6 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
@@ -22,6 +21,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import xyz.dgz48.tasks.webapi.audit.domain.AuditEventType;
 import xyz.dgz48.tasks.webapi.audit.usecase.AuditLogPort;
+import xyz.dgz48.tasks.webapi.shared.infra.AppZones;
 import xyz.dgz48.tasks.webapi.task.domain.Priority;
 import xyz.dgz48.tasks.webapi.task.domain.StakeholderAlreadyExistsException;
 import xyz.dgz48.tasks.webapi.task.domain.Task;
@@ -45,7 +45,6 @@ class AddStakeholderUseCaseTest {
   private static final Long OTHER_TENANT_USER_ID = 30L;
   private static final Long NEW_STAKEHOLDER_ID = 50L;
 
-  private static final ZoneId JST = ZoneId.of("Asia/Tokyo");
   private static final Instant FIXED_INSTANT = Instant.parse("2026-06-01T01:00:00Z");
 
   @Mock TaskRepository taskRepository;
@@ -82,11 +81,11 @@ class AddStakeholderUseCaseTest {
         "new-stakeholder@example.com",
         OWNER_ID,
         "所有者 太郎",
-        LocalDateTime.now());
+        LocalDateTime.now(AppZones.JST));
   }
 
   private void setupClock() {
-    when(clock.getZone()).thenReturn(JST);
+    when(clock.getZone()).thenReturn(AppZones.JST);
     when(clock.instant()).thenReturn(FIXED_INSTANT);
   }
 

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/usecase/ChangeTaskStatusUseCaseTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/usecase/ChangeTaskStatusUseCaseTest.java
@@ -9,7 +9,6 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
@@ -18,6 +17,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import xyz.dgz48.tasks.webapi.shared.exception.PreconditionFailedException;
+import xyz.dgz48.tasks.webapi.shared.infra.AppZones;
 import xyz.dgz48.tasks.webapi.task.domain.Priority;
 import xyz.dgz48.tasks.webapi.task.domain.Task;
 import xyz.dgz48.tasks.webapi.task.domain.TaskAuthorizationDomainService;
@@ -36,9 +36,9 @@ class ChangeTaskStatusUseCaseTest {
   private static final Long ASSIGNEE_ID = 20L;
   private static final Long OTHER_USER_ID = 30L;
 
-  private static final ZoneId JST = ZoneId.of("Asia/Tokyo");
   private static final Instant FIXED_INSTANT = Instant.parse("2026-06-01T01:00:00Z");
-  private static final LocalDateTime FIXED_LDT = LocalDateTime.ofInstant(FIXED_INSTANT, JST);
+  private static final LocalDateTime FIXED_LDT =
+      LocalDateTime.ofInstant(FIXED_INSTANT, AppZones.JST);
 
   @Mock TaskRepository taskRepository;
   @Mock StakeholderRepository stakeholderRepository;
@@ -68,7 +68,7 @@ class ChangeTaskStatusUseCaseTest {
   }
 
   private void setupClock() {
-    when(clock.getZone()).thenReturn(JST);
+    when(clock.getZone()).thenReturn(AppZones.JST);
     when(clock.instant()).thenReturn(FIXED_INSTANT);
   }
 

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/usecase/CreateTaskUseCaseTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/usecase/CreateTaskUseCaseTest.java
@@ -13,7 +13,6 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
@@ -23,6 +22,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import xyz.dgz48.tasks.webapi.audit.domain.AuditEventType;
 import xyz.dgz48.tasks.webapi.audit.usecase.AuditLogPort;
+import xyz.dgz48.tasks.webapi.shared.infra.AppZones;
 import xyz.dgz48.tasks.webapi.task.domain.Priority;
 import xyz.dgz48.tasks.webapi.task.domain.Task;
 import xyz.dgz48.tasks.webapi.task.domain.TaskOwnershipException;
@@ -38,9 +38,9 @@ class CreateTaskUseCaseTest {
   private static final Long OWNER_ID = 10L;
   private static final Long STAKEHOLDER_ID = 20L;
 
-  private static final ZoneId JST = ZoneId.of("Asia/Tokyo");
   private static final Instant FIXED_INSTANT = Instant.parse("2026-06-01T01:00:00Z");
-  private static final LocalDateTime FIXED_LDT = LocalDateTime.ofInstant(FIXED_INSTANT, JST);
+  private static final LocalDateTime FIXED_LDT =
+      LocalDateTime.ofInstant(FIXED_INSTANT, AppZones.JST);
 
   @Mock TaskRepository taskRepository;
   @Mock StakeholderRepository stakeholderRepository;
@@ -107,7 +107,7 @@ class CreateTaskUseCaseTest {
         .thenReturn(created);
     when(tenantMembershipPort.findActiveRole(STAKEHOLDER_ID, TENANT_ID))
         .thenReturn(Optional.of(TenantRole.MEMBER));
-    when(clock.getZone()).thenReturn(JST);
+    when(clock.getZone()).thenReturn(AppZones.JST);
     when(clock.instant()).thenReturn(FIXED_INSTANT);
 
     useCase.execute(
@@ -157,7 +157,7 @@ class CreateTaskUseCaseTest {
         .thenReturn(created);
     when(tenantMembershipPort.findActiveRole(STAKEHOLDER_ID, TENANT_ID))
         .thenReturn(Optional.of(TenantRole.MEMBER));
-    when(clock.getZone()).thenReturn(JST);
+    when(clock.getZone()).thenReturn(AppZones.JST);
     when(clock.instant()).thenReturn(FIXED_INSTANT);
 
     useCase.execute(

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/usecase/ListTasksUseCaseTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/usecase/ListTasksUseCaseTest.java
@@ -9,7 +9,6 @@ import static org.mockito.Mockito.when;
 import java.time.Clock;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -22,6 +21,7 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import xyz.dgz48.tasks.webapi.shared.infra.AppZones;
 import xyz.dgz48.tasks.webapi.task.domain.Priority;
 import xyz.dgz48.tasks.webapi.task.domain.Task;
 import xyz.dgz48.tasks.webapi.task.domain.TaskStatus;
@@ -60,7 +60,7 @@ class ListTasksUseCaseTest {
   }
 
   private void setupClock() {
-    when(clock.getZone()).thenReturn(ZoneId.of("Asia/Tokyo"));
+    when(clock.getZone()).thenReturn(AppZones.JST);
     when(clock.instant()).thenReturn(TODAY.atStartOfDay().toInstant(ZoneOffset.of("+09:00")));
   }
 


### PR DESCRIPTION
## 概要
`ZoneId.of("Asia/Tokyo")` の重複を `shared.infra.AppZones.JST`(OPEN モジュール)に集約。#512 を拡張し test だけでなく main も一括解消。

## 変更
- 新設: `AppZones`(`public static final ZoneId JST`)
- main 11 ファイル + `ClockConfig` のローカル `JST` / inline を `AppZones.JST` 参照に
- test: `StakeholderIT` の `now()`×5 / `AddStakeholderUseCaseTest`×1 を `now(AppZones.JST)` 化、各 test の `JST` も集約

## 受入基準(#512)
- [ ] `:webapi:compileTestJava` で JavaTimeDefaultTimeZone 警告ゼロ
- [ ] 全テスト green

## 対象外
- `TestcontainersConfiguration` の `--default-time-zone=Asia/Tokyo`(DB コンテナ引数)
- `SecurityConfigTest` の `Instant.now()`(TZ 非依存)

Closes #512