### PR TITLE
feat(web): ADR-0025 S3 — html-validate + v.Nu 導入(CE メタデータ + inline 退行ガード + web-ci.yml 組込み)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -54,6 +54,9 @@ npx biome check --write .
 
 # Apply all fixes including unsafe (template literals, node: protocol, etc.)
 npx biome check --write --unsafe .
+
+# html-validate — HTML Living Standard 準拠 + CE メタデータ検証
+npm run html-validate
 ```
 
 ## Code Quality Toolchain

--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -104,9 +104,10 @@ jobs:
               -H "Content-Type: text/html; charset=utf-8" \
               --data-binary @"$f" \
               "http://localhost:8888/?out=gnu")
-            if [ -n "$(printf '%s' "$out" | tr -d '[:space:]')" ]; then
+            error_lines=$(printf '%s\n' "$out" | grep ': error:' || true)
+            if [ -n "$error_lines" ]; then
               echo "::error::v.Nu: $f"
-              printf '%s\n' "$out"
+              printf '%s\n' "$error_lines"
               errors=1
             fi
           done

--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -96,12 +96,22 @@ jobs:
       - name: Nu Html Checker (v.Nu — Living Standard 準拠)
         id: vnu
         run: |
-          docker run --rm \
-            -v "${{ github.workspace }}/web:/workdir:ro" \
-            ghcr.io/validator/validator:latest \
-            --skip-non-html \
-            /workdir/index.html \
-            /workdir/tasks.html
+          docker run -d --rm --name vnu-server -p 8888:8888 ghcr.io/validator/validator:latest
+          timeout 30 bash -c 'until curl -sf http://localhost:8888/ >/dev/null 2>&1; do sleep 1; done'
+          errors=0
+          for f in index.html tasks.html; do
+            out=$(curl -s \
+              -H "Content-Type: text/html; charset=utf-8" \
+              --data-binary @"$f" \
+              "http://localhost:8888/?out=gnu")
+            if [ -n "$(printf '%s' "$out" | tr -d '[:space:]')" ]; then
+              echo "::error::v.Nu: $f"
+              printf '%s\n' "$out"
+              errors=1
+            fi
+          done
+          docker stop vnu-server || true
+          exit "$errors"
 
       - name: Build CI report
         id: ci-report

--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -89,6 +89,20 @@ jobs:
         id: biome
         run: npx biome ci .
 
+      - name: html-validate (CE metadata + inline guard)
+        id: html-validate
+        run: npx html-validate index.html tasks.html
+
+      - name: Nu Html Checker (v.Nu — Living Standard 準拠)
+        id: vnu
+        run: |
+          docker run --rm \
+            -v "${{ github.workspace }}/web:/workdir:ro" \
+            ghcr.io/validator/validator:latest \
+            --skip-non-html \
+            /workdir/index.html \
+            /workdir/tasks.html
+
       - name: Build CI report
         id: ci-report
         if: always() && github.event_name == 'pull_request'
@@ -97,6 +111,8 @@ jobs:
           COPY_OUTCOME: ${{ steps.copy-vendor.outcome }}
           VENDOR_OUTCOME: ${{ steps.vendor-check.outcome }}
           BIOME_OUTCOME: ${{ steps.biome.outcome }}
+          HTML_VALIDATE_OUTCOME: ${{ steps.html-validate.outcome }}
+          VNU_OUTCOME: ${{ steps.vnu.outcome }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           RUN_NUM: ${{ github.run_number }}
           GH_SHA: ${{ github.sha }}
@@ -114,6 +130,8 @@ jobs:
             echo "| copy-vendor $(icon "$COPY_OUTCOME") | vendor アセットコピー |"
             echo "| vendor check $(icon "$VENDOR_OUTCOME") | 主要ファイル存在確認 |"
             echo "| biome ci $(icon "$BIOME_OUTCOME") | lint / format 検証 |"
+            echo "| html-validate $(icon "$HTML_VALIDATE_OUTCOME") | CE メタデータ + inline 退行ガード |"
+            echo "| v.Nu $(icon "$VNU_OUTCOME") | Living Standard 準拠検証 |"
             echo ""
             echo "_最終更新: ${NOW}_"
             echo '__CI_REPORT_EOF__'

--- a/web/.htmlvalidate.json
+++ b/web/.htmlvalidate.json
@@ -1,0 +1,171 @@
+{
+  "$schema": "https://html-validate.org/schemas/config.json",
+  "extends": ["html-validate:recommended"],
+  "elements": [
+    "html5",
+    {
+      "*": {
+        "attributes": {
+          "onclick": {
+            "deprecated": "インラインイベントハンドラは禁止です。addEventListener を使用してください(ADR-0022: CSP script-src 'self')"
+          },
+          "ondblclick": {
+            "deprecated": "インラインイベントハンドラは禁止です。addEventListener を使用してください(ADR-0022)"
+          },
+          "oncontextmenu": {
+            "deprecated": "インラインイベントハンドラは禁止です。addEventListener を使用してください(ADR-0022)"
+          },
+          "onmousedown": {
+            "deprecated": "インラインイベントハンドラは禁止です。addEventListener を使用してください(ADR-0022)"
+          },
+          "onmouseup": {
+            "deprecated": "インラインイベントハンドラは禁止です。addEventListener を使用してください(ADR-0022)"
+          },
+          "onmousemove": {
+            "deprecated": "インラインイベントハンドラは禁止です。addEventListener を使用してください(ADR-0022)"
+          },
+          "onmouseover": {
+            "deprecated": "インラインイベントハンドラは禁止です。addEventListener を使用してください(ADR-0022)"
+          },
+          "onmouseout": {
+            "deprecated": "インラインイベントハンドラは禁止です。addEventListener を使用してください(ADR-0022)"
+          },
+          "onmouseenter": {
+            "deprecated": "インラインイベントハンドラは禁止です。addEventListener を使用してください(ADR-0022)"
+          },
+          "onmouseleave": {
+            "deprecated": "インラインイベントハンドラは禁止です。addEventListener を使用してください(ADR-0022)"
+          },
+          "onwheel": {
+            "deprecated": "インラインイベントハンドラは禁止です。addEventListener を使用してください(ADR-0022)"
+          },
+          "onkeydown": {
+            "deprecated": "インラインイベントハンドラは禁止です。addEventListener を使用してください(ADR-0022)"
+          },
+          "onkeyup": {
+            "deprecated": "インラインイベントハンドラは禁止です。addEventListener を使用してください(ADR-0022)"
+          },
+          "onkeypress": {
+            "deprecated": "インラインイベントハンドラは禁止です。addEventListener を使用してください(ADR-0022)"
+          },
+          "onfocus": {
+            "deprecated": "インラインイベントハンドラは禁止です。addEventListener を使用してください(ADR-0022)"
+          },
+          "onblur": {
+            "deprecated": "インラインイベントハンドラは禁止です。addEventListener を使用してください(ADR-0022)"
+          },
+          "onchange": {
+            "deprecated": "インラインイベントハンドラは禁止です。addEventListener を使用してください(ADR-0022)"
+          },
+          "oninput": {
+            "deprecated": "インラインイベントハンドラは禁止です。addEventListener を使用してください(ADR-0022)"
+          },
+          "onsubmit": {
+            "deprecated": "インラインイベントハンドラは禁止です。addEventListener を使用してください(ADR-0022)"
+          },
+          "onreset": {
+            "deprecated": "インラインイベントハンドラは禁止です。addEventListener を使用してください(ADR-0022)"
+          },
+          "oninvalid": {
+            "deprecated": "インラインイベントハンドラは禁止です。addEventListener を使用してください(ADR-0022)"
+          },
+          "oncopy": {
+            "deprecated": "インラインイベントハンドラは禁止です。addEventListener を使用してください(ADR-0022)"
+          },
+          "oncut": {
+            "deprecated": "インラインイベントハンドラは禁止です。addEventListener を使用してください(ADR-0022)"
+          },
+          "onpaste": {
+            "deprecated": "インラインイベントハンドラは禁止です。addEventListener を使用してください(ADR-0022)"
+          },
+          "ondrag": {
+            "deprecated": "インラインイベントハンドラは禁止です。addEventListener を使用してください(ADR-0022)"
+          },
+          "ondragend": {
+            "deprecated": "インラインイベントハンドラは禁止です。addEventListener を使用してください(ADR-0022)"
+          },
+          "ondragenter": {
+            "deprecated": "インラインイベントハンドラは禁止です。addEventListener を使用してください(ADR-0022)"
+          },
+          "ondragleave": {
+            "deprecated": "インラインイベントハンドラは禁止です。addEventListener を使用してください(ADR-0022)"
+          },
+          "ondragover": {
+            "deprecated": "インラインイベントハンドラは禁止です。addEventListener を使用してください(ADR-0022)"
+          },
+          "ondragstart": {
+            "deprecated": "インラインイベントハンドラは禁止です。addEventListener を使用してください(ADR-0022)"
+          },
+          "ondrop": {
+            "deprecated": "インラインイベントハンドラは禁止です。addEventListener を使用してください(ADR-0022)"
+          },
+          "onload": {
+            "deprecated": "インラインイベントハンドラは禁止です。addEventListener を使用してください(ADR-0022)"
+          },
+          "onerror": {
+            "deprecated": "インラインイベントハンドラは禁止です。addEventListener を使用してください(ADR-0022)"
+          },
+          "onscroll": {
+            "deprecated": "インラインイベントハンドラは禁止です。addEventListener を使用してください(ADR-0022)"
+          },
+          "onresize": {
+            "deprecated": "インラインイベントハンドラは禁止です。addEventListener を使用してください(ADR-0022)"
+          },
+          "ontoggle": {
+            "deprecated": "インラインイベントハンドラは禁止です。addEventListener を使用してください(ADR-0022)"
+          },
+          "onclose": {
+            "deprecated": "インラインイベントハンドラは禁止です。addEventListener を使用してください(ADR-0022)"
+          }
+        }
+      },
+      "app-conflict-banner": {
+        "flow": true
+      },
+      "app-desc-popover": {
+        "flow": true
+      },
+      "app-error-banner": {
+        "flow": true
+      },
+      "app-pager": {
+        "flow": true
+      },
+      "app-priority-badge": {
+        "flow": true,
+        "phrasing": true,
+        "attributes": {
+          "priority": {},
+          "editable": { "boolean": true },
+          "task-id": {}
+        }
+      },
+      "app-status-badge": {
+        "flow": true,
+        "phrasing": true,
+        "attributes": {
+          "status": {},
+          "editable": { "boolean": true },
+          "task-id": {}
+        }
+      },
+      "app-task-drawer": {
+        "flow": true
+      },
+      "app-task-row": {
+        "flow": true
+      },
+      "app-tenant-switcher": {
+        "flow": true,
+        "phrasing": true
+      },
+      "app-visibility-badge": {
+        "flow": true,
+        "phrasing": true,
+        "attributes": {
+          "visibility": {}
+        }
+      }
+    }
+  ]
+}

--- a/web/README.md
+++ b/web/README.md
@@ -39,6 +39,7 @@ npm run html-validate
 ```
 
 確認事項:
+
 1. `observedAttributes` に列挙した属性はすべて `attributes` に追記する
 2. ページ HTML (`index.html` / `tasks.html`) に要素を追記したら `npm run html-validate` で green を確認
 

--- a/web/README.md
+++ b/web/README.md
@@ -1,0 +1,56 @@
+# web/ — フロントエンド
+
+静的 SPA (HTML5 / CSS3 / 素の JS / Bootstrap 5)。npm プロジェクト。  
+技術選定の背景は `docs/adr/0022-*.md`〜`docs/adr/0025-*.md` 参照。
+
+## コマンド
+
+```bash
+# lockfile から依存をインストール
+npm ci
+
+# vendor アセットを node_modules からコピー
+npm run copy-vendor
+
+# Biome — JS / CSS / JSON lint + format 確認
+npx biome ci .
+
+# html-validate — HTML Living Standard 準拠 + CE メタデータ検証
+npm run html-validate
+```
+
+## Custom Element メタデータの追従手順
+
+`web/js/components/app-*.js` に新しい Custom Element を追加・変更したとき、  
+**`.htmlvalidate.json` の `elements[1]` オブジェクト**を更新してください。
+
+### 新しい CE を追加するとき
+
+```jsonc
+// .htmlvalidate.json の elements 配列 2 番目のオブジェクトに追記
+"app-my-widget": {
+  "flow": true,       // <main> / <div> / <section> 等の flow content 文脈で使う場合
+  "phrasing": true,   // <span> / インライン文脈でも使う場合は追加
+  "attributes": {
+    "my-attr": {},                   // 任意文字列
+    "toggle": { "boolean": true }   // boolean 属性 (presence のみ意味を持つ)
+  }
+}
+```
+
+確認事項:
+1. `observedAttributes` に列挙した属性はすべて `attributes` に追記する
+2. ページ HTML (`index.html` / `tasks.html`) に要素を追記したら `npm run html-validate` で green を確認
+
+### CE を変更・削除するとき
+
+- 属性名を変更: `attributes` キーを新旧で更新
+- 要素を削除: 対応するエントリごと削除
+
+### inline event handler ガードについて
+
+`onclick` 等 36 種の on\* 属性は `.htmlvalidate.json` の `"*"` (全要素共通) エントリで  
+`{ "deprecated": "..." }` に設定されており、書き戻すと `no-deprecated-attr` エラーになります。  
+ADR-0022 の CSP `script-src 'self'` と二重で保護しています。
+
+新しい on\* 属性を追加したい場合は ADR-0022 を参照して設計を見直してください。

--- a/web/index.html
+++ b/web/index.html
@@ -22,7 +22,6 @@
     </nav>
 
     <main class="container mt-4">
-      <h1 class="visually-hidden">Tasks</h1>
       <div id="loading" class="text-center py-5">
         <div class="spinner-border text-primary" role="status">
           <span class="visually-hidden">Loading...</span>
@@ -33,7 +32,7 @@
       <div id="content-logged-in" class="d-none">
         <div class="card">
           <div class="card-body">
-            <h5 class="card-title">ユーザー情報</h5>
+            <p class="card-title fw-semibold">ユーザー情報</p>
             <pre id="user-info" class="bg-light p-3 rounded small"></pre>
           </div>
         </div>

--- a/web/index.html
+++ b/web/index.html
@@ -22,6 +22,7 @@
     </nav>
 
     <main class="container mt-4">
+      <h1 class="visually-hidden">Tasks</h1>
       <div id="loading" class="text-center py-5">
         <div class="spinner-border text-primary" role="status">
           <span class="visually-hidden">Loading...</span>

--- a/web/index.html
+++ b/web/index.html
@@ -1,11 +1,11 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="ja">
   <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Tasks</title>
-    <link rel="stylesheet" href="vendor/bootstrap/css/bootstrap.min.css" />
-    <link rel="stylesheet" href="css/app.css" />
+    <link rel="stylesheet" href="vendor/bootstrap/css/bootstrap.min.css">
+    <link rel="stylesheet" href="css/app.css">
   </head>
   <body>
     <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
@@ -14,7 +14,7 @@
         <div class="ms-auto d-flex align-items-center">
           <app-tenant-switcher id="tenant-switcher" class="d-none"></app-tenant-switcher>
           <span id="nav-username" class="navbar-text text-white me-3 d-none"></span>
-          <button id="btn-logout" class="btn btn-outline-light btn-sm d-none">
+          <button id="btn-logout" type="button" class="btn btn-outline-light btn-sm d-none">
             ログアウト
           </button>
         </div>

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -14,7 +14,8 @@
         "keycloak-js": "24.0.5"
       },
       "devDependencies": {
-        "@biomejs/biome": "^2.4.16"
+        "@biomejs/biome": "^2.4.16",
+        "html-validate": "^11.5.3"
       },
       "engines": {
         "node": ">=24"
@@ -204,6 +205,16 @@
         "url": "https://github.com/sponsors/ayuhito"
       }
     },
+    "node_modules/@html-validate/stylish": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@html-validate/stylish/-/stylish-6.0.0.tgz",
+      "integrity": "sha512-d1/lI3qIXhGVJF3+MmKEBn1dRX6U4Z+BDaOdDI3E6SXcO+OQ7hC/3mSo6BIjwQlcuV6NdDOKm6QCrzIQL1EezQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.16.0 || >= 24.0.0"
+      }
+    },
     "node_modules/@popperjs/core": {
       "version": "2.11.8",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
@@ -213,6 +224,36 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
+      }
+    },
+    "node_modules/@sidvind/better-ajv-errors": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@sidvind/better-ajv-errors/-/better-ajv-errors-7.0.0.tgz",
+      "integrity": "sha512-imVsp5D3KxJ8+uUmu2dsLKnFg3qdX952v/L1gZoCa0NO2ivhQWHMpYM2KmpFrRXHWFjlqkNZ/935nxiTqXEi1A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^22.12 || >= 24.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/bootstrap": {
@@ -250,10 +291,92 @@
       ],
       "license": "MIT"
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/html-validate": {
+      "version": "11.5.3",
+      "resolved": "https://registry.npmjs.org/html-validate/-/html-validate-11.5.3.tgz",
+      "integrity": "sha512-YJAqUomHuND2ppz4QoRoWMm4tLHFxGTkqoBDiMjBm9pzictNkEB78q0yT3U9s6oiy9XoEmVC2QEQcube+fMw5g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/html-validate"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@html-validate/stylish": "^6.0.0",
+        "@sidvind/better-ajv-errors": "7.0.0",
+        "ajv": "^8.0.0",
+        "kleur": "^4.1.0",
+        "prompts": "^2.0.0",
+        "semver": "^7.0.0"
+      },
+      "bin": {
+        "html-validate": "bin/html-validate.mjs"
+      },
+      "engines": {
+        "node": "^22.22.0 || >= 24.8.0"
+      },
+      "peerDependencies": {
+        "@jest/globals": "^29.0.3 || ^30.0.0",
+        "@vitest/expect": "^3.0.0 || ^4.0.1",
+        "jest": "^29.0.3 || ^30.0.0",
+        "jest-snapshot": "^29.0.3 || ^30.0.0",
+        "vitest": "^3.0.0 || ^4.0.1"
+      },
+      "peerDependenciesMeta": {
+        "@jest/globals": {
+          "optional": true
+        },
+        "@vitest/expect": {
+          "optional": true
+        },
+        "jest": {
+          "optional": true
+        },
+        "jest-snapshot": {
+          "optional": true
+        },
+        "vitest": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/js-sha256": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.11.1.tgz",
       "integrity": "sha512-o6WSo/LUvY2uC4j7mO50a2ms7E/EAdbP0swigLV+nzHKTTaYnaLIWJ02VdXrsJX0vGedDESQnLsOekr94ryfjg==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/jwt-decode": {
@@ -274,6 +397,70 @@
         "js-sha256": "^0.11.0",
         "jwt-decode": "^4.0.0"
       }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/prompts": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/prompts/node_modules/kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/web/package.json
+++ b/web/package.json
@@ -10,12 +10,14 @@
     "keycloak-js": "24.0.5"
   },
   "scripts": {
-    "copy-vendor": "node scripts/copy-vendor.js"
+    "copy-vendor": "node scripts/copy-vendor.js",
+    "html-validate": "html-validate index.html tasks.html"
   },
   "engines": {
     "node": ">=24"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.4.16"
+    "@biomejs/biome": "^2.4.16",
+    "html-validate": "^11.5.3"
   }
 }

--- a/web/tasks.html
+++ b/web/tasks.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>タスク一覧 — Tasks</title>
-  <link rel="stylesheet" href="vendor/bootstrap/css/bootstrap.min.css" />
-  <link rel="stylesheet" href="vendor/bootstrap-icons/bootstrap-icons.min.css" />
-  <link rel="stylesheet" href="css/app.css" />
+  <link rel="stylesheet" href="vendor/bootstrap/css/bootstrap.min.css">
+  <link rel="stylesheet" href="vendor/bootstrap-icons/bootstrap-icons.min.css">
+  <link rel="stylesheet" href="css/app.css">
 </head>
 <body>
 <a href="#main-content" class="visually-hidden-focusable position-absolute p-2 m-2 bg-primary text-white rounded">
@@ -26,7 +26,7 @@
         aria-hidden="true">?</div>
       <span id="nav-username" class="small d-none d-lg-inline"></span>
     </div>
-    <button id="btn-logout" class="btn btn-outline-secondary btn-sm">
+    <button id="btn-logout" type="button" class="btn btn-outline-secondary btn-sm">
       <i class="bi bi-box-arrow-right me-1" aria-hidden="true"></i>ログアウト
     </button>
   </div>
@@ -66,7 +66,7 @@
         <label for="sortSel" class="text-muted small mb-0">
           <i class="bi bi-sort-down me-1" aria-hidden="true"></i>並び替え
         </label>
-        <select id="sortSel" class="form-select form-select-sm w-sort-sel" aria-label="並び替え">
+        <select id="sortSel" class="form-select form-select-sm w-sort-sel">
           <option value="dueDate,asc">期限(昇順)</option>
           <option value="dueDate,desc">期限(降順)</option>
           <option value="priority,desc">優先度(高→低)</option>
@@ -74,7 +74,7 @@
           <option value="createdAt,desc">作成日(新しい順)</option>
           <option value="createdAt,asc">作成日(古い順)</option>
         </select>
-        <button id="btn-new-task" class="btn btn-sm btn-primary" aria-label="新規タスクを作成">
+        <button id="btn-new-task" type="button" class="btn btn-sm btn-primary" aria-label="新規タスクを作成">
           <i class="bi bi-plus-lg me-1" aria-hidden="true"></i>新規
         </button>
       </div>
@@ -93,7 +93,7 @@
     <app-conflict-banner id="conflict-banner"></app-conflict-banner>
 
     <!-- Loading skeleton (design-system.md §6.11) -->
-    <div id="loading-skeleton" class="task-section" aria-busy="true" aria-label="読み込み中">
+    <section id="loading-skeleton" class="task-section" aria-busy="true" aria-label="読み込み中">
       <div class="section-head placeholder-glow">
         <span class="placeholder col-2"></span>
         <span class="placeholder col-1 ms-2"></span>
@@ -105,7 +105,7 @@
         <div class="skel-row placeholder-glow"><span class="placeholder col-10 h-100 d-block skel-placeholder"></span></div>
         <div class="skel-row placeholder-glow"><span class="placeholder col-12 h-100 d-block skel-placeholder"></span></div>
       </div>
-    </div>
+    </section>
 
     <!-- Task table panel -->
     <div id="task-panel" class="task-section d-none">


### PR DESCRIPTION
closes #563

## Summary

- `html-validate ^11.5.3` を devDependency に追加、`html-validate:recommended` ベースで設定
- ADR-0024 の Custom Elements 10 部品のメタデータ(`flow` / `phrasing` / `attributes`)を `.htmlvalidate.json` に定義
- `"*"` グローバル要素定義で `onclick` 等 36 種の `on*` 属性を `deprecated` 設定 → `no-deprecated-attr: error` で退行を検知
- `no-inline-style: error` は `recommended` に含まれ、`style=` の書き戻しも検知済み
- `web-ci.yml` に html-validate ステップ + v.Nu(`ghcr.io/validator/validator:latest`)ステップを追加
- CI sticky report テーブルに両ステップの結果行を追加
- HTML Living Standard 適合に向けて `index.html` / `tasks.html` を修正(DOCTYPE 統一・void-style・button type・ARIA 修正)
- `web/README.md` に CE メタデータ追従手順を記載

## HTML 修正内容(html-validate:recommended 適合)

| ファイル | 修正 |
|---|---|
| `index.html` | `<!doctype>` → `<!DOCTYPE>`、void 要素の自己閉じスラッシュ除去、`button type="button"` |
| `tasks.html` | void 要素の自己閉じスラッシュ除去、`button type="button"` × 2、冗長 `aria-label` 削除(`<select>`)、`<div aria-label>` → `<section aria-label>`(`prefer-native-element`) |

## Test plan

- [ ] html-validate が両ファイルで green なことを確認(`npm run html-validate`)
- [ ] `index.html` に `style="color:red"` を追記 → `no-inline-style` error を確認後 revert
- [ ] `tasks.html` の任意要素に `onclick="1"` を追記 → `no-deprecated-attr` error を確認後 revert
- [ ] CI で html-validate ステップ・v.Nu ステップが green になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)