### PR TITLE
feat(web): C-3 右ドロワー(新規作成 / 詳細編集、URL 同期) (#476)

### DIFF
--- a/web/css/app.css
+++ b/web/css/app.css
@@ -311,3 +311,70 @@ app-task-row { display: contents; }
 /* Utility: whitespace and text sizes from rowHTML() */
 .td-nowrap      { white-space: nowrap; }
 .add-desc-hint  { font-size: 11px; }
+
+/* ---- Drawer content (app-task-drawer) ---- */
+.offcanvas-end        { width: 460px; }
+.offcanvas-header     { gap: 8px; flex-wrap: wrap; }
+.offcanvas-title      { font-size: 15px; }
+
+.drawer-field-label {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: .04em;
+  color: var(--app-muted);
+  text-transform: uppercase;
+  margin-bottom: 5px;
+}
+
+.drawer-desc-text {
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--app-ink);
+}
+
+/* Meta key-value grid (2-column, label + value) */
+.drawer-meta-grid {
+  display: grid;
+  grid-template-columns: 90px 1fr;
+  row-gap: 8px;
+  column-gap: 12px;
+  align-items: baseline;
+}
+.drawer-meta-label {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--app-muted);
+  text-transform: uppercase;
+  letter-spacing: .04em;
+}
+.drawer-meta-value { font-size: 13px; }
+
+/* Stakeholder / selected-user chips */
+.drawer-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  min-height: 28px;
+}
+.drawer-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  background: #eef2ff;
+  color: #3b4cca;
+  border: 1px solid #c5cff9;
+  border-radius: 20px;
+  padding: 3px 10px 3px 10px;
+  font-size: 12px;
+  font-weight: 500;
+}
+.drawer-chip-rm {
+  background: none;
+  border: none;
+  padding: 0 0 0 4px;
+  font-size: 14px;
+  line-height: 1;
+  color: #7a82c6;
+  cursor: pointer;
+}
+.drawer-chip-rm:hover { color: #c92a2a; }

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -66,6 +66,23 @@ const Api = (() => {
     return response.text();
   }
 
+  async function _throwFromResponse(response) {
+    const body = await response.text().catch(() => '');
+    const err = new Error(`${response.status} ${response.statusText}: ${body}`);
+    err.status = response.status;
+    throw err;
+  }
+
+  // Returns the raw Response (handles 401 refresh), for callers that need headers.
+  async function requestRaw(path, options = {}) {
+    const response = await _fetch(path, await Auth.getToken(), options);
+    if (response.status === 401) {
+      const newToken = await Auth.refreshToken();
+      return _fetch(path, newToken, options);
+    }
+    return response;
+  }
+
   /**
    * GET /api/auth/me — 認証済みユーザー情報を取得する。
    * @returns {Promise<Object>}
@@ -155,5 +172,90 @@ const Api = (() => {
     return request('/api/tenant/users');
   }
 
-  return { setTenantId, request, getMe, selectTenant, listTasks, patchTask, changeStatus, listTenantUsers };
+  /**
+   * GET /api/tasks/{id} — タスク詳細取得(A-12)。ETag も返す。
+   * @param {number} id
+   * @returns {Promise<{task: TaskDetail, etag: string|null}>}
+   */
+  async function getTask(id) {
+    const resp = await requestRaw(`/api/tasks/${id}`);
+    if (!resp.ok) await _throwFromResponse(resp);
+    return { task: await resp.json(), etag: resp.headers.get('ETag') };
+  }
+
+  /**
+   * POST /api/tasks — タスク作成(A-2)。
+   * @param {Object} body — TaskCreateRequest
+   * @returns {Promise<Task>}
+   */
+  function createTask(body) {
+    return request('/api/tasks', { method: 'POST', body: JSON.stringify(body) });
+  }
+
+  /**
+   * DELETE /api/tasks/{id} — タスク論理削除(A-15)。If-Match 必須(ADR-0012)。
+   * @param {number} id
+   * @param {string} etag — W/"<version>"
+   * @returns {Promise<void>}
+   */
+  function deleteTask(id, etag) {
+    return request(`/api/tasks/${id}`, {
+      method: 'DELETE',
+      headers: { 'If-Match': etag },
+    });
+  }
+
+  /**
+   * PATCH /api/tasks/{id}/visibility — 公開範囲変更(A-17)。
+   * @param {number} id
+   * @param {string} visibility — Visibility 値
+   * @param {number[]} [stakeholderUserIds] — visibility=STAKEHOLDERS のとき指定
+   * @returns {Promise<Task>}
+   */
+  function changeVisibility(id, visibility, stakeholderUserIds) {
+    const body = { visibility };
+    if (stakeholderUserIds) body.stakeholderUserIds = stakeholderUserIds;
+    return request(`/api/tasks/${id}/visibility`, { method: 'PATCH', body: JSON.stringify(body) });
+  }
+
+  /**
+   * GET /api/tasks/{id}/stakeholders — 関係者一覧取得。
+   * @param {number} id
+   * @returns {Promise<Stakeholder[]>}
+   */
+  function listStakeholders(id) {
+    return request(`/api/tasks/${id}/stakeholders`);
+  }
+
+  /**
+   * POST /api/tasks/{id}/stakeholders — 関係者追加(A-19)。
+   * @param {number} taskId
+   * @param {number} userId
+   * @returns {Promise<Stakeholder>}
+   */
+  function addStakeholder(taskId, userId) {
+    return request(`/api/tasks/${taskId}/stakeholders`, {
+      method: 'POST',
+      body: JSON.stringify({ userId }),
+    });
+  }
+
+  /**
+   * DELETE /api/tasks/{taskId}/stakeholders/{userId} — 関係者削除(A-20)。
+   * @param {number} taskId
+   * @param {number} userId
+   * @returns {Promise<void>}
+   */
+  function removeStakeholder(taskId, userId) {
+    return request(`/api/tasks/${taskId}/stakeholders/${userId}`, { method: 'DELETE' });
+  }
+
+  return {
+    setTenantId, request, requestRaw,
+    getMe, selectTenant,
+    listTasks, getTask, createTask, patchTask, deleteTask,
+    changeStatus, changeVisibility,
+    listTenantUsers,
+    listStakeholders, addStakeholder, removeStakeholder,
+  };
 })();

--- a/web/js/components/app-task-drawer.js
+++ b/web/js/components/app-task-drawer.js
@@ -1,118 +1,1060 @@
-// <app-task-drawer> — Bootstrap Offcanvas drawer for creating a new task.
-// Methods: setUsers(tenantUsers), open()
-// Fires: drawer-submit (bubbling) — currently a no-op until Sprint 3 POST /api/tasks
-const _drawerTpl = document.createElement('template');
-_drawerTpl.innerHTML = `
-<div class="offcanvas offcanvas-end" tabindex="-1" aria-labelledby="newTaskLabel">
-  <div class="offcanvas-header border-bottom">
-    <h5 class="offcanvas-title" id="newTaskLabel">
-      <i class="bi bi-plus-circle me-2 text-primary" aria-hidden="true"></i>新規タスク
-    </h5>
-    <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="閉じる"></button>
-  </div>
-  <div class="offcanvas-body">
-    <form class="new-task-form">
-      <div class="mb-3">
-        <label class="form-label small fw-bold" for="newTitle">
-          タイトル <span class="text-danger" aria-hidden="true">*</span>
-        </label>
-        <input id="newTitle" class="form-control" maxlength="100"
-          placeholder="例: 設計レビュー" required aria-required="true" />
-      </div>
-      <div class="mb-3">
-        <label class="form-label small fw-bold" for="newDesc">説明</label>
-        <textarea id="newDesc" class="form-control" rows="3"
-          maxlength="2000" placeholder="任意・最大2000文字"></textarea>
-      </div>
-      <div class="row g-3">
-        <div class="col-6">
-          <label class="form-label small fw-bold" for="newDue">
-            期限日 <span class="text-danger" aria-hidden="true">*</span>
-          </label>
-          <input type="date" id="newDue" class="form-control" required aria-required="true" />
-        </div>
-        <div class="col-6">
-          <label class="form-label small fw-bold" for="newAssignee">担当者</label>
-          <select id="newAssignee" class="form-select new-assignee-sel">
-            <option value="">未割当</option>
-          </select>
-        </div>
-      </div>
-      <div class="mt-3">
-        <fieldset>
-          <legend class="form-label small fw-bold">
-            優先度 <span class="text-danger" aria-hidden="true">*</span>
-          </legend>
-          <div class="btn-group w-100" role="group">
-            <input type="radio" class="btn-check" name="newPri" id="newPri-H" value="HIGH">
-            <label class="btn btn-outline-danger" for="newPri-H">高</label>
-            <input type="radio" class="btn-check" name="newPri" id="newPri-M" value="MEDIUM" checked>
-            <label class="btn btn-outline-warning" for="newPri-M">中</label>
-            <input type="radio" class="btn-check" name="newPri" id="newPri-L" value="LOW">
-            <label class="btn btn-outline-secondary" for="newPri-L">低</label>
-          </div>
-        </fieldset>
-      </div>
-      <div class="mt-3">
-        <fieldset>
-          <legend class="form-label small fw-bold">
-            公開範囲 <span class="text-danger" aria-hidden="true">*</span>
-          </legend>
-          <div class="btn-group w-100" role="group">
-            <input type="radio" class="btn-check" name="newVis" id="newVis-T" value="TENANT" checked>
-            <label class="btn btn-outline-success" for="newVis-T">
-              <i class="bi bi-globe2" aria-hidden="true"></i> テナント
-            </label>
-            <input type="radio" class="btn-check" name="newVis" id="newVis-S" value="STAKEHOLDERS">
-            <label class="btn btn-outline-primary" for="newVis-S">
-              <i class="bi bi-people-fill" aria-hidden="true"></i> 関係者
-            </label>
-            <input type="radio" class="btn-check" name="newVis" id="newVis-P" value="PRIVATE">
-            <label class="btn btn-outline-secondary" for="newVis-P">
-              <i class="bi bi-lock-fill" aria-hidden="true"></i> 非公開
-            </label>
-          </div>
-        </fieldset>
-      </div>
-      <div class="d-flex gap-2 mt-4">
-        <button type="submit" class="btn btn-primary flex-grow-1">作成</button>
-        <button type="button" class="btn btn-light" data-bs-dismiss="offcanvas">取消</button>
-      </div>
-    </form>
-  </div>
-</div>`;
+// <app-task-drawer> — Bootstrap Offcanvas drawer for task create / detail / edit.
+//
+// Public API:
+//   setUsers(tenantUsers)         — set tenant user list for dropdowns
+//   setCurrentUser(userId)        — set logged-in user ID for permission checks
+//   open() / openNew(opts?)       — open in "new task" mode
+//   openDetail(taskId)            — load task and open in detail mode
+//   openEdit(taskId)              — load task and open in edit mode
+//
+// Fires (bubbling):
+//   drawer-task-created  { task }        — POST /api/tasks succeeded
+//   drawer-task-updated  { task }        — PATCH succeeded (detail re-fetched)
+//   drawer-task-deleted  { taskId }      — DELETE succeeded
+//   drawer-closed                        — offcanvas fully hidden
+
+const PRI_LABEL = { HIGH: '高', MEDIUM: '中', LOW: '低' };
+const ST_LABEL  = { NOT_STARTED: '未着手', IN_PROGRESS: '進行中', DONE: '完了', ON_HOLD: '保留' };
+const VIS_LABEL = { TENANT: 'テナント', STAKEHOLDERS: '関係者', PRIVATE: '非公開' };
+const VIS_ICON  = { TENANT: 'bi-globe2', STAKEHOLDERS: 'bi-people-fill', PRIVATE: 'bi-lock-fill' };
 
 class AppTaskDrawer extends HTMLElement {
-  #offcanvasEl = null;
+  #oc          = null;
+  #mode        = null;  // 'new' | 'detail' | 'edit'
+  #task        = null;
+  #etag        = null;
+  #tenantUsers = [];
+  #currentUserId = null;
+  #stakeholders  = [];
+  #selectedSH    = [];  // [{userId, fullName}] for new-mode stakeholder picker
+  #prevPath      = null;
+  #skipHideUrl   = false;
+  #popHandler    = null;
 
   connectedCallback() {
-    this.replaceChildren(_drawerTpl.content.cloneNode(true));
-    this.#offcanvasEl = this.firstElementChild;
-    this.querySelector('.new-task-form').addEventListener('submit', e => {
-      e.preventDefault();
-      // TODO: POST /api/tasks (Sprint 3+)
-      this.dispatchEvent(new CustomEvent('drawer-submit', { bubbles: true }));
-      bootstrap.Offcanvas.getInstance(this.#offcanvasEl)?.hide();
+    const el = document.createElement('div');
+    el.className = 'offcanvas offcanvas-end';
+    el.setAttribute('tabindex', '-1');
+    el.innerHTML =
+      '<div class="offcanvas-header border-bottom"></div>' +
+      '<div class="offcanvas-body"></div>';
+    this.appendChild(el);
+
+    this.#oc = bootstrap.Offcanvas.getOrCreateInstance(el);
+    el.addEventListener('hidden.bs.offcanvas', () => this.#onHidden());
+
+    this.#popHandler = () => this.#onPopState();
+    window.addEventListener('popstate', this.#popHandler);
+  }
+
+  disconnectedCallback() {
+    window.removeEventListener('popstate', this.#popHandler);
+  }
+
+  // ---- Public API ----
+
+  setUsers(users)        { this.#tenantUsers = users || []; }
+  setCurrentUser(userId) { this.#currentUserId = userId; }
+
+  open() { this.openNew(); }
+
+  // List URL to restore when closing after a direct-URL auto-open
+  static #LIST_URL = '/tasks.html';
+
+  openNew(opts = {}) {
+    this.#prevPath = this.#safeListUrl('/tasks/new');
+    this.#mode     = 'new';
+    this.#task     = null;
+    this.#etag     = null;
+    this.#stakeholders = [];
+    this.#selectedSH   = [];
+    this.#renderNew(opts);
+    this.#pushUrl('/tasks/new');
+    this.#oc.show();
+  }
+
+  async openDetail(taskId) {
+    this.#prevPath = this.#safeListUrl(`/tasks/${taskId}`);
+    this.#mode = 'detail';
+    this.#renderLoading();
+    this.#pushUrl(`/tasks/${taskId}`);
+    this.#oc.show();
+    await this.#loadAndRenderDetail(taskId);
+  }
+
+  async openEdit(taskId) {
+    this.#prevPath = this.#safeListUrl(`/tasks/${taskId}/edit`);
+    this.#renderLoading();
+    this.#pushUrl(`/tasks/${taskId}/edit`);
+    this.#oc.show();
+    if (!this.#task || this.#task.id !== taskId) {
+      await this.#loadTaskData(taskId);
+    }
+    this.#mode = 'edit';
+    if (this.#task) this.#renderEdit();
+  }
+
+  // Return current path unless it matches drawerUrl (direct-URL open), then fall back to list.
+  #safeListUrl(drawerUrl) {
+    const cur = location.pathname + location.search;
+    return cur === drawerUrl ? AppTaskDrawer.#LIST_URL : cur;
+  }
+
+  // ---- Private helpers ----
+
+  get #hdr() { return this.firstElementChild?.querySelector('.offcanvas-header'); }
+  get #bdy() { return this.firstElementChild?.querySelector('.offcanvas-body'); }
+
+  #can(type) {
+    const t = this.#task;
+    if (!t) return false;
+    if (type === 'edit')        return !!t.editable;
+    if (type === 'delete')      return !!t.deletable;
+    if (type === 'status')      return t.editable || t.assignee?.id === this.#currentUserId;
+    if (type === 'stakeholder') return t.editable || t.assignee?.id === this.#currentUserId;
+    if (type === 'visibility')  return !!t.editable;
+    return false;
+  }
+
+  async #loadTaskData(taskId) {
+    try {
+      const [{ task, etag }, stakeholders] = await Promise.all([
+        Api.getTask(taskId),
+        Api.listStakeholders(taskId).catch(() => []),
+      ]);
+      this.#task         = task;
+      this.#etag         = etag;
+      this.#stakeholders = stakeholders;
+    } catch (err) {
+      this.#renderError(err);
+      this.#task = null;
+    }
+  }
+
+  async #loadAndRenderDetail(taskId) {
+    await this.#loadTaskData(taskId);
+    if (this.#task) {
+      this.#mode = 'detail';
+      this.#renderDetail();
+    }
+  }
+
+  #pushUrl(url) { history.pushState({ drawer: true }, '', url); }
+  #replaceUrl(url) { history.replaceState({ drawer: true }, '', url); }
+
+  #onHidden() {
+    if (!this.#skipHideUrl && this.#prevPath) {
+      history.replaceState(null, '', this.#prevPath);
+    }
+    this.#skipHideUrl = false;
+    this.#mode = null;
+    this.dispatchEvent(new CustomEvent('drawer-closed', { bubbles: true }));
+  }
+
+  #onPopState() {
+    const inst = bootstrap.Offcanvas.getInstance(this.firstElementChild);
+    if (inst) {
+      this.#skipHideUrl = true;
+      inst.hide();
+    }
+  }
+
+  // ---- Shared rendering helpers ----
+
+  #makeCloseBtn() {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'btn-close';
+    btn.setAttribute('data-bs-dismiss', 'offcanvas');
+    btn.setAttribute('aria-label', '閉じる');
+    return btn;
+  }
+
+  #makeErrorMsg(msg) {
+    const d = document.createElement('div');
+    d.className = 'alert alert-danger py-2 small mb-3';
+    d.setAttribute('role', 'alert');
+    d.textContent = msg;
+    return d;
+  }
+
+  #makeSpinner(label = '読み込み中...') {
+    const d = document.createElement('div');
+    d.className = 'text-center py-5';
+    d.innerHTML =
+      '<div class="spinner-border text-primary" role="status">' +
+      '<span class="visually-hidden">' + label + '</span></div>' +
+      '<p class="mt-2 small text-muted">' + label + '</p>';
+    return d;
+  }
+
+  // ---- Loading / error states ----
+
+  #renderLoading() {
+    this.#hdr.replaceChildren();
+    this.#bdy.replaceChildren(this.#makeSpinner());
+  }
+
+  #renderError(err) {
+    const hdr = this.#hdr;
+    hdr.replaceChildren();
+    const title = document.createElement('h5');
+    title.className = 'offcanvas-title';
+    title.textContent = 'エラー';
+    hdr.append(title, this.#makeCloseBtn());
+
+    this.#bdy.replaceChildren(
+      this.#makeErrorMsg(
+        err.status === 404
+          ? 'このタスクは表示できません(存在しないか参照権限がありません)'
+          : 'タスクの取得に失敗しました: ' + (err.message || ''),
+      ),
+    );
+  }
+
+  // ---- NEW MODE ----
+
+  #renderNew(opts = {}) {
+    const hdr = this.#hdr;
+    hdr.replaceChildren();
+    const title = document.createElement('h5');
+    title.className = 'offcanvas-title';
+    title.innerHTML = '<i class="bi bi-plus-circle me-2 text-primary" aria-hidden="true"></i>新規タスク';
+    hdr.append(title, this.#makeCloseBtn());
+
+    const form = this.#buildNewForm(opts);
+    this.#bdy.replaceChildren(form);
+  }
+
+  #buildNewForm(opts = {}) {
+    const form = document.createElement('form');
+    form.className = 'new-task-form';
+    form.noValidate = true;
+
+    // Error area
+    const errDiv = document.createElement('div');
+    errDiv.className = 'd-none';
+    errDiv.id = 'new-form-error';
+    form.appendChild(errDiv);
+
+    // Title
+    const titleGrp = this.#fieldGroup('newTitle', 'タイトル', true);
+    const titleInput = document.createElement('input');
+    titleInput.id = 'newTitle'; titleInput.className = 'form-control';
+    titleInput.maxLength = 100; titleInput.required = true;
+    titleInput.placeholder = '例: 設計レビュー';
+    titleInput.setAttribute('aria-required', 'true');
+    titleGrp.appendChild(titleInput);
+    form.appendChild(titleGrp);
+
+    // Description
+    const descGrp = this.#fieldGroup('newDesc', '説明', false);
+    const descTa = document.createElement('textarea');
+    descTa.id = 'newDesc'; descTa.className = 'form-control';
+    descTa.rows = 3; descTa.maxLength = 2000;
+    descTa.placeholder = '任意・最大2000文字';
+    descGrp.appendChild(descTa);
+    form.appendChild(descGrp);
+
+    // Due date + Assignee row
+    const row = document.createElement('div');
+    row.className = 'row g-3';
+
+    const dueCol = document.createElement('div');
+    dueCol.className = 'col-6';
+    const dueGrp = this.#fieldGroup('newDue', '期限日', true);
+    const dueInput = document.createElement('input');
+    dueInput.type = 'date'; dueInput.id = 'newDue';
+    dueInput.className = 'form-control'; dueInput.required = true;
+    if (opts.dueDate) dueInput.value = opts.dueDate;
+    dueGrp.appendChild(dueInput);
+    dueCol.appendChild(dueGrp);
+
+    const assCol = document.createElement('div');
+    assCol.className = 'col-6';
+    const assGrp = this.#fieldGroup('newAssignee', '担当者', false);
+    const assSel = document.createElement('select');
+    assSel.id = 'newAssignee'; assSel.className = 'form-select new-assignee-sel';
+    const emptyOpt = document.createElement('option');
+    emptyOpt.value = ''; emptyOpt.textContent = '未割当';
+    assSel.appendChild(emptyOpt);
+    this.#tenantUsers.forEach(u => {
+      const opt = document.createElement('option');
+      opt.value = u.userId; opt.textContent = u.fullName;
+      assSel.appendChild(opt);
+    });
+    assGrp.appendChild(assSel);
+    assCol.appendChild(assGrp);
+    row.append(dueCol, assCol);
+    form.appendChild(row);
+
+    // Priority
+    const priGrp = document.createElement('div');
+    priGrp.className = 'mt-3';
+    const priFs = document.createElement('fieldset');
+    const priLeg = document.createElement('legend');
+    priLeg.className = 'form-label small fw-bold';
+    priLeg.innerHTML = '優先度 <span class="text-danger" aria-hidden="true">*</span>';
+    const priBtnGrp = document.createElement('div');
+    priBtnGrp.className = 'btn-group w-100'; priBtnGrp.setAttribute('role', 'group');
+    [['HIGH','btn-outline-danger','高'],['MEDIUM','btn-outline-warning','中'],['LOW','btn-outline-secondary','低']].forEach(([val, cls, lbl], i) => {
+      const inp = document.createElement('input');
+      inp.type = 'radio'; inp.className = 'btn-check';
+      inp.name = 'newPri'; inp.id = `newPri-${val}`; inp.value = val;
+      if (i === 1) inp.checked = true;
+      const lab = document.createElement('label');
+      lab.className = `btn ${cls}`; lab.htmlFor = `newPri-${val}`;
+      lab.textContent = lbl;
+      priBtnGrp.append(inp, lab);
+    });
+    priFs.append(priLeg, priBtnGrp);
+    priGrp.appendChild(priFs);
+    form.appendChild(priGrp);
+
+    // Visibility
+    const visGrp = document.createElement('div');
+    visGrp.className = 'mt-3';
+    const visFs = document.createElement('fieldset');
+    const visLeg = document.createElement('legend');
+    visLeg.className = 'form-label small fw-bold';
+    visLeg.innerHTML = '公開範囲 <span class="text-danger" aria-hidden="true">*</span>';
+    const visBtnGrp = document.createElement('div');
+    visBtnGrp.className = 'btn-group w-100'; visBtnGrp.setAttribute('role', 'group');
+    [['TENANT','btn-outline-success','bi-globe2','テナント'],['STAKEHOLDERS','btn-outline-primary','bi-people-fill','関係者'],['PRIVATE','btn-outline-secondary','bi-lock-fill','非公開']].forEach(([val, cls, icon, lbl], i) => {
+      const inp = document.createElement('input');
+      inp.type = 'radio'; inp.className = 'btn-check';
+      inp.name = 'newVis'; inp.id = `newVis-${val}`; inp.value = val;
+      if (i === 0) inp.checked = true;
+      const lab = document.createElement('label');
+      lab.className = `btn ${cls}`; lab.htmlFor = `newVis-${val}`;
+      lab.innerHTML = `<i class="bi ${icon}" aria-hidden="true"></i> ${lbl}`;
+      visBtnGrp.append(inp, lab);
+    });
+    visFs.append(visLeg, visBtnGrp);
+    visGrp.appendChild(visFs);
+    form.appendChild(visGrp);
+
+    // Stakeholder picker (shown only when STAKEHOLDERS is selected)
+    const shSection = document.createElement('div');
+    shSection.id = 'new-sh-section'; shSection.className = 'd-none mt-3';
+    const shLabel = document.createElement('div');
+    shLabel.className = 'form-label small fw-bold'; shLabel.textContent = '関係者';
+    const shChips = document.createElement('div');
+    shChips.id = 'new-sh-chips'; shChips.className = 'drawer-chips mb-2';
+    const shRow = document.createElement('div');
+    shRow.className = 'd-flex gap-2';
+    const shSel = document.createElement('select');
+    shSel.id = 'new-sh-sel'; shSel.className = 'form-select form-select-sm flex-grow-1';
+    const shOptBlank = document.createElement('option');
+    shOptBlank.value = ''; shOptBlank.textContent = '追加する...';
+    shSel.appendChild(shOptBlank);
+    this.#tenantUsers.forEach(u => {
+      const opt = document.createElement('option');
+      opt.value = u.userId; opt.textContent = u.fullName;
+      shSel.appendChild(opt);
+    });
+    const shAddBtn = document.createElement('button');
+    shAddBtn.type = 'button'; shAddBtn.className = 'btn btn-sm btn-outline-secondary';
+    shAddBtn.textContent = '追加';
+    shRow.append(shSel, shAddBtn);
+    shSection.append(shLabel, shChips, shRow);
+    form.appendChild(shSection);
+
+    // Toggle stakeholder section on visibility change
+    visBtnGrp.addEventListener('change', () => {
+      const val = form.querySelector('input[name="newVis"]:checked')?.value;
+      shSection.classList.toggle('d-none', val !== 'STAKEHOLDERS');
+      this.#syncNewShPickerOpts(shSel, shChips);
+    });
+
+    shAddBtn.addEventListener('click', () => {
+      const uid = Number(shSel.value);
+      if (!uid) return;
+      const user = this.#tenantUsers.find(u => u.userId === uid);
+      if (!user || this.#selectedSH.some(s => s.userId === uid)) return;
+      this.#selectedSH.push({ userId: uid, fullName: user.fullName });
+      this.#renderNewShChips(shChips, shSel);
+    });
+
+    // Submit
+    const footer = document.createElement('div');
+    footer.className = 'd-flex gap-2 mt-4';
+    const submitBtn = document.createElement('button');
+    submitBtn.type = 'submit'; submitBtn.className = 'btn btn-primary flex-grow-1';
+    submitBtn.textContent = '作成';
+    const cancelBtn = document.createElement('button');
+    cancelBtn.type = 'button'; cancelBtn.className = 'btn btn-light';
+    cancelBtn.setAttribute('data-bs-dismiss', 'offcanvas'); cancelBtn.textContent = '取消';
+    footer.append(submitBtn, cancelBtn);
+    form.appendChild(footer);
+
+    form.addEventListener('submit', e => { e.preventDefault(); this.#submitNew(form); });
+    return form;
+  }
+
+  #syncNewShPickerOpts(sel, chipsEl) {
+    const currentIds = new Set(this.#selectedSH.map(s => s.userId));
+    [...sel.options].forEach(o => {
+      if (o.value === '') return;
+      o.hidden = currentIds.has(Number(o.value));
+    });
+    this.#renderNewShChips(chipsEl, sel);
+  }
+
+  #renderNewShChips(chipsEl, sel) {
+    chipsEl.replaceChildren();
+    this.#selectedSH.forEach(sh => {
+      const chip = this.#makeChip(sh.fullName, () => {
+        this.#selectedSH = this.#selectedSH.filter(s => s.userId !== sh.userId);
+        this.#syncNewShPickerOpts(sel, chipsEl);
+      });
+      chipsEl.appendChild(chip);
     });
   }
 
-  setUsers(tenantUsers) {
-    const sel = this.querySelector('.new-assignee-sel');
-    if (!sel) return;
-    // Keep the empty "未割当" option, replace user options
-    while (sel.options.length > 1) sel.remove(1);
-    tenantUsers.forEach(u => {
+  async #submitNew(form) {
+    const errDiv = form.querySelector('#new-form-error');
+    const submitBtn = form.querySelector('[type=submit]');
+    errDiv.className = 'd-none';
+
+    const title = form.querySelector('#newTitle').value.trim();
+    if (!title) {
+      errDiv.textContent = 'タイトルは必須です';
+      errDiv.className = 'alert alert-danger py-2 small mb-3';
+      return;
+    }
+    const dueDate = form.querySelector('#newDue').value;
+    if (!dueDate) {
+      errDiv.textContent = '期限日は必須です';
+      errDiv.className = 'alert alert-danger py-2 small mb-3';
+      return;
+    }
+    const priority   = form.querySelector('input[name="newPri"]:checked')?.value || 'MEDIUM';
+    const visibility = form.querySelector('input[name="newVis"]:checked')?.value || 'TENANT';
+    const assigneeId = form.querySelector('#newAssignee').value
+      ? Number(form.querySelector('#newAssignee').value) : null;
+    const desc = form.querySelector('#newDesc').value.trim() || null;
+
+    const body = { title, dueDate, priority, visibility };
+    if (desc)       body.description = desc;
+    if (assigneeId) body.assigneeId  = assigneeId;
+    if (visibility === 'STAKEHOLDERS' && this.#selectedSH.length)
+      body.stakeholderUserIds = this.#selectedSH.map(s => s.userId);
+
+    submitBtn.disabled = true;
+    submitBtn.textContent = '作成中...';
+    try {
+      const task = await Api.createTask(body);
+      this.#oc.hide();
+      this.dispatchEvent(new CustomEvent('drawer-task-created', { bubbles: true, detail: { task } }));
+    } catch (err) {
+      submitBtn.disabled = false;
+      submitBtn.textContent = '作成';
+      errDiv.textContent = '作成に失敗しました: ' + (err.message || '');
+      errDiv.className = 'alert alert-danger py-2 small mb-3';
+    }
+  }
+
+  // ---- DETAIL MODE ----
+
+  #renderDetail() {
+    const task = this.#task;
+    const hdr = this.#hdr;
+    hdr.replaceChildren();
+
+    // Header: visibility badge + title
+    const visBadge = document.createElement('span');
+    visBadge.className = `vis-badge vis-${task.visibility} me-2`;
+    visBadge.innerHTML = `<i class="bi ${VIS_ICON[task.visibility]}" aria-hidden="true"></i>${VIS_LABEL[task.visibility]}`;
+
+    const titleEl = document.createElement('h5');
+    titleEl.className = 'offcanvas-title text-truncate flex-grow-1';
+    titleEl.title = task.title;
+    titleEl.textContent = task.title;
+
+    hdr.append(visBadge, titleEl, this.#makeCloseBtn());
+
+    // Body
+    const bdy = this.#bdy;
+    bdy.replaceChildren();
+
+    // Error area
+    const errDiv = document.createElement('div');
+    errDiv.className = 'd-none';
+    errDiv.id = 'detail-error';
+    bdy.appendChild(errDiv);
+
+    // Status
+    const statusRow = document.createElement('div');
+    statusRow.className = 'mb-3';
+    const statusLabel = document.createElement('div');
+    statusLabel.className = 'drawer-field-label'; statusLabel.textContent = 'ステータス';
+    statusRow.appendChild(statusLabel);
+    if (this.#can('status')) {
+      const sel = document.createElement('select');
+      sel.className = `form-select form-select-sm d-inline-block w-auto inline-sel st-sel-${task.status}`;
+      ['NOT_STARTED','IN_PROGRESS','DONE','ON_HOLD'].forEach(s => {
+        const opt = document.createElement('option');
+        opt.value = s; opt.textContent = ST_LABEL[s]; opt.selected = s === task.status;
+        sel.appendChild(opt);
+      });
+      sel.addEventListener('change', () => this.#changeStatus(sel));
+      statusRow.appendChild(sel);
+    } else {
+      const badge = document.createElement('span');
+      badge.className = `st-badge st-${task.status}`; badge.textContent = ST_LABEL[task.status];
+      statusRow.appendChild(badge);
+    }
+    bdy.appendChild(statusRow);
+
+    // Description
+    if (task.description) {
+      const descRow = document.createElement('div');
+      descRow.className = 'mb-3';
+      const descLabel = document.createElement('div');
+      descLabel.className = 'drawer-field-label'; descLabel.textContent = '説明';
+      const descText = document.createElement('p');
+      descText.className = 'mb-0 small drawer-desc-text'; descText.textContent = task.description;
+      descRow.append(descLabel, descText);
+      bdy.appendChild(descRow);
+    }
+
+    // Meta fields grid
+    const meta = document.createElement('div');
+    meta.className = 'drawer-meta-grid mb-3';
+    const metaFields = [
+      ['優先度',   this.#makePriBadge(task.priority)],
+      ['期限',     this.#dueDateEl(task.dueDate)],
+      ['担当者',   document.createTextNode(task.assignee?.fullName ?? '—')],
+      ['所有者',   document.createTextNode(task.owner?.fullName ?? '—')],
+      ['作成日',   document.createTextNode(this.#fmtDate(task.createdAt))],
+      ['更新日',   document.createTextNode(this.#fmtDate(task.updatedAt))],
+    ];
+    if (task.completedAt) {
+      metaFields.push(['完了日時', document.createTextNode(this.#fmtDateTime(task.completedAt))]);
+    }
+    metaFields.forEach(([lbl, valNode]) => {
+      const lblEl = document.createElement('span');
+      lblEl.className = 'drawer-meta-label'; lblEl.textContent = lbl;
+      const valEl = document.createElement('span');
+      valEl.className = 'drawer-meta-value'; valEl.appendChild(valNode);
+      meta.append(lblEl, valEl);
+    });
+    bdy.appendChild(meta);
+
+    bdy.appendChild(document.createElement('hr'));
+
+    // Visibility section
+    const visRow = document.createElement('div');
+    visRow.className = 'mb-3';
+    const visLabel = document.createElement('div');
+    visLabel.className = 'drawer-field-label'; visLabel.textContent = '公開範囲';
+    visRow.appendChild(visLabel);
+    const visBadge2 = document.createElement('span');
+    visBadge2.className = `vis-badge vis-${task.visibility}`;
+    visBadge2.innerHTML = `<i class="bi ${VIS_ICON[task.visibility]}" aria-hidden="true"></i>${VIS_LABEL[task.visibility]}`;
+    visRow.appendChild(visBadge2);
+    if (this.#can('visibility')) {
+      const changeBtn = document.createElement('button');
+      changeBtn.type = 'button';
+      changeBtn.className = 'btn btn-link btn-sm ms-2 p-0';
+      changeBtn.textContent = '変更';
+      changeBtn.addEventListener('click', () => this.#showVisibilityPicker(visRow));
+      visRow.appendChild(changeBtn);
+    }
+    bdy.appendChild(visRow);
+
+    // Stakeholders section
+    bdy.appendChild(this.#buildStakeholdersSection());
+
+    bdy.appendChild(document.createElement('hr'));
+
+    // Action buttons
+    const actions = document.createElement('div');
+    actions.className = 'd-flex gap-2 flex-wrap';
+    if (this.#can('edit')) {
+      const editBtn = document.createElement('button');
+      editBtn.type = 'button'; editBtn.className = 'btn btn-primary btn-sm';
+      editBtn.innerHTML = '<i class="bi bi-pencil me-1" aria-hidden="true"></i>編集';
+      editBtn.addEventListener('click', () => this.#switchToEdit());
+      actions.appendChild(editBtn);
+    }
+    if (this.#can('delete')) {
+      const delBtn = document.createElement('button');
+      delBtn.type = 'button'; delBtn.className = 'btn btn-outline-danger btn-sm';
+      delBtn.innerHTML = '<i class="bi bi-trash me-1" aria-hidden="true"></i>削除';
+      delBtn.addEventListener('click', () => this.#showDeleteConfirm(actions));
+      actions.appendChild(delBtn);
+    }
+    if (actions.children.length) bdy.appendChild(actions);
+  }
+
+  #buildStakeholdersSection() {
+    const section = document.createElement('div');
+    section.className = 'mb-3';
+    const label = document.createElement('div');
+    label.className = 'drawer-field-label'; label.textContent = '関係者';
+    section.appendChild(label);
+
+    const chips = document.createElement('div');
+    chips.className = 'drawer-chips';
+    if (this.#stakeholders.length === 0) {
+      const empty = document.createElement('span');
+      empty.className = 'text-muted small'; empty.textContent = 'なし';
+      chips.appendChild(empty);
+    } else {
+      this.#stakeholders.forEach(sh => {
+        const rmFn = this.#can('stakeholder')
+          ? () => this.#removeStakeholder(sh.userId)
+          : null;
+        chips.appendChild(this.#makeChip(sh.fullName, rmFn));
+      });
+    }
+    section.appendChild(chips);
+
+    if (this.#can('stakeholder')) {
+      const addRow = document.createElement('div');
+      addRow.className = 'd-flex gap-2 mt-2';
+      const sel = document.createElement('select');
+      sel.className = 'form-select form-select-sm flex-grow-1';
+      const blankOpt = document.createElement('option');
+      blankOpt.value = ''; blankOpt.textContent = '関係者を追加...';
+      sel.appendChild(blankOpt);
+      const existIds = new Set(this.#stakeholders.map(s => s.userId));
+      this.#tenantUsers.forEach(u => {
+        if (existIds.has(u.userId)) return;
+        const opt = document.createElement('option');
+        opt.value = u.userId; opt.textContent = u.fullName;
+        sel.appendChild(opt);
+      });
+      const addBtn = document.createElement('button');
+      addBtn.type = 'button'; addBtn.className = 'btn btn-sm btn-outline-secondary';
+      addBtn.textContent = '追加';
+      addBtn.addEventListener('click', () => this.#addStakeholder(Number(sel.value)));
+      addRow.append(sel, addBtn);
+      section.appendChild(addRow);
+    }
+    return section;
+  }
+
+  #showVisibilityPicker(visRow) {
+    // Replace the row content with an inline selector
+    const task = this.#task;
+    visRow.replaceChildren();
+    const lbl = document.createElement('div');
+    lbl.className = 'drawer-field-label'; lbl.textContent = '公開範囲';
+    const sel = document.createElement('select');
+    sel.className = 'form-select form-select-sm d-inline-block w-auto me-2';
+    Object.entries(VIS_LABEL).forEach(([val, name]) => {
       const opt = document.createElement('option');
-      opt.value       = u.userId;
-      opt.textContent = u.fullName;
+      opt.value = val; opt.textContent = name; opt.selected = val === task.visibility;
       sel.appendChild(opt);
     });
+
+    // SH picker shown when STAKEHOLDERS
+    const shSection = document.createElement('div');
+    shSection.className = 'mt-2 d-none';
+    const shSel = document.createElement('select');
+    shSel.className = 'form-select form-select-sm flex-grow-1';
+    const shOptBlank = document.createElement('option');
+    shOptBlank.value = ''; shOptBlank.textContent = '関係者を選択...';
+    shSel.appendChild(shOptBlank);
+    this.#tenantUsers.forEach(u => {
+      const opt = document.createElement('option');
+      opt.value = u.userId; opt.textContent = u.fullName;
+      opt.selected = this.#stakeholders.some(s => s.userId === u.userId);
+      shSel.appendChild(opt);
+    });
+    shSel.multiple = true;
+    shSection.appendChild(shSel);
+
+    sel.addEventListener('change', () => {
+      shSection.classList.toggle('d-none', sel.value !== 'STAKEHOLDERS');
+    });
+    if (task.visibility === 'STAKEHOLDERS') shSection.classList.remove('d-none');
+
+    const saveBtn = document.createElement('button');
+    saveBtn.type = 'button'; saveBtn.className = 'btn btn-sm btn-primary me-1';
+    saveBtn.textContent = '保存';
+    const cancelBtn = document.createElement('button');
+    cancelBtn.type = 'button'; cancelBtn.className = 'btn btn-sm btn-light';
+    cancelBtn.textContent = '取消';
+
+    saveBtn.addEventListener('click', async () => {
+      const newVis = sel.value;
+      let shIds;
+      if (newVis === 'STAKEHOLDERS') {
+        shIds = [...shSel.selectedOptions].map(o => Number(o.value)).filter(Boolean);
+      }
+      saveBtn.disabled = true; saveBtn.textContent = '保存中...';
+      try {
+        await Api.changeVisibility(task.id, newVis, shIds);
+        // Reload task + stakeholders and re-render
+        await this.#loadAndRenderDetail(task.id);
+        this.dispatchEvent(new CustomEvent('drawer-task-updated', {
+          bubbles: true,
+          detail: { task: this.#task },
+        }));
+      } catch (err) {
+        this.#showDetailError('公開範囲の変更に失敗しました: ' + (err.message || ''));
+        this.#renderDetail();
+      }
+    });
+
+    cancelBtn.addEventListener('click', () => this.#renderDetail());
+
+    const btnRow = document.createElement('div');
+    btnRow.className = 'mt-2'; btnRow.append(saveBtn, cancelBtn);
+    visRow.append(lbl, sel, shSection, btnRow);
   }
 
-  open() {
-    if (!this.#offcanvasEl) return;
-    this.querySelector('.new-task-form')?.reset();
-    bootstrap.Offcanvas.getOrCreateInstance(this.#offcanvasEl).show();
+  #showDeleteConfirm(actionsEl) {
+    actionsEl.replaceChildren();
+    const msg = document.createElement('span');
+    msg.className = 'small text-danger me-2 align-self-center';
+    msg.textContent = `「${this.#task.title}」を削除しますか？`;
+    const doBtn = document.createElement('button');
+    doBtn.type = 'button'; doBtn.className = 'btn btn-danger btn-sm';
+    doBtn.textContent = '削除する';
+    const cancelBtn = document.createElement('button');
+    cancelBtn.type = 'button'; cancelBtn.className = 'btn btn-light btn-sm';
+    cancelBtn.textContent = '取消';
+
+    doBtn.addEventListener('click', async () => {
+      doBtn.disabled = true; doBtn.textContent = '削除中...';
+      try {
+        await Api.deleteTask(this.#task.id, this.#etag);
+        const taskId = this.#task.id;
+        this.#oc.hide();
+        this.dispatchEvent(new CustomEvent('drawer-task-deleted', {
+          bubbles: true,
+          detail: { taskId },
+        }));
+      } catch (err) {
+        if (err.status === 412) {
+          this.#showDetailError('他のユーザーがこのタスクを編集しました。ページを再読み込みしてください。');
+        } else {
+          this.#showDetailError('削除に失敗しました: ' + (err.message || ''));
+        }
+        this.#renderDetail();
+      }
+    });
+
+    cancelBtn.addEventListener('click', () => this.#renderDetail());
+    actionsEl.append(msg, doBtn, cancelBtn);
+  }
+
+  #showDetailError(msg) {
+    const errDiv = this.#bdy.querySelector('#detail-error');
+    if (!errDiv) return;
+    errDiv.textContent = msg;
+    errDiv.className = 'alert alert-danger py-2 small mb-3';
+  }
+
+  async #changeStatus(sel) {
+    const task = this.#task;
+    const prev = task.status;
+    sel.disabled = true;
+    try {
+      const updated = await Api.changeStatus(task.id, sel.value);
+      this.#task = updated;
+      if (updated.version != null) this.#etag = `W/"${updated.version}"`;
+      this.dispatchEvent(new CustomEvent('drawer-task-updated', {
+        bubbles: true,
+        detail: { task: updated },
+      }));
+      this.#renderDetail();
+    } catch (err) {
+      sel.value = prev;
+      sel.disabled = false;
+      this.#showDetailError('ステータスの更新に失敗しました: ' + (err.message || ''));
+    }
+  }
+
+  async #addStakeholder(userId) {
+    if (!userId) return;
+    try {
+      const sh = await Api.addStakeholder(this.#task.id, userId);
+      this.#stakeholders = [...this.#stakeholders, sh];
+      this.#renderDetail();
+    } catch (err) {
+      this.#showDetailError(
+        err.status === 409
+          ? 'このユーザーはすでに関係者です'
+          : '関係者の追加に失敗しました: ' + (err.message || ''),
+      );
+    }
+  }
+
+  async #removeStakeholder(userId) {
+    try {
+      await Api.removeStakeholder(this.#task.id, userId);
+      this.#stakeholders = this.#stakeholders.filter(s => s.userId !== userId);
+      this.#renderDetail();
+    } catch (err) {
+      this.#showDetailError('関係者の削除に失敗しました: ' + (err.message || ''));
+    }
+  }
+
+  // ---- EDIT MODE ----
+
+  #switchToEdit() {
+    this.#mode = 'edit';
+    this.#replaceUrl(`/tasks/${this.#task.id}/edit`);
+    this.#renderEdit();
+  }
+
+  #switchToDetail() {
+    this.#mode = 'detail';
+    this.#replaceUrl(`/tasks/${this.#task.id}`);
+    this.#renderDetail();
+  }
+
+  #renderEdit() {
+    const task = this.#task;
+    const hdr = this.#hdr;
+    hdr.replaceChildren();
+    const title = document.createElement('h5');
+    title.className = 'offcanvas-title text-truncate flex-grow-1';
+    title.textContent = 'タスク編集';
+    hdr.append(title, this.#makeCloseBtn());
+
+    const bdy = this.#bdy;
+    bdy.replaceChildren();
+
+    const errDiv = document.createElement('div');
+    errDiv.className = 'd-none'; errDiv.id = 'edit-form-error';
+    bdy.appendChild(errDiv);
+
+    const form = document.createElement('form');
+    form.noValidate = true;
+    bdy.appendChild(form);
+
+    // Title
+    const titleGrp = this.#fieldGroup('editTitle', 'タイトル', true);
+    const titleInput = document.createElement('input');
+    titleInput.id = 'editTitle'; titleInput.className = 'form-control';
+    titleInput.maxLength = 100; titleInput.required = true;
+    titleInput.value = task.title;
+    titleGrp.appendChild(titleInput);
+    form.appendChild(titleGrp);
+
+    // Description
+    const descGrp = this.#fieldGroup('editDesc', '説明', false);
+    const descTa = document.createElement('textarea');
+    descTa.id = 'editDesc'; descTa.className = 'form-control';
+    descTa.rows = 4; descTa.maxLength = 2000;
+    descTa.value = task.description || '';
+    descGrp.appendChild(descTa);
+    form.appendChild(descGrp);
+
+    // Due + Assignee row
+    const row = document.createElement('div'); row.className = 'row g-3';
+    const dueCol = document.createElement('div'); dueCol.className = 'col-6';
+    const dueGrp = this.#fieldGroup('editDue', '期限日', true);
+    const dueInput = document.createElement('input');
+    dueInput.type = 'date'; dueInput.id = 'editDue';
+    dueInput.className = 'form-control'; dueInput.required = true;
+    dueInput.value = task.dueDate || '';
+    dueGrp.appendChild(dueInput);
+    dueCol.appendChild(dueGrp);
+
+    const assCol = document.createElement('div'); assCol.className = 'col-6';
+    const assGrp = this.#fieldGroup('editAssignee', '担当者', false);
+    const assSel = document.createElement('select');
+    assSel.id = 'editAssignee'; assSel.className = 'form-select';
+    const emptyOpt = document.createElement('option');
+    emptyOpt.value = ''; emptyOpt.textContent = '未割当';
+    assSel.appendChild(emptyOpt);
+    this.#tenantUsers.forEach(u => {
+      const opt = document.createElement('option');
+      opt.value = u.userId; opt.textContent = u.fullName;
+      opt.selected = task.assignee?.id === u.userId;
+      assSel.appendChild(opt);
+    });
+    assGrp.appendChild(assSel);
+    assCol.appendChild(assGrp);
+    row.append(dueCol, assCol);
+    form.appendChild(row);
+
+    // Priority
+    const priGrp = document.createElement('div'); priGrp.className = 'mt-3';
+    const priFs = document.createElement('fieldset');
+    const priLeg = document.createElement('legend');
+    priLeg.className = 'form-label small fw-bold';
+    priLeg.innerHTML = '優先度 <span class="text-danger" aria-hidden="true">*</span>';
+    const priBtnGrp = document.createElement('div');
+    priBtnGrp.className = 'btn-group w-100'; priBtnGrp.setAttribute('role', 'group');
+    [['HIGH','btn-outline-danger','高'],['MEDIUM','btn-outline-warning','中'],['LOW','btn-outline-secondary','低']].forEach(([val, cls, lbl]) => {
+      const inp = document.createElement('input');
+      inp.type = 'radio'; inp.className = 'btn-check';
+      inp.name = 'editPri'; inp.id = `editPri-${val}`; inp.value = val;
+      inp.checked = task.priority === val;
+      const lab = document.createElement('label');
+      lab.className = `btn ${cls}`; lab.htmlFor = `editPri-${val}`;
+      lab.textContent = lbl;
+      priBtnGrp.append(inp, lab);
+    });
+    priFs.append(priLeg, priBtnGrp);
+    priGrp.appendChild(priFs);
+    form.appendChild(priGrp);
+
+    // Buttons
+    const footer = document.createElement('div');
+    footer.className = 'd-flex gap-2 mt-4';
+    const saveBtn = document.createElement('button');
+    saveBtn.type = 'submit'; saveBtn.className = 'btn btn-primary flex-grow-1';
+    saveBtn.textContent = '保存';
+    const cancelBtn = document.createElement('button');
+    cancelBtn.type = 'button'; cancelBtn.className = 'btn btn-light';
+    cancelBtn.textContent = '取消';
+    cancelBtn.addEventListener('click', () => this.#switchToDetail());
+    footer.append(saveBtn, cancelBtn);
+    form.appendChild(footer);
+
+    form.addEventListener('submit', e => { e.preventDefault(); this.#submitEdit(form); });
+  }
+
+  async #submitEdit(form) {
+    const errDiv = this.#bdy.querySelector('#edit-form-error');
+    const saveBtn = form.querySelector('[type=submit]');
+    errDiv.className = 'd-none';
+
+    const title = form.querySelector('#editTitle').value.trim();
+    if (!title) {
+      errDiv.textContent = 'タイトルは必須です';
+      errDiv.className = 'alert alert-danger py-2 small mb-3';
+      return;
+    }
+    const dueDate = form.querySelector('#editDue').value;
+    if (!dueDate) {
+      errDiv.textContent = '期限日は必須です';
+      errDiv.className = 'alert alert-danger py-2 small mb-3';
+      return;
+    }
+
+    const priority   = form.querySelector('input[name="editPri"]:checked')?.value;
+    const assigneeId = form.querySelector('#editAssignee').value
+      ? Number(form.querySelector('#editAssignee').value) : null;
+    const desc = form.querySelector('#editDesc').value.trim() || null;
+
+    const body = {};
+    if (title    !== this.#task.title)         body.title       = title;
+    if (dueDate  !== this.#task.dueDate)        body.dueDate     = dueDate;
+    if (priority !== this.#task.priority)       body.priority    = priority;
+    // description: null to clear, string to set
+    const prevDesc = this.#task.description || null;
+    if (desc !== prevDesc) body.description = desc;
+    // assigneeId: null to clear
+    const prevAss = this.#task.assignee?.id ?? null;
+    if (assigneeId !== prevAss) body.assigneeId = assigneeId;
+
+    if (Object.keys(body).length === 0) {
+      // No changes — just go back to detail
+      this.#switchToDetail();
+      return;
+    }
+
+    saveBtn.disabled = true; saveBtn.textContent = '保存中...';
+    try {
+      const updated = await Api.patchTask(this.#task.id, this.#etag, body);
+      this.#task = updated;
+      // Re-fetch ETag from updated task (patchTask returns TaskDetail with version)
+      this.#etag = updated.version != null ? `W/"${updated.version}"` : this.#etag;
+      this.dispatchEvent(new CustomEvent('drawer-task-updated', {
+        bubbles: true,
+        detail: { task: updated },
+      }));
+      this.#switchToDetail();
+    } catch (err) {
+      saveBtn.disabled = false; saveBtn.textContent = '保存';
+      if (err.status === 412) {
+        errDiv.textContent = '他のユーザーがこのタスクを編集しました。一旦閉じてから再度開いてください。';
+      } else if (err.status === 403) {
+        errDiv.textContent = '編集権限がありません';
+      } else {
+        errDiv.textContent = '保存に失敗しました: ' + (err.message || '');
+      }
+      errDiv.className = 'alert alert-danger py-2 small mb-3';
+    }
+  }
+
+  // ---- Utilities ----
+
+  #fieldGroup(id, label, required) {
+    const grp = document.createElement('div');
+    grp.className = 'mb-3';
+    const lbl = document.createElement('label');
+    lbl.className = 'form-label small fw-bold';
+    lbl.htmlFor = id;
+    lbl.textContent = label;
+    if (required) {
+      const star = document.createElement('span');
+      star.className = 'text-danger ms-1'; star.setAttribute('aria-hidden', 'true');
+      star.textContent = '*';
+      lbl.appendChild(star);
+    }
+    grp.appendChild(lbl);
+    return grp;
+  }
+
+  #makeChip(label, onRemove) {
+    const chip = document.createElement('span');
+    chip.className = 'drawer-chip';
+    chip.textContent = label;
+    if (onRemove) {
+      const rm = document.createElement('button');
+      rm.type = 'button'; rm.className = 'drawer-chip-rm';
+      rm.setAttribute('aria-label', `${label}を削除`);
+      rm.innerHTML = '&times;';
+      rm.addEventListener('click', onRemove);
+      chip.appendChild(rm);
+    }
+    return chip;
+  }
+
+  #makePriBadge(priority) {
+    const span = document.createElement('span');
+    span.className = `pri-badge pri-${priority}`; span.textContent = PRI_LABEL[priority];
+    return span;
+  }
+
+  #dueDateEl(dueDate) {
+    if (!dueDate) return document.createTextNode('—');
+    const today = new Date(
+      new Intl.DateTimeFormat('en-CA', { timeZone: 'Asia/Tokyo' }).format(new Date()) + 'T00:00:00'
+    );
+    const due  = new Date(dueDate + 'T00:00:00');
+    const diff = Math.round((due - today) / 86400000);
+    const md   = dueDate.slice(5).replace('-', '/');
+    if (diff < 0) {
+      const span = document.createElement('span');
+      span.className = 'due-overdue'; span.textContent = `${dueDate}(${diff}日)`;
+      return span;
+    }
+    if (diff === 0) {
+      const span = document.createElement('span');
+      span.className = 'due-today'; span.textContent = `今日 (${md})`;
+      return span;
+    }
+    return document.createTextNode(`${dueDate} (あと${diff}日)`);
+  }
+
+  #fmtDate(iso) {
+    if (!iso) return '—';
+    return new Intl.DateTimeFormat('ja-JP', {
+      timeZone: 'Asia/Tokyo', year: 'numeric', month: '2-digit', day: '2-digit',
+    }).format(new Date(iso));
+  }
+
+  #fmtDateTime(iso) {
+    if (!iso) return '—';
+    return new Intl.DateTimeFormat('ja-JP', {
+      timeZone: 'Asia/Tokyo',
+      year: 'numeric', month: '2-digit', day: '2-digit',
+      hour: '2-digit', minute: '2-digit',
+    }).format(new Date(iso));
   }
 }
+
 customElements.define('app-task-drawer', AppTaskDrawer);

--- a/web/js/tasks.js
+++ b/web/js/tasks.js
@@ -194,9 +194,9 @@ function updateSortCarets() {
   });
 }
 
-// ---- Row click (S-05 detail — wired in later sprint) ----
+// ---- Row click → open detail drawer (S-05) ----
 function onRowClick(id) {
-  console.log('task row clicked:', id);
+  taskDrawer.openDetail(id);
 }
 
 // ---- Event listeners on CEs ----
@@ -220,6 +220,16 @@ errorBanner.addEventListener('error-retry', loadTasks);
 
 // app-conflict-banner
 conflictBanner.addEventListener('conflict-reload', () => { conflictBanner.hide(); loadTasks(); });
+
+// app-task-drawer events
+taskDrawer.addEventListener('drawer-task-created', () => loadTasks());
+taskDrawer.addEventListener('drawer-task-deleted', () => loadTasks());
+taskDrawer.addEventListener('drawer-task-updated', e => {
+  const updated = e.detail?.task;
+  if (!updated) { loadTasks(); return; }
+  taskMap.set(updated.id, updated);
+  rerenderRow(updated.id);
+});
 
 // app-pager
 pager.addEventListener('page-change', e => {
@@ -250,6 +260,7 @@ async function main() {
   }
 
   currentUserId = me.user?.id ?? null;
+  taskDrawer.setCurrentUser(currentUserId);
 
   const user = Auth.getUser();
   const displayName = user?.name || user?.preferred_username || '';
@@ -279,6 +290,19 @@ async function main() {
 
   updateSortCarets();
   await loadTasks();
+
+  // Auto-open drawer based on URL path (direct URL / page reload with task URL)
+  const path = location.pathname;
+  const newMatch    = /\/tasks\/new\/?$/.exec(path);
+  const editMatch   = /\/tasks\/(\d+)\/edit\/?$/.exec(path);
+  const detailMatch = /\/tasks\/(\d+)\/?$/.exec(path);
+  if (newMatch) {
+    taskDrawer.openNew();
+  } else if (editMatch) {
+    await taskDrawer.openEdit(Number(editMatch[1]));
+  } else if (detailMatch) {
+    await taskDrawer.openDetail(Number(detailMatch[1]));
+  }
 }
 
 main();


### PR DESCRIPTION
## Summary

- `app-task-drawer.js` を 3 モード(new / detail / edit)の Custom Element に全面改修。Bootstrap Offcanvas を再利用しつつ、モードごとにヘッダ・ボディを動的構築する
- `api.js` に不足していた 8 エンドポイント(getTask / createTask / deleteTask / changeVisibility / stakeholder CRUD)を追加
- `tasks.js` で行クリック → `openDetail`、ドロワーイベント受信、URL ベースの自動オープンを追加
- `app.css` にドロワーコンテンツ用スタイル(`.drawer-field-label`, `.drawer-meta-grid`, `.drawer-chip` 等)を追加

## 変更詳細

### new モード
- 7 フィールド(タイトル / 説明 / 期限 / 担当者 / 優先度 / 公開範囲)のフォーム
- `visibility = STAKEHOLDERS` 選択時のみ関係者ピッカーセクション(チップ型 + ドロップダウン)を表示
- 作成成功後 `drawer-task-created` イベントを発火 → 一覧リロード

### detail モード
- 全フィールド表示 + メタグリッド(所有者 / 担当者 / 日付 / 完了日時)
- ステータス変更(所有者 ∪ 担当者): inline select、成功後 ETag を更新
- visibility 変更(所有者のみ): inline ピッカー + `STAKEHOLDERS` 時の multi-select、変更後 GET で再取得
- 関係者追加・削除(所有者 ∪ 担当者): チップ表示 + ドロップダウン追加
- 削除(所有者のみ): フッタ内インライン確認ダイアログ(モーダル不使用)

### edit モード
- タイトル / 説明 / 期限 / 担当者 / 優先度の部分更新フォーム
- 変更なし時はリクエスト省略、保存後は detail モードに戻る
- 412 / 403 のエラーメッセージをフォーム上部に表示

### URL 同期(screen-flow.md §5.3)
- 開く: `history.pushState` で `/tasks/new` / `/tasks/{id}` / `/tasks/{id}/edit` に同期
- モード切替(detail ↔ edit): `history.replaceState`(履歴エントリを増やさない)
- 閉じる: `history.replaceState` で元の URL に戻る
- ブラウザバック: `popstate` でドロワーを閉じる
- 直 URL アクセス: `tasks.js main()` で `location.pathname` を検出して自動オープン

### 認可 UI(ADR-0005)
- `editable` = 所有者のみ `true` → 編集 / 削除 / visibility 変更ボタンの表示制御
- `canStakeholder` = `editable || assignee.id === currentUserId` → 関係者追加・削除の表示制御
- `canStatus` = 同上 → ステータス select の活性制御

## 懸念事項(#476 コメントに詳細)
- `/tasks.html` の URL ハードコード → #480/#483(CloudFront)確定後に要更新
- 直 URL の本格 fallback → #483 CloudFront の URL ルーティング設定が必要

## Test plan
- [ ] `+ 新規` ボタン → ドロワー開 / URL が `/tasks/new` に変化 / 作成 → 一覧リロード
- [ ] 行クリック → detail ドロワー / URL が `/tasks/{id}` に変化 / ブラウザバックで閉じる
- [ ] detail → 「編集」 → edit モード / URL が `/tasks/{id}/edit` に変化 / 保存 → detail 戻り
- [ ] 所有者でない行のドロワー: 編集・削除ボタン非表示、status select 非活性
- [ ] 担当者の行のドロワー: status select 活性、関係者追加可、編集ボタン非表示
- [ ] `visibility=STAKEHOLDERS` 新規作成 → 関係者ピッカー表示 / 選択して作成
- [ ] 削除: 確認ダイアログ → 実行 → ドロワー閉 / 一覧リロード
- [ ] 412 発生時: エラーメッセージ表示

Closes #476

🤖 Generated with [Claude Code](https://claude.com/claude-code)