### PR TITLE
refactor(webapi): native query 原則禁止の規約明文化 + 既存 native の JPQL/派生化(#524)

### DIFF
--- a/docs/specs/コーディング規約.md
+++ b/docs/specs/コーディング規約.md
@@ -2,7 +2,7 @@
 
 タスク管理システム(tasks-webapi)
 
-Version 1.9
+Version 2.0
 
 2026-06-10
 
@@ -23,6 +23,7 @@ Version 1.9
 | 1.7 | 2026-06-05 | §18 レビューチェックリストに IAM ポリシーの resource スコープ確認項目を追加(Issue #399 事後改善) | 開発チーム |
 | 1.8 | 2026-06-08 | Issue #451 / [ADR-0019](../adr/0019-structured-logging-boot-standard.md): §7 全面改訂。PII を出力禁止に格上げ(非意図的漏洩経路 4 点を含む)、MDC 項目の出力条件明確化、fluent `addKeyValue` 作法追加、[ログ設計](./ログ設計.md) への参照追加 | 開発チーム |
 | 1.9 | 2026-06-10 | Issue #493 / ADR-0018 / ADR-0021 / #490: §20.4 build.gradle 設定を確定済み内容に置換(「追加予定」表記解消)。§20.5 CI 段階表を PR 検証=`nativeCompile` / tag 駆動=`bootBuildImage` の確定構成に改訂、Dockerfile 記述削除。§20.6 task 名を `:webapi:nativeCompile` / workflow `Native Build` に修正。§16.1 依存追加時の Native 対応確認手順を新設。§18 レビューチェックリストに Native 観点追加。§19・§20 に ADR-0018 / ADR-0021 参照追加 | 開発チーム |
+| 2.0 | 2026-06-10 | Issue #524: §8.1 に native query 原則禁止・2 例外カテゴリ・クエリ射影既定方針を追記 | 開発チーム |
 
 ## 目次
 
@@ -443,6 +444,8 @@ public record TaskCreateRequest(
   - 派生クエリ: `deleteByTenantIdAndId(Long tenantId, Long id)` 等。
   - JPQL: `@Modifying @Query("UPDATE ... WHERE tenant_id = :tenantId AND id = :id ...")`。
   - native query: `WHERE tenant_id = :tenantId AND ...` を SQL に明示。
+- **native query は原則禁止**(設計規約 §3.3)。JPQL / 派生クエリで表現できるクエリに native を使わない。native を許容するのは (1) モジュール境界を越えて他モジュールのテーブルを参照する集計、(2) DB 固有関数・JPQL の表現力を超える複雑クエリ ―― に限り、`// native 理由: …` をコードに必ず付与する。
+- **クエリ射影の既定方針**: 既定はエンティティ取得 + adapter でのマッピング。専用射影(scalar / DTO)は (a) エンティティが持たない他テーブル列が必要、(b) 高頻度・横長テーブルで over-fetch が実測で効く、のいずれかに限る。同一テーブルの列 subset 違いでメソッドを増やさない。
 
 ---
 

--- a/docs/specs/設計規約.md
+++ b/docs/specs/設計規約.md
@@ -2,9 +2,9 @@
 
 タスク管理システム(tasks-webapi)
 
-Version 1.8
+Version 1.9
 
-2026-06-08
+2026-06-10
 
 作成者: 開発チーム
 
@@ -22,6 +22,7 @@ Version 1.8
 | 1.6 | 2026-06-05 | Issue #315 / [ADR-0010](../adr/0010-tenant-isolation-hibernate-filter.md): §3.3.1「Hibernate Filter 除外テーブル」追加、付与基準の明文化 | 開発チーム |
 | 1.7 | 2026-06-06 | Issue #309 / [ADR-0016](../adr/0016-initial-tenant-selection-policy.md): §3.3 に `X-Tenant-Id` ヘッダ未指定時の初期テナント自動解決フロー(`UserTenantsResolverService`)を追記 | 開発チーム |
 | 1.8 | 2026-06-08 | Issue #451 / [ADR-0019](../adr/0019-structured-logging-boot-standard.md): §4.2 改訂。Spring Boot 標準構造化ログ採用の反映、MDC 項目の出力条件明確化、PII 出力禁止への格上げ、[ログ設計](./ログ設計.md) への参照追加 | 開発チーム |
+| 1.9 | 2026-06-10 | Issue #524: §3.3 に native query 原則禁止・2 例外カテゴリ・クエリ射影既定方針を追記 | 開発チーム |
 
 ## 目次
 
@@ -319,6 +320,11 @@ dev 環境への tasks-webapi 初回デプロイ前(Flyway 履歴テーブル `f
   - Repository を経由せず `EntityManager#find` → 取得した管理エンティティを変更し flush に任せる(この場合は Filter が効いた select 経路を必ず通る)
 - **「テナント無視で全件検索」する Repository メソッドを書かない**。バッチや管理者用途で必要になったら、明示的に `@FilterDef` を一時無効化するヘルパー経由でのみ実施し、レビュー必須。
 - `X-Tenant-Id` ヘッダ未指定かつ認証済みリクエスト(免除パス `/api/auth/**`, `/api/tenants/**`, `/actuator/**` を除く)は `UserTenantsResolverService` が `joined_at ASC` で最初の ACTIVE メンバーシップを自動選択して `TenantContext` を設定する。0 件の場合は 403 を返す([ADR-0016](../adr/0016-initial-tenant-selection-policy.md))。
+- **native query は原則禁止。** JPQL / 派生クエリで表現できるクエリに native を使わない。native を許容するのは次の 2 カテゴリに限り、`// native 理由: …` をコードに必ず併記する:
+  1. **Spring Modulith のモジュール境界を越えて他モジュールのテーブルを参照する集計**
+  2. **DB 固有関数・JPQL の表現力を超える複雑クエリ**
+- **native / bulk DML（`@Modifying`）は Hibernate Filter が効かない**ため、tenant スコープのテーブルに対するこれらのクエリは `tenant_id` を明示絞り込みし、`// tenant_id 明示: bulk DML は Filter 不適用(ADR-0010 §3)` を併記する。
+- **クエリ射影の既定方針**: 既定はエンティティ取得 + adapter でのマッピング。専用射影(scalar / DTO)は (a) エンティティが持たない他テーブル列が必要、(b) 高頻度・横長テーブルで over-fetch が実測で効く、のいずれかに限る。同一テーブルの列 subset 違いでメソッドを増やさない。
 
 #### 3.3.x TenantFilterBypassService — Filter 一時無効化のガイドライン
 

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/adapter/persistence/TaskStakeholderJpaRepository.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/adapter/persistence/TaskStakeholderJpaRepository.java
@@ -9,7 +9,7 @@ import org.springframework.data.repository.query.Param;
 interface TaskStakeholderJpaRepository
     extends JpaRepository<TaskStakeholderJpaEntity, TaskStakeholderJpaEntityId> {
 
-  /** ユーザー情報を JOIN した関係者一覧。テナントフィルタは native なので明示指定。 */
+  // native 理由: モジュール境界越え（users テーブル JOIN — task モジュールから users 列を取得）
   @Query(
       value =
           """
@@ -29,29 +29,23 @@ interface TaskStakeholderJpaRepository
   List<StakeholderProjection> findWithUserInfoByTaskIdAndTenantId(
       @Param("taskId") Long taskId, @Param("tenantId") Long tenantId);
 
-  @Query(
-      value =
-          "SELECT ts.user_id FROM task_stakeholders ts"
-              + " WHERE ts.task_id = :taskId AND ts.tenant_id = :tenantId",
-      nativeQuery = true)
-  List<Long> findUserIdsByTaskIdAndTenantId(
-      @Param("taskId") Long taskId, @Param("tenantId") Long tenantId);
+  List<TaskStakeholderJpaEntity> findByTaskId(Long taskId);
 
   @Override
   boolean existsById(TaskStakeholderJpaEntityId id);
 
+  // tenant_id 明示: bulk DML は Filter 不適用(ADR-0010 §3)
   @Modifying
   @Query(
-      value =
-          "DELETE FROM task_stakeholders"
-              + " WHERE task_id = :taskId AND user_id = :userId AND tenant_id = :tenantId",
-      nativeQuery = true)
+      "DELETE FROM TaskStakeholderJpaEntity ts"
+          + " WHERE ts.taskId = :taskId AND ts.userId = :userId AND ts.tenantId = :tenantId")
   void deleteByTaskIdAndUserId(
       @Param("taskId") Long taskId, @Param("userId") Long userId, @Param("tenantId") Long tenantId);
 
+  // tenant_id 明示: bulk DML は Filter 不適用(ADR-0010 §3)
   @Modifying
   @Query(
-      value = "DELETE FROM task_stakeholders WHERE task_id = :taskId AND tenant_id = :tenantId",
-      nativeQuery = true)
+      "DELETE FROM TaskStakeholderJpaEntity ts"
+          + " WHERE ts.taskId = :taskId AND ts.tenantId = :tenantId")
   int deleteAllByTaskIdAndTenantId(@Param("taskId") Long taskId, @Param("tenantId") Long tenantId);
 }

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/adapter/persistence/TaskStakeholderJpaRepositoryAdapter.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/adapter/persistence/TaskStakeholderJpaRepositoryAdapter.java
@@ -22,7 +22,9 @@ class TaskStakeholderJpaRepositoryAdapter implements StakeholderRepository {
 
   @Override
   public List<Long> findUserIdsByTaskId(Long taskId, Long tenantId) {
-    return jpaRepository.findUserIdsByTaskIdAndTenantId(taskId, tenantId);
+    return jpaRepository.findByTaskId(taskId).stream()
+        .map(TaskStakeholderJpaEntity::getUserId)
+        .toList();
   }
 
   @Override

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/adapter/persistence/TenantJpaRepository.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/adapter/persistence/TenantJpaRepository.java
@@ -30,6 +30,7 @@ interface TenantJpaRepository extends JpaRepository<TenantJpaEntity, Long> {
       """)
   long countUsersByTenantId(@Param("tenantId") Long tenantId);
 
+  // native 理由: モジュール境界越え（他モジュールのテーブル参照）
   @Query(
       value =
           """
@@ -40,32 +41,21 @@ interface TenantJpaRepository extends JpaRepository<TenantJpaEntity, Long> {
   long countTasksByTenantId(@Param("tenantId") Long tenantId);
 
   @Query(
-      value =
-          """
-          SELECT COUNT(*) FROM tenants
-          WHERE status != 'DELETED'
-          """,
-      nativeQuery = true)
+      "SELECT COUNT(t) FROM TenantJpaEntity t"
+          + " WHERE t.status <> xyz.dgz48.tasks.webapi.tenant.domain.TenantStatus.DELETED")
   long countNonDeletedTenants();
 
   @Query(
-      value =
-          """
-          SELECT COUNT(*) FROM tenants
-          WHERE status = 'ACTIVE'
-          """,
-      nativeQuery = true)
+      "SELECT COUNT(t) FROM TenantJpaEntity t"
+          + " WHERE t.status = xyz.dgz48.tasks.webapi.tenant.domain.TenantStatus.ACTIVE")
   long countActiveTenants();
 
   @Query(
-      value =
-          """
-          SELECT COUNT(*) FROM tenants
-          WHERE status = 'SUSPENDED'
-          """,
-      nativeQuery = true)
+      "SELECT COUNT(t) FROM TenantJpaEntity t"
+          + " WHERE t.status = xyz.dgz48.tasks.webapi.tenant.domain.TenantStatus.SUSPENDED")
   long countSuspendedTenants();
 
+  // native 理由: モジュール境界越え（他モジュールのテーブル参照）
   @Query(
       value =
           """
@@ -75,6 +65,7 @@ interface TenantJpaRepository extends JpaRepository<TenantJpaEntity, Long> {
       nativeQuery = true)
   long countTotalUsers();
 
+  // native 理由: モジュール境界越え（他モジュールのテーブル参照）
   @Query(
       value =
           """
@@ -85,12 +76,9 @@ interface TenantJpaRepository extends JpaRepository<TenantJpaEntity, Long> {
   long countTotalTasks();
 
   @Query(
-      value =
-          """
-          SELECT COUNT(*) FROM tenants
-          WHERE created_at >= :since AND status != 'DELETED'
-          """,
-      nativeQuery = true)
+      "SELECT COUNT(t) FROM TenantJpaEntity t"
+          + " WHERE t.createdAt >= :since"
+          + " AND t.status <> xyz.dgz48.tasks.webapi.tenant.domain.TenantStatus.DELETED")
   long countTenantsCreatedSince(@Param("since") LocalDateTime since);
 
   @Query(
@@ -101,6 +89,7 @@ interface TenantJpaRepository extends JpaRepository<TenantJpaEntity, Long> {
       """)
   List<Object[]> countUsersByTenantIds(@Param("tenantIds") List<Long> tenantIds);
 
+  // native 理由: モジュール境界越え（他モジュールのテーブル参照）
   @Query(
       value =
           """


### PR DESCRIPTION
## Summary

- 設計規約 §3.3 / コーディング規約 §8.1 に **native query 原則禁止・2 例外カテゴリ・クエリ射影既定方針** を追記（設計規約 v1.8 → v1.9 / コーディング規約 v1.9 → v2.0）
- 廃止対象 7 本を派生/JPQL へ変換し、手書き `tenant_id` を Filter に委譲または bulk DML の明示絞り込みへ整理
- 据置 5 本（モジュール境界越え native）に `// native 理由:` コメントを付与

Closes #524

## 変更内訳

### `TaskStakeholderJpaRepository`
| 変更 | Before | After |
|---|---|---|
| `findUserIdsByTaskIdAndTenantId` | native SQL | **削除** → `findByTaskId` 派生クエリ（Filter 自動適用） |
| `deleteByTaskIdAndUserId` | native SQL | JPQL bulk DELETE（`tenant_id` 明示維持） |
| `deleteAllByTaskIdAndTenantId` | native SQL | JPQL bulk DELETE（同上） |
| `findWithUserInfoByTaskIdAndTenantId` | native（据置） | `// native 理由:` コメント付与 |

### `TaskStakeholderJpaRepositoryAdapter`
- `findUserIdsByTaskId` を `jpaRepository.findByTaskId(taskId).stream().map(::getUserId).toList()` へ変更
- Port 署名（`tenantId` 引数）は維持。Hibernate Filter が `tenant_id` を自動付与するため引数は使用しない

### `TenantJpaRepository`
| 変更 | Before | After |
|---|---|---|
| `countNonDeletedTenants` | native SQL | JPQL（`t.status <> TenantStatus.DELETED`） |
| `countActiveTenants` | native SQL | JPQL（`t.status = TenantStatus.ACTIVE`） |
| `countSuspendedTenants` | native SQL | JPQL（`t.status = TenantStatus.SUSPENDED`） |
| `countTenantsCreatedSince` | native SQL | JPQL（`t.createdAt >= :since AND t.status <> ...DELETED`） |
| `countTotalUsers` / `countTotalTasks` / `countTasksByTenantId` / `countTasksByTenantIds` | native（据置） | `// native 理由: モジュール境界越え` コメント付与 |

## Test plan

- [x] `:webapi:check` green（6m 29s）
- [x] 既存 `TenantFilterIsolationTest` で Hibernate Filter の自動適用を回帰確認
- [x] 既存 `TaskCrossTenantIT` でクロステナント漏洩なしを回帰確認
- [x] Use-case 単体テスト（`ListStakeholdersUseCaseTest` / `DeleteTaskUseCaseTest` / `AddStakeholderUseCaseTest` 等）で `findUserIdsByTaskId` Port モックが変更なしで動作

🤖 Generated with [Claude Code](https://claude.ai/claude-code)