### PR TITLE
docs(adr): ADR-0022 セキュリティヘッダー + ADR-0023 最小 E2E 基盤

### DIFF
--- a/docs/adr/0022-security-response-headers.md
+++ b/docs/adr/0022-security-response-headers.md
@@ -1,0 +1,189 @@
+# ADR-0022: セキュリティレスポンスヘッダー方針 — 最小許可・既定厳格の CSP とヘッダー群
+
+- **Status**: Accepted
+- **Date**: 2026-06-11
+- **Deciders**: win2cot, 開発チーム
+- **Tags**: security, frontend, api, infra, csp, headers
+
+## 目次
+
+- [1. コンテキスト(Context)](#1-コンテキストcontext)
+- [2. 検討した選択肢(Options Considered)](#2-検討した選択肢options-considered)
+- [3. 決定(Decision)](#3-決定decision)
+  - [3.1 ヘッダー分担基準(per-header 単一オーナー)](#31-ヘッダー分担基準per-header-単一オーナー)
+  - [3.2 フロント(CloudFront Response Headers Policy)](#32-フロントcloudfront-response-headers-policy)
+  - [3.3 API(Spring Security .headers())](#33-apispring-security-headers)
+  - [3.4 導入手順](#34-導入手順)
+- [4. 理由(Rationale)](#4-理由rationale)
+- [5. 影響(Consequences)](#5-影響consequences)
+- [6. 実装メモ(Implementation Notes)](#6-実装メモimplementation-notes)
+- [7. 参考リンク(References)](#7-参考リンクreferences)
+
+## 1. コンテキスト(Context)
+
+本システムのレスポンスセキュリティヘッダーは、これまで部分的・暗黙的にしか整備されていない。現状:
+
+- **ALB(`infra/shared/modules/alb/main.tf`)**: HTTPS Listener で HSTS を注入(dev 短期 / prd 1 年、`preload` なし=共有 apex `dgz48.xyz`)。TLS 1.3 ポリシー・HTTP→HTTPS 301・`drop_invalid_header_fields` 済み。
+- **API(`security/adapter/web/SecurityConfig.java`)**: `csrf.disable()` / `STATELESS` / OAuth2 リソースサーバのみ。`.headers()` 未設定で Spring デフォルト(`X-Frame-Options: DENY` / `nosniff` / `Cache-Control`)に暗黙依存。**CSP / Referrer-Policy / Permissions-Policy なし**。
+- **フロント(`web/` の静的 SPA、S3 + CloudFront 配信)**: セキュリティヘッダー皆無。`index.html` / `tasks.html` は外部 CDN(`cdn.jsdelivr.net` から Bootstrap・keycloak-js)を SRI 付きで読み、inline `<script>` 各 1・`onclick=` / `style=` 多数(`tasks.html` 21 箇所)。
+
+CSP 設計に効く実装事実: keycloak-js は `checkLoginIframe: false`(iframe 不使用→認証 origin への `frame-src` 不要)、ログインはトップレベルリダイレクト・トークン交換/discovery は `fetch`(= `connect-src`)。フロントは API origin(`api-<env>.tasks.dgz48.xyz`)と Keycloak origin(`auth-<env>.dgz48.xyz`)へ `fetch`。Bootstrap5 は `data:` URI の SVG を背景に使う(`img-src data:` 必要)。
+
+**外部資産の供給方針(2026-06-11 決定)**: 本番運用まで見据え、Bootstrap・keycloak-js は **第三者 CDN を使わず npm 取り込みで自前配信(S3/CloudFront)** する(§4)。よって CSP は `script-src 'self'` / `style-src 'self'` に絞れる。現状 `index.html` と `tasks.html` で同一 `bootstrap@5.3.3` バンドルの SRI 値が食い違う既存バグがあるが、自前配信化で SRI 自体が不要になり解消する。
+
+本 ADR は **「必要なものだけを最小限許可し、それ以外は厳格に拒否する」** 方針(win2cot 指示)を、現実装の修正を許容したうえで全レスポンス面に適用する。
+
+## 2. 検討した選択肢(Options Considered)
+
+### 選択肢 A: 現状維持(暗黙デフォルト依存)
+
+- 概要: Spring/ALB デフォルトのみ、CSP 無し。
+- 欠点: XSS 緩和の中核 CSP 不在。明文化・退行検知不能。責務分界未定義。却下。
+
+### 選択肢 B: 最小許可・既定厳格を二面で明示(採用)
+
+- 概要: `default-src 'none'` を起点に必要 source だけ allowlist した CSP を **フロント(CloudFront)** に配信、**API(Spring)** には JSON 専用の防御的最小 CSP。inline は全廃して `'unsafe-inline'` を排除。外部資産は **npm 自前配信**で `script-src/style-src 'self'`。HSTS の SSOT は TLS 終端。関連ヘッダーも明示。
+- 利点: XSS 主経路を最大限に塞ぐ。明示で退行をテスト検知。責務分界が説明可能。
+- 欠点: フロント inline 撤去 + npm 取り込み + CloudFront RHP 新設の実装コスト。
+
+### 選択肢 C: nonce ベース CSP
+
+- 概要: inline を残し per-response nonce。
+- 欠点: nonce はレスポンス毎の動的生成前提で、SSR の無い静的 S3+CloudFront と原理的に不適。却下。
+
+### CDN 継続 vs 自前配信(選択肢 B 内の論点、自前配信を採用)
+
+- CDN+SRI 継続: 実装変更は最小だが、(1) keycloak-js を第三者に依存=**auth 経路の SPOF**、(2) cache partitioning で公共 CDN の性能便益は消失済み、(3) CSP に第三者 origin が残る、(4) Renovate 標準では CDN URL を管理できず実質バージョン未管理。
+- **npm 自前配信(採用)**: `script-src 'self'` に最小化、auth 経路の第三者依存を排除、Renovate 標準 npm manager で管理(改善)。コストはビルドレスなフロントに npm + deploy 時コピー(バンドラ不要)が一段増えること。
+
+## 3. 決定(Decision)
+
+**採用**: 選択肢 B(自前配信版)。
+
+### 3.1 ヘッダー分担基準(per-header 単一オーナー)
+
+レスポンスヘッダーの出力層は次の基準で一意に定める。
+
+> **各ヘッダーは1つの層だけが出力する(単一オーナー)。オーナーは「そのヘッダーが守るべき全レスポンスに到達でき、かつアプリ正しい値を出せる最下層」とする。二重出力は禁止。**
+
+帰結:
+
+- **HSTS → その経路の TLS 終端**(API=ALB、静的=CloudFront)。HSTS は接続(transport)スコープであり、かつ **ALB 自身が生成する 404 fixed-response や HTTP→HTTPS リダイレクトにも乗る必要がある**(Spring から到達不能)。
+- **CSP / X-Frame-Options / Referrer-Policy / Permissions-Policy / X-Content-Type-Options / Cache-Control → アプリ層**(API=Spring、静的=CloudFront、auth=Keycloak)。値が**コンテンツ/アプリ固有**で、特に **ALB listener は共有**(tasks-webapi と Keycloak を同一 listener で収容、infra ADR-0006)のため listener レベルに API 用 CSP を置くと Keycloak のログイン画面を壊す。ALB は技術的にこれらを listener 属性で出せるが**出さない**。
+- 完全な single-source にできないのは、API 経路だけ **TLS 終端(ALB)≠コンテンツ origin(Spring)が別層** かつ **ALB が共有** という構造による必然。静的経路は TLS 終端=コンテンツ origin が CloudFront 単一なので分割は起きない。
+- **二重出力の排除**を必ず担保する: Spring の HSTS writer は disable(§3.3)、ALB は CSP/nosniff/X-Frame 等を出さない。
+
+### 3.2 フロント(CloudFront Response Headers Policy)
+
+CSP(`<env>` は Terraform 変数でテンプレート化、外部資産は自前配信のため `'self'`):
+
+```
+default-src 'none';
+script-src 'self';
+style-src 'self';
+img-src 'self' data:;
+font-src 'self';
+connect-src 'self' https://api-<env>.tasks.dgz48.xyz https://auth-<env>.dgz48.xyz;
+frame-ancestors 'none';
+base-uri 'self';
+form-action 'self';
+object-src 'none'
+```
+
+- `frame-src` 不要(keycloak-js `checkLoginIframe: false`)。Report-Only 期間で iframe 要求が出た場合のみ `frame-src https://auth-<env>.dgz48.xyz` 追加。
+- `'unsafe-inline'` / `'unsafe-eval'` は付けない。
+
+固定ヘッダー:
+
+| ヘッダー | 値 | 備考 |
+|---|---|---|
+| `Strict-Transport-Security` | `max-age=31536000; includeSubDomains`(dev 短期) | `preload` なし。CloudFront が静的経路の TLS 終端=オーナー |
+| `X-Content-Type-Options` | `nosniff` | |
+| `Referrer-Policy` | `no-referrer` | 緩和が要れば `strict-origin-when-cross-origin` |
+| `Permissions-Policy` | `camera=(), microphone=(), geolocation=(), payment=(), usb=(), accelerometer=(), gyroscope=(), magnetometer=()` | 未使用機能を全無効化 |
+| `X-Frame-Options` | `DENY` | `frame-ancestors 'none'` の後方互換 |
+| `Cross-Origin-Opener-Policy` | `same-origin` | Keycloak はリダイレクト方式で安全 |
+| `Cross-Origin-Resource-Policy` | `same-origin` | |
+
+> `Cross-Origin-Embedder-Policy` は付与しない(COEP は他オリジン資産の読込を壊しうるため)。
+
+### 3.3 API(Spring Security .headers())
+
+JSON 専用の防御的最小 CSP:
+
+```
+Content-Security-Policy: default-src 'none'; frame-ancestors 'none'
+```
+
+加えて明示(デフォルト依存をやめテストで固定):
+
+- `X-Content-Type-Options: nosniff`(明示)
+- `X-Frame-Options: DENY`(明示)
+- `Referrer-Policy: no-referrer`
+- `Cache-Control: no-store`
+- **HSTS writer は無効化**(`httpStrictTransportSecurity().disable()`)。HSTS の SSOT は ALB(§3.1)、`forward-headers-strategy` の有無に依らず二重送出させない。
+
+`csrf.disable()` は据置(ステートレス JWT、設計規約 §5.5)。
+
+### 3.4 導入手順
+
+最終形は enforce(`Content-Security-Policy`)。enforce 切替の前に dev/stg で短期 `Content-Security-Policy-Report-Only` を有効化し違反を観測してから切替(検証体制は §6)。
+
+## 4. 理由(Rationale)
+
+- **XSS 緩和の費用対効果が最大**: `default-src 'none'` + 最小 allowlist + inline 全廃で注入スクリプト実行を広く塞ぐ。捨てる利点(inline の手軽さ)はリファクタ一度で解消。
+- **自前配信が本番運用に堪える**: 第三者 CDN は (1) auth 経路 SPOF、(2) cache partitioning で性能便益消失、(3) CSP に第三者 origin が残る。npm 自前配信なら `script-src 'self'` に絞れ、可用性は自社インフラに閉じ、Renovate 標準 npm manager でバージョン管理も改善する(現状 CDN URL は実質未管理)。ビルドレスなフロントに最小のコピー手順が増えるのが唯一の実コスト(バンドラ不要)。
+- **静的配信に nonce は不向き**: SSR の無い S3+CloudFront で安全な nonce 運用手段が無く、選択肢 C は不適。
+- **責務分界が基準で一意化**(§3.1): per-header 単一オーナー + 二重出力禁止で SSOT が明確になり、HSTS 二重送出のような曖昧さを排除。
+- **退行検知**: ヘッダーを IaC とコードに明示、API は MockMvc で値を assert、フロントは E2E(ADR-0023)で `securitypolicyviolation` 0 を assert。
+
+## 5. 影響(Consequences)
+
+### 良い影響(Positive)
+
+- フロント・API とも XSS / クリックジャッキング / MIME スニッフィング / referrer 漏洩への既定防御が明示され、テストで守れる。
+- 第三者 CDN 依存(特に auth 経路 SPOF)を排除。SRI 不一致の既存バグも解消。
+- ヘッダーの SSOT が層ごとに一意。`script-src 'self'` で将来さらに絞る余地も残る。
+
+### 悪い影響・制約(Negative)
+
+- `web/` の inline 撤去に加え、**npm 取り込み + deploy 時 S3 コピー**の手順が増える(ビルドレス→最小のコピー工程)。
+- CloudFront に Response Headers Policy を新設し distribution へ紐付ける IaC 作業。
+- CSP の `connect-src` を env 別 origin にテンプレート化し、API/Keycloak URL 変更時に追従が要る。
+
+### 既存ドキュメント・規約への波及
+
+- `docs/specs/設計規約.md` §5.4 に「セキュリティレスポンスヘッダー」節を新設(本 ADR を SSOT 参照、§3.1 の分担基準を明記)。§5.5 据置。
+- `docs/specs/基本設計書.md` SC-8 近傍にヘッダー方針 + HSTS の SSOT(TLS 終端)を追記。
+- infra: CloudFront モジュールに `aws_cloudfront_response_headers_policy` 追加。
+- **本 ADR をもって `web/` に npm(`package.json` + Node)を導入する(npm 導入の SSOT は本 ADR)**。ビルドレスだったフロント初の npm 化で、最小のビルド工程(資産コピー)を伴う。`package.json` は Renovate 標準 npm 管理対象に入る(`renovate.json` の `area/web` ルールが実機能する)。後続のフロント技術選定(コンポーネント化方針など)はこの npm 導入を前提にできる。
+- CSP 違反の自動検証は ADR-0023(最小 E2E 基盤)に相乗り。
+
+## 6. 実装メモ(Implementation Notes)
+
+着手順(レイヤー横断 + テスト種別が多く分割推奨):
+
+1. **フロント自前配信 + inline 撤去**(`web/`): `package.json` に bootstrap・keycloak-js を追加し deploy 時に `node_modules/.../dist` を S3 へコピー。HTML の CDN タグを `'self'` 参照へ置換(SRI 不一致バグも同時解消)。inline `<script>` を `js/` へ、`onclick=` を `addEventListener` へ、`style=` を `css/app.css` クラスへ移行。機能等価を手動確認。
+2. **API ヘッダー**(`SecurityConfig.java`): §3.3 を実装、`SecurityConfigTest`(MockMvc)で各ヘッダー値を assert。
+3. **CloudFront RHP**(`infra`): §3.2 を env テンプレートで定義し distribution に紐付け。HSTS は CloudFront(静的経路の TLS 終端)が出す。
+4. **Report-Only → enforce**: 3 でまず Report-Only を dev/stg に付与 → 検証(下記) → enforce 切替。
+
+### CSP 検証体制(Report-Only 期間、hybrid)
+
+「コンソールを見る」を曖昧な背景作業にしない。担当・完了基準を明示する。
+
+- **(a) 手動パス(オーナー: win2cot)**: enforce 切替前に stg で DevTools を開き、決めたフロー(Keycloak ログイン/トークン更新、タスク CRUD、モーダル/ドロップダウン=Popper、カレンダー)を一巡して違反を記録。完了基準=列挙フローで違反 0。本 ADR 内の独立タスクとして計画に乗せる。
+- **(b) 自動ガード(機械検知、ADR-0023 に相乗り)**: Playwright E2E の全ページ共通フィクスチャで `securitypolicyviolation` イベント 0 を assert。回帰を継続的に守る。**E2E 基盤(ADR-0023)の成立に blocked**、Sprint 3 以降。
+
+「Issue/Project audit は機械検知優先」の原則に沿い、(a) は着手時の一過性確認、(b) を恒常ガードとする二段構え。
+
+## 7. 参考リンク(References)
+
+- `webapi/.../security/adapter/web/SecurityConfig.java` / `application.yml` — 現 API 設定
+- `web/index.html` / `web/tasks.html` / `web/js/auth.js` / `web/js/api.js` — フロント現況
+- `infra/shared/modules/alb/main.tf` — HSTS 注入(API 経路の TLS 終端)
+- `renovate.json` — 依存管理(npm 取り込み後に web 資産も対象化)
+- `docs/specs/設計規約.md` §5.4 / §5.5 / `docs/specs/基本設計書.md` SC-8
+- infra ADR-0006 — 共有 ALB / CloudFront はフロント静的配信専用
+- **ADR-0023 — 最小 E2E 基盤(CSP 自動ガードの相乗り先)**
+- MDN: Content-Security-Policy / OWASP Secure Headers Project

--- a/docs/adr/0022-security-response-headers.md
+++ b/docs/adr/0022-security-response-headers.md
@@ -77,7 +77,7 @@ CSP 設計に効く実装事実: keycloak-js は `checkLoginIframe: false`(ifram
 
 CSP(`<env>` は Terraform 変数でテンプレート化、外部資産は自前配信のため `'self'`):
 
-```
+```text
 default-src 'none';
 script-src 'self';
 style-src 'self';
@@ -111,7 +111,7 @@ object-src 'none'
 
 JSON 専用の防御的最小 CSP:
 
-```
+```text
 Content-Security-Policy: default-src 'none'; frame-ancestors 'none'
 ```
 

--- a/docs/adr/0023-minimal-e2e-harness.md
+++ b/docs/adr/0023-minimal-e2e-harness.md
@@ -1,0 +1,111 @@
+# ADR-0023: 最小 E2E テスト基盤 — Playwright(TypeScript)+ hermetic compose、機能完了ごとに段階拡充
+
+- **Status**: Accepted
+- **Date**: 2026-06-11
+- **Deciders**: win2cot, 開発チーム
+- **Tags**: testing, e2e, frontend, ci, quality
+
+## 目次
+
+- [1. コンテキスト(Context)](#1-コンテキストcontext)
+- [2. 検討した選択肢(Options Considered)](#2-検討した選択肢options-considered)
+- [3. 決定(Decision)](#3-決定decision)
+- [4. 理由(Rationale)](#4-理由rationale)
+- [5. 影響(Consequences)](#5-影響consequences)
+- [6. 実装メモ(Implementation Notes)](#6-実装メモimplementation-notes)
+- [7. 参考リンク(References)](#7-参考リンクreferences)
+
+## 1. コンテキスト(Context)
+
+現状、自動化されたブラウザ E2E テストは存在しない。あるのは **手動の E2E 動作確認**(Issue #233 = 手順書 + 証跡)と、開発計画書の **システムテスト・UAT フェーズ**(2026-08-11〜09-04、QA/テスター 1 名、UAT 合格率 95%)のみ。フロントは `web/` のビルドレスな静的 SPA。`docker-compose.local.yml` は **mysql + keycloak のみ**で webapi/web は別建て。
+
+これでは、(1) 実装完了機能の「最低限動く」を早期・継続確認する手段が無く退行が UAT まで露見しない、(2) ADR-0022 の CSP 自動ガード(`securitypolicyviolation` 0 の assert)が乗る土台が無い。
+
+win2cot の意図は「システムテストを待たず、**実装が終わった機能から順に最小の煙感知 E2E を足す**」継続的 E2E。重い UAT は上位層として残す。本 ADR は**最小の自動 E2E 基盤**を立て、機能完了ごとに段階拡充する枠組みを定める(深いカバレッジ設計はテスト工程送り)。
+
+なお ADR-0022 によりフロント(`web/`)に npm が導入されるため、Node ツールチェーンは既にプロジェクトに入る。本 E2E を Node/TypeScript で組んでも言語/生態系の追加コストは小さい。
+
+## 2. 検討した選択肢(Options Considered)
+
+### ツール: Playwright vs Cypress
+
+- **Playwright(採用)**: ヘッドレス Chromium、CI 親和性、`securitypolicyviolation` 捕捉・ネットワーク傍受、マルチオリジン(別ドメイン Keycloak)に強い。
+- Cypress: CI 並列・マルチオリジンで取り回しが劣る。不採用。
+
+### テストコード言語: TypeScript vs JavaScript vs Java(TypeScript を採用)
+
+- **TypeScript(採用)**: Playwright を**フルに使い倒す**ための第一級ターゲット。純正テストランナー **`@playwright/test`** が付属し、フィクスチャ・並列実行・自動リトライ・`expect` の auto-waiting アサーション・HTML レポート・trace viewer が一式揃う。型安全でテストコードの誤りも早期検知。Playwright が `.ts` をネイティブ実行するため追加バンドラ不要。
+- JavaScript: 同等に動くが型安全を失う。純正ランナーは TS と同様に使える。TS を上位互換として採用。
+- Java(Playwright for Java): 開発陣の主言語で Gradle/JUnit と一体化できるが、**純正ランナーが無く JUnit を自前配線**(フィクスチャ/並列/レポートを組む手間)、新機能追従と資料も TS/JS に劣る。「Playwright をフル活用」の目的に最も遠く不採用。
+
+### CI 実行環境: hermetic compose vs デプロイ済み dev
+
+- **compose で hermetic full stack(採用)**: compose を拡張し mysql+keycloak+webapi+web 静的配信を CI 内で起動し叩く。再現性・隔離が高い。起動コスト(数分)はある。
+- デプロイ済み dev: 共有環境・データ汚染・並行でフレーキー。不採用。
+
+### 着手時期 / 拡充モデル
+
+- **Sprint 3 で scaffold + 既存機能 backfill、以降 DoD で段階拡充(採用)**。大きく 8 月一括は意図に反し不採用。
+
+## 3. 決定(Decision)
+
+**採用**: Playwright(TypeScript / `@playwright/test`)による最小 E2E 基盤を新規 `e2e/`(Node パッケージ)に置き、hermetic compose full stack に対し CI で実行する。Sprint 3 で scaffold + 既存機能を backfill し、以降は機能完了ごとに段階拡充する。
+
+具体:
+
+- **配置**: リポジトリ直下に `e2e/`(独自 `package.json` + `@playwright/test` + TypeScript)。`web/`(資産のみ)・`webapi/`(Gradle)とは独立。Renovate 標準 npm manager の管理対象に入る。
+- **実行スタック**: `docker-compose` を拡張し、既存 mysql+keycloak に **webapi + web 静的配信**を加えて full stack を hermetic 起動。新ワークフロー `e2e.yml` が起動 → **`npx playwright test`** → trace/動画 アーティファクト。PR で実行(対象パス/スケジュールで調整可)。
+- **拡充モデル(DoD 化)**: UI 機能の **完了の定義(DoD)に「ハッピーパスの煙感知 spec 1 本」を含める**。Sprint 3 で既存完了機能(Keycloak ログイン往復 / テナント切替 / タスク一覧 + CRUD)を backfill。以降は機能ごとに追加。
+- **CSP 自動ガード(ADR-0022 (b))**: 共通フィクスチャで `page.on('console')` / `securitypolicyviolation` イベントを購読し 0 を assert。Report-Only → enforce の移行を機械で守る。
+- **位置づけ**: 8 月の システムテスト/UAT は重い受入層として残す。本基盤はその下の**高速・継続の煙感知層**。
+
+## 4. 理由(Rationale)
+
+- **Playwright をフル活用**: TS + `@playwright/test` で純正ランナー(フィクスチャ/並列/リトライ/trace/HTML レポート)を最大限使える。型安全でテストコードの誤りも早期検知。`.ts` ネイティブ実行で追加バンドラ不要。
+- **Node 追加コストが小さい**: ADR-0022 でフロントに npm が入るため Node 生態系は既にプロジェクトに存在し、E2E を TS にしても整合する。依存は Renovate npm manager で追従。
+- **早期・継続の退行検知**: 機能完了ごとに最小 E2E を足し、UAT を待たず「最低限動く」を担保。テストピラミッドの観点でも妥当。
+- **hermetic compose で再現性**: 既存 compose + Testcontainers 文化があり、full stack を CI で立てる素地がある。
+- **機械検知優先の原則と整合**: CSP 違反含む検知可能事象を人手監視でなく自動アサーションで守る。
+- 捨てる利点: Java での言語統一(Gradle/JUnit 一体化)は、Playwright のフル活用(純正ランナー)と資料の厚さを優先して捨てる。
+
+## 5. 影響(Consequences)
+
+### 良い影響(Positive)
+
+- 実装済み機能の動作を早期・継続的に自動検証。ADR-0022 の CSP 自動ガードの土台ができる。
+- `e2e/` が npm パッケージとして Renovate(npm)管理に乗る。Playwright の trace/レポート/並列をフルに使える。
+
+### 悪い影響・制約(Negative)
+
+- 新規 `e2e/` Node パッケージ・新 CI ワークフロー `e2e.yml`・compose 拡張(webapi+web 追加)が必要。
+- CI に full stack 起動(数分)+ `npx playwright install` が加わる。対象パス絞り込み等で緩和。
+- テストコードは Java(バックエンド)と別言語の TS になる(ただし Node は ADR-0022 で既に導入済)。
+- DoD 変更(機能完了に煙感知 spec)を規約に反映する必要。
+
+### 既存ドキュメント・規約への波及
+
+- `docs/specs/コーディング規約.md`(またはテスト方針)に「UI 機能の DoD = 煙感知 E2E spec 1 本」を明記。
+- 開発計画書のテスト体系に本基盤(継続層)と UAT(受入層)の位置づけを追記。
+- `docker-compose` に webapi+web 静的配信サービスを追加(local/CI 共用 or プロファイル)。
+- ADR-0022 の CSP 自動ガード(b)は本基盤の成立に blocked。
+
+## 6. 実装メモ(Implementation Notes)
+
+着手(Sprint 3):
+
+1. **scaffold**: `e2e/`(`package.json` + `@playwright/test` + TypeScript 設定)。最小 1 spec(トップ表示)で疎通。CI で `npx playwright install`。
+2. **compose 拡張**: mysql+keycloak に webapi + web 静的配信を追加し full stack を一括起動可能に。
+3. **CI ワークフロー `e2e.yml`**: full stack 起動 → `npx playwright test` → trace/動画 アーティファクト。
+4. **backfill**: Keycloak ログイン往復 / テナント切替 / タスク一覧 + CRUD のハッピーパス(`*.spec.ts`)。
+5. **CSP 共通フィクスチャ**: `securitypolicyviolation` を購読し 0 assert(ADR-0022 (b))。
+6. **DoD 規約反映**: 機能完了 = 煙感知 spec 1 本。
+
+カバレッジの深さはテスト工程で別途議論。
+
+## 7. 参考リンク(References)
+
+- Issue #233 — 手動 E2E 動作確認手順 + 証跡(既存)
+- `docs/specs/開発計画書.md` — システムテスト/UAT フェーズ(2026-08-11〜)
+- `docker-compose.local.yml` — 現 compose(mysql+keycloak)
+- **ADR-0022 — セキュリティレスポンスヘッダー(CSP 自動ガードの依頼元 / npm 導入元)**
+- Playwright / `@playwright/test` 公式


### PR DESCRIPTION
ADR-0022(最小許可・既定厳格のセキュリティレスポンスヘッダー、npm 自前配信、per-header 単一オーナー)と ADR-0023(Playwright + hermetic compose の最小 E2E 基盤)。同一議論の産物のため 1 PR。

Closes #526
Closes #536
Refs #525
Refs #535

## 未対応レビュー

| 指摘 | 内容 | 状態 |
|---|---|---|
| [MD040 コードブロック言語指定](https://github.com/win2cot/tasks-webapi/pull/543#pullrequestreview-2868609951) | ADR-0022 行80・114 の fenced code block に言語指定なし | 対応済み(2108a00) |
