### PR TITLE
chore(web): Node.js 24 固定 + package-lock.json 追加

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,0 +1,101 @@
+{
+  "name": "tasks-web",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "tasks-web",
+      "version": "1.0.0",
+      "dependencies": {
+        "@fontsource/noto-sans-jp": "^5.0.0",
+        "bootstrap": "5.3.3",
+        "bootstrap-icons": "1.11.3",
+        "keycloak-js": "24.0.5"
+      },
+      "engines": {
+        "node": ">=24"
+      }
+    },
+    "node_modules/@fontsource/noto-sans-jp": {
+      "version": "5.2.9",
+      "resolved": "https://registry.npmjs.org/@fontsource/noto-sans-jp/-/noto-sans-jp-5.2.9.tgz",
+      "integrity": "sha512-6yVGiofnrnbiJjU8ch4JGSs2HqyozxMvsVyVmFwOnDH3u//qQKLqmKM4n0lqN0637uaJNzUW9nIJqbbMgHVQzw==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
+    },
+    "node_modules/bootstrap": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.3.tgz",
+      "integrity": "sha512-8HLCdWgyoMguSO9o+aH+iuZ+aht+mzW0u3HIMzVu7Srrpv7EBBxTnrFlSCskwdY1+EOFQSm7uMJhNQHkdPcmjg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/twbs"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/bootstrap"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "@popperjs/core": "^2.11.8"
+      }
+    },
+    "node_modules/bootstrap-icons": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/bootstrap-icons/-/bootstrap-icons-1.11.3.tgz",
+      "integrity": "sha512-+3lpHrCw/it2/7lBL15VR0HEumaBss0+f/Lb6ZvHISn1mlK83jjFpooTLsMWbIjJMDjDjOExMsTxnXSIT4k4ww==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/twbs"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/bootstrap"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/js-sha256": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.11.1.tgz",
+      "integrity": "sha512-o6WSo/LUvY2uC4j7mO50a2ms7E/EAdbP0swigLV+nzHKTTaYnaLIWJ02VdXrsJX0vGedDESQnLsOekr94ryfjg==",
+      "license": "MIT"
+    },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/keycloak-js": {
+      "version": "24.0.5",
+      "resolved": "https://registry.npmjs.org/keycloak-js/-/keycloak-js-24.0.5.tgz",
+      "integrity": "sha512-VQOSn3j13DPB6OuavKAq+sRjDERhIKrXgBzekoHRstifPuyULILguugX6yxRUYFSpn3OMYUXmSX++tkdCupOjA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "js-sha256": "^0.11.0",
+        "jwt-decode": "^4.0.0"
+      }
+    }
+  }
+}

--- a/web/package.json
+++ b/web/package.json
@@ -13,6 +13,6 @@
     "copy-vendor": "node scripts/copy-vendor.js"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=24"
   }
 }


### PR DESCRIPTION
## Summary

- `package.json` の `engines.node` を `>=18` → `>=24` に変更
  - Node 18/20 は EOL 済み; 24 は現行 Active LTS (24.16.0 で生成)
- `package-lock.json` を新規コミット
  - ロックファイル未コミットによるビルド非再現問題を解消
  - `@fontsource/noto-sans-jp: "^5.0.0"` 等の範囲指定依存が実行タイミングによらず同一バージョンに固定される

## Test plan

- [ ] CI で `npm install` が `package-lock.json` を元に正常完了する
- [ ] `npm run copy-vendor` が Node 24 環境で正常完了する

🤖 Generated with [Claude Code](https://claude.com/claude-code)