### PR TITLE
refactor(webapi): クエリ実装 3 段優先順位の規約化 + count 4 本を導出クエリへ(#533)

### DIFF
--- a/docs/specs/コーディング規約.md
+++ b/docs/specs/コーディング規約.md
@@ -2,9 +2,9 @@
 
 タスク管理システム(tasks-webapi)
 
-Version 2.0
+Version 2.1
 
-2026-06-10
+2026-06-11
 
 作成者: 開発チーム
 
@@ -24,6 +24,7 @@ Version 2.0
 | 1.8 | 2026-06-08 | Issue #451 / [ADR-0019](../adr/0019-structured-logging-boot-standard.md): §7 全面改訂。PII を出力禁止に格上げ(非意図的漏洩経路 4 点を含む)、MDC 項目の出力条件明確化、fluent `addKeyValue` 作法追加、[ログ設計](./ログ設計.md) への参照追加 | 開発チーム |
 | 1.9 | 2026-06-10 | Issue #493 / ADR-0018 / ADR-0021 / #490: §20.4 build.gradle 設定を確定済み内容に置換(「追加予定」表記解消)。§20.5 CI 段階表を PR 検証=`nativeCompile` / tag 駆動=`bootBuildImage` の確定構成に改訂、Dockerfile 記述削除。§20.6 task 名を `:webapi:nativeCompile` / workflow `Native Build` に修正。§16.1 依存追加時の Native 対応確認手順を新設。§18 レビューチェックリストに Native 観点追加。§19・§20 に ADR-0018 / ADR-0021 参照追加 | 開発チーム |
 | 2.0 | 2026-06-10 | Issue #524: §8.1 に native query 原則禁止・2 例外カテゴリ・クエリ射影既定方針を追記 | 開発チーム |
+| 2.1 | 2026-06-11 | Issue #533: §8.1 の native 禁止規則をクエリ実装 3 段優先順位（導出 > JPQL > native）に再編 | 開発チーム |
 
 ## 目次
 
@@ -444,7 +445,10 @@ public record TaskCreateRequest(
   - 派生クエリ: `deleteByTenantIdAndId(Long tenantId, Long id)` 等。
   - JPQL: `@Modifying @Query("UPDATE ... WHERE tenant_id = :tenantId AND id = :id ...")`。
   - native query: `WHERE tenant_id = :tenantId AND ...` を SQL に明示。
-- **native query は原則禁止**(設計規約 §3.3)。JPQL / 派生クエリで表現できるクエリに native を使わない。native を許容するのは (1) モジュール境界を越えて他モジュールのテーブルを参照する集計、(2) DB 固有関数・JPQL の表現力を超える複雑クエリ ―― に限り、`// native 理由: …` をコードに必ず付与する。
+- **クエリ実装の優先順位**(設計規約 §3.3): 次の順で選択し、上位で表現できる場合は下位を使わない:
+  1. **メソッド名導出クエリ**(`findBy...` / `countBy...` / `existsBy...` 等)— 起動時クエリ検証あり・文字列保守不要・Hibernate Filter が効く
+  2. **明示クエリ(`@Query`, JPQL)**— 導出で表現できない場合のみ(スカラ射影 / GROUP BY / 単一文 bulk DML 等)
+  3. **native query**— (1) モジュール境界を越えて他モジュールのテーブルを参照する集計、(2) DB 固有関数・JPQL の表現力を超える複雑クエリ ―― に限り、`// native 理由: …` をコードに必ず付与する
 - **クエリ射影の既定方針**: 既定はエンティティ取得 + adapter でのマッピング。専用射影(scalar / DTO)は (a) エンティティが持たない他テーブル列が必要、(b) 高頻度・横長テーブルで over-fetch が実測で効く、のいずれかに限る。同一テーブルの列 subset 違いでメソッドを増やさない。
 
 ---

--- a/docs/specs/設計規約.md
+++ b/docs/specs/設計規約.md
@@ -2,9 +2,9 @@
 
 タスク管理システム(tasks-webapi)
 
-Version 1.9
+Version 2.0
 
-2026-06-10
+2026-06-11
 
 作成者: 開発チーム
 
@@ -23,6 +23,7 @@ Version 1.9
 | 1.7 | 2026-06-06 | Issue #309 / [ADR-0016](../adr/0016-initial-tenant-selection-policy.md): §3.3 に `X-Tenant-Id` ヘッダ未指定時の初期テナント自動解決フロー(`UserTenantsResolverService`)を追記 | 開発チーム |
 | 1.8 | 2026-06-08 | Issue #451 / [ADR-0019](../adr/0019-structured-logging-boot-standard.md): §4.2 改訂。Spring Boot 標準構造化ログ採用の反映、MDC 項目の出力条件明確化、PII 出力禁止への格上げ、[ログ設計](./ログ設計.md) への参照追加 | 開発チーム |
 | 1.9 | 2026-06-10 | Issue #524: §3.3 に native query 原則禁止・2 例外カテゴリ・クエリ射影既定方針を追記 | 開発チーム |
+| 2.0 | 2026-06-11 | Issue #533: §3.3 の native 禁止規則をクエリ実装 3 段優先順位（導出 > JPQL > native）に再編、Filter 無効文脈の注意を明記 | 開発チーム |
 
 ## 目次
 
@@ -320,10 +321,12 @@ dev 環境への tasks-webapi 初回デプロイ前(Flyway 履歴テーブル `f
   - Repository を経由せず `EntityManager#find` → 取得した管理エンティティを変更し flush に任せる(この場合は Filter が効いた select 経路を必ず通る)
 - **「テナント無視で全件検索」する Repository メソッドを書かない**。バッチや管理者用途で必要になったら、明示的に `@FilterDef` を一時無効化するヘルパー経由でのみ実施し、レビュー必須。
 - `X-Tenant-Id` ヘッダ未指定かつ認証済みリクエスト(免除パス `/api/auth/**`, `/api/tenants/**`, `/actuator/**` を除く)は `UserTenantsResolverService` が `joined_at ASC` で最初の ACTIVE メンバーシップを自動選択して `TenantContext` を設定する。0 件の場合は 403 を返す([ADR-0016](../adr/0016-initial-tenant-selection-policy.md))。
-- **native query は原則禁止。** JPQL / 派生クエリで表現できるクエリに native を使わない。native を許容するのは次の 2 カテゴリに限り、`// native 理由: …` をコードに必ず併記する:
-  1. **Spring Modulith のモジュール境界を越えて他モジュールのテーブルを参照する集計**
-  2. **DB 固有関数・JPQL の表現力を超える複雑クエリ**
+- **クエリ実装の優先順位**: 次の順で選択し、上位で表現できる場合は下位を使わない:
+  1. **メソッド名導出クエリ**(`findBy...` / `countBy...` / `existsBy...` 等)— Hibernate Filter が効く・起動時クエリ検証あり・`@Query` 文字列の保守不要
+  2. **明示クエリ(`@Query`, JPQL)**— 導出で表現できない場合のみ。該当例: 単一列スカラ射影 / GROUP BY・複雑集計 / 単一文 bulk DML(`@Modifying`。派生 `deleteBy...` は select-then-delete のため bulk 等価でない)
+  3. **native query**— JPQL でも無理・著しく不自然なときのみ。許容カテゴリは (1) Spring Modulith のモジュール境界を越えて他モジュールのテーブルを参照する集計、(2) DB 固有関数・JPQL の表現力を超える複雑クエリ ―― に限り、`// native 理由: …` を必ず付与する
 - **native / bulk DML（`@Modifying`）は Hibernate Filter が効かない**ため、tenant スコープのテーブルに対するこれらのクエリは `tenant_id` を明示絞り込みし、`// tenant_id 明示: bulk DML は Filter 不適用(ADR-0010 §3)` を併記する。
+- **Hibernate Filter に依存した派生クエリを Filter 無効文脈から呼ぶとクロステナント漏洩しうる**。`TenantFilterBypassService.runAsSaaSAdmin()` は Filter を無効化するため、そのブロック内からテナントスコープの派生クエリを呼んではならない。現状 `runAsSaaSAdmin` の全呼び出し元は `tenant` feature 内に閉じておりタスク系ユースケースに触れていないが、将来 SaaS Admin 文脈でタスク系ユースケースを呼ぶ場合は注意すること。
 - **クエリ射影の既定方針**: 既定はエンティティ取得 + adapter でのマッピング。専用射影(scalar / DTO)は (a) エンティティが持たない他テーブル列が必要、(b) 高頻度・横長テーブルで over-fetch が実測で効く、のいずれかに限る。同一テーブルの列 subset 違いでメソッドを増やさない。
 
 #### 3.3.x TenantFilterBypassService — Filter 一時無効化のガイドライン

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/adapter/persistence/PlatformMetricsPersistenceAdapter.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/adapter/persistence/PlatformMetricsPersistenceAdapter.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 import xyz.dgz48.tasks.webapi.shared.infra.AppZones;
 import xyz.dgz48.tasks.webapi.tenant.domain.PlatformMetrics;
+import xyz.dgz48.tasks.webapi.tenant.domain.TenantStatus;
 import xyz.dgz48.tasks.webapi.tenant.usecase.PlatformMetricsPort;
 
 /** {@link PlatformMetricsPort} の JPA 実装。 */
@@ -20,13 +21,15 @@ class PlatformMetricsPersistenceAdapter implements PlatformMetricsPort {
   @Override
   @Transactional(readOnly = true)
   public PlatformMetrics getMetrics() {
-    long totalTenants = tenantJpaRepository.countNonDeletedTenants();
-    long activeTenants = tenantJpaRepository.countActiveTenants();
-    long suspendedTenants = tenantJpaRepository.countSuspendedTenants();
+    long totalTenants = tenantJpaRepository.countByStatusNot(TenantStatus.DELETED);
+    long activeTenants = tenantJpaRepository.countByStatus(TenantStatus.ACTIVE);
+    long suspendedTenants = tenantJpaRepository.countByStatus(TenantStatus.SUSPENDED);
     long totalUsers = tenantJpaRepository.countTotalUsers();
     long totalTasks = tenantJpaRepository.countTotalTasks();
     LocalDateTime since = LocalDateTime.now(clock.withZone(AppZones.JST)).minusHours(24);
-    long newTenantsLast24h = tenantJpaRepository.countTenantsCreatedSince(since);
+    long newTenantsLast24h =
+        tenantJpaRepository.countByCreatedAtGreaterThanEqualAndStatusNot(
+            since, TenantStatus.DELETED);
     return new PlatformMetrics(
         totalTenants, activeTenants, suspendedTenants, totalUsers, totalTasks, newTenantsLast24h);
   }

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/adapter/persistence/TenantJpaRepository.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/adapter/persistence/TenantJpaRepository.java
@@ -40,20 +40,9 @@ interface TenantJpaRepository extends JpaRepository<TenantJpaEntity, Long> {
       nativeQuery = true)
   long countTasksByTenantId(@Param("tenantId") Long tenantId);
 
-  @Query(
-      "SELECT COUNT(t) FROM TenantJpaEntity t"
-          + " WHERE t.status <> xyz.dgz48.tasks.webapi.tenant.domain.TenantStatus.DELETED")
-  long countNonDeletedTenants();
+  long countByStatus(TenantStatus status);
 
-  @Query(
-      "SELECT COUNT(t) FROM TenantJpaEntity t"
-          + " WHERE t.status = xyz.dgz48.tasks.webapi.tenant.domain.TenantStatus.ACTIVE")
-  long countActiveTenants();
-
-  @Query(
-      "SELECT COUNT(t) FROM TenantJpaEntity t"
-          + " WHERE t.status = xyz.dgz48.tasks.webapi.tenant.domain.TenantStatus.SUSPENDED")
-  long countSuspendedTenants();
+  long countByStatusNot(TenantStatus status);
 
   // native 理由: モジュール境界越え（他モジュールのテーブル参照）
   @Query(
@@ -75,11 +64,7 @@ interface TenantJpaRepository extends JpaRepository<TenantJpaEntity, Long> {
       nativeQuery = true)
   long countTotalTasks();
 
-  @Query(
-      "SELECT COUNT(t) FROM TenantJpaEntity t"
-          + " WHERE t.createdAt >= :since"
-          + " AND t.status <> xyz.dgz48.tasks.webapi.tenant.domain.TenantStatus.DELETED")
-  long countTenantsCreatedSince(@Param("since") LocalDateTime since);
+  long countByCreatedAtGreaterThanEqualAndStatusNot(LocalDateTime createdAt, TenantStatus status);
 
   @Query(
       """


### PR DESCRIPTION
## Summary

- 設計規約 §3.3 / コーディング規約 §8.1 の native 禁止規則を **クエリ実装 3 段優先順位（導出 > JPQL > native）** に再編
- `TenantJpaRepository` の count 4 本を `@Query` JPQL から **導出クエリ 3 本** に置換（起動時クエリ検証が効くぶん安全）
- `PlatformMetricsPersistenceAdapter` 呼び出し側を新シグネチャに更新
- Hibernate Filter 無効文脈（`runAsSaaSAdmin` 内等）でテナントスコープ派生クエリを呼ぶ危険性を設計規約に明記

Closes #533

## 変更内訳

### `TenantJpaRepository`

| 旧（`@Query` JPQL 4 本） | 新（導出クエリ 3 本） |
|---|---|
| `countNonDeletedTenants()` | `countByStatusNot(TenantStatus status)` |
| `countActiveTenants()` | `countByStatus(TenantStatus status)` |
| `countSuspendedTenants()` | ↑ 同メソッドを SUSPENDED で呼び出し |
| `countTenantsCreatedSince(LocalDateTime since)` | `countByCreatedAtGreaterThanEqualAndStatusNot(LocalDateTime createdAt, TenantStatus status)` |

`TenantJpaEntity` は `TenantFilteredEntity` 非継承（`tenants` テーブルは管理テーブルで `tenant_id` 列なし）のため Filter 影響なし。純粋に「最も単純な表現」への置換。

### docs

- 設計規約 v1.9 → v2.0: §3.3 の native 禁止規則を 3 段優先順位に再編、Filter 無効文脈の注意を追記
- コーディング規約 v2.0 → v2.1: §8.1 に同 3 段優先順位を追記

### 据置確認

`deleteByTaskIdAndUserId` / `deleteAllByTaskIdAndTenantId` は単一文 bulk DML であり派生 `deleteBy...` は select-then-delete で等価でないため `@Modifying @Query` JPQL のまま変更なし（#524 の判断を踏襲）。

## Test plan

- [x] `:webapi:check` green
- [x] `PlatformMetricsPersistenceAdapter` 呼び出し側の戻り値整合を確認（`long` のまま変わらず）

🤖 Generated with [Claude Code](https://claude.ai/claude-code)