### PR TITLE
chore(web): 旧 tenant-switcher.js(死にコード)を削除

### DIFF
--- a/web/js/tenant-switcher.js
+++ b/web/js/tenant-switcher.js
@@ -1,2 +1,0 @@
-// Replaced by web/js/components/app-tenant-switcher.js (Issue #546, ADR-0024).
-// This file is kept for reference only and is no longer loaded by any page.


### PR DESCRIPTION
## Summary

- `web/js/tenant-switcher.js` を削除(#555)
- #546 / PR #553 で `web/js/components/app-tenant-switcher.js` に置換済みのスタブで、どのページからもロードされていない参照専用の死にコード
- `grep` で旧ファイルへの参照ゼロを確認済み

## Test plan

- [ ] `grep -r "[^-]tenant-switcher\.js" web/` で 0 件(CI または手動)
- [ ] 既存の Node.js / Gradle チェックが通過

Closes #555

🤖 Generated with [Claude Code](https://claude.com/claude-code)