### PR TITLE
feat(web): ADR-0025 S4 — tsc 基盤一式 + コア 3 ファイル型検査(// @ts-check) (#571)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -57,6 +57,9 @@ npx biome check --write --unsafe .
 
 # html-validate — HTML Living Standard 準拠 + CE メタデータ検証
 npm run html-validate
+
+# TypeScript 型検査 (// @ts-check 付きファイルのみ検査、js/**/*.js がプログラムに含まれる)
+npx tsc --noEmit
 ```
 
 ## Code Quality Toolchain

--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -89,6 +89,10 @@ jobs:
         id: biome
         run: npx biome ci .
 
+      - name: Type check (tsc --noEmit)
+        id: tsc
+        run: npx tsc --noEmit
+
       - name: html-validate (CE metadata + inline guard)
         id: html-validate
         run: npx html-validate index.html tasks.html
@@ -122,6 +126,7 @@ jobs:
           COPY_OUTCOME: ${{ steps.copy-vendor.outcome }}
           VENDOR_OUTCOME: ${{ steps.vendor-check.outcome }}
           BIOME_OUTCOME: ${{ steps.biome.outcome }}
+          TSC_OUTCOME: ${{ steps.tsc.outcome }}
           HTML_VALIDATE_OUTCOME: ${{ steps.html-validate.outcome }}
           VNU_OUTCOME: ${{ steps.vnu.outcome }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -141,6 +146,7 @@ jobs:
             echo "| copy-vendor $(icon "$COPY_OUTCOME") | vendor アセットコピー |"
             echo "| vendor check $(icon "$VENDOR_OUTCOME") | 主要ファイル存在確認 |"
             echo "| biome ci $(icon "$BIOME_OUTCOME") | lint / format 検証 |"
+            echo "| tsc --noEmit $(icon "$TSC_OUTCOME") | 型検査(// @ts-check ファイル) |"
             echo "| html-validate $(icon "$HTML_VALIDATE_OUTCOME") | CE メタデータ + inline 退行ガード |"
             echo "| v.Nu $(icon "$VNU_OUTCOME") | Living Standard 準拠検証 |"
             echo ""

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * tasks-webapi 呼び出しラッパー
  *
@@ -5,9 +6,82 @@
  * X-Tenant-Id は setTenantId() で設定する(未設定時は省略 — /api/auth/me 等のテナント不要 API 向け)。
  */
 
+// --- API response type definitions (aligned with api/openapi.yaml) ---
+
+/**
+ * @typedef {'NOT_STARTED'|'IN_PROGRESS'|'DONE'|'ON_HOLD'} TaskStatus
+ * @typedef {'HIGH'|'MEDIUM'|'LOW'} Priority
+ * @typedef {'TENANT'|'STAKEHOLDERS'|'PRIVATE'} Visibility
+ * @typedef {'TENANT_ADMIN'|'MEMBER'} Role
+ */
+
+/**
+ * @typedef {object} UserSummary
+ * @property {number} id
+ * @property {string} fullName
+ */
+
+/**
+ * @typedef {object} Task
+ * @property {number} id
+ * @property {number} version
+ * @property {string} title
+ * @property {string|null} description
+ * @property {TaskStatus} status
+ * @property {Priority} priority
+ * @property {Visibility} visibility
+ * @property {UserSummary} owner
+ * @property {UserSummary|null} assignee
+ * @property {string} dueDate
+ * @property {string|null} completedAt
+ * @property {string} createdAt
+ * @property {string} updatedAt
+ * @property {boolean} editable
+ * @property {boolean} deletable
+ */
+
+/**
+ * @typedef {Task & {tenantId: number}} TaskDetail
+ */
+
+/**
+ * @typedef {object} TaskPage
+ * @property {Task[]} content
+ * @property {number} totalElements
+ * @property {number} totalPages
+ * @property {number} number
+ * @property {number} size
+ * @property {number} overdueCount
+ */
+
+/**
+ * @typedef {object} TenantUser
+ * @property {number} userId
+ * @property {string} email
+ * @property {string} fullName
+ * @property {string|null} [departmentName]
+ * @property {Role} role
+ * @property {'ACTIVE'|'INVITED'|'DISABLED'} status
+ * @property {string} joinedAt
+ */
+
+/**
+ * @typedef {object} Stakeholder
+ * @property {number} userId
+ * @property {string} fullName
+ * @property {string} email
+ * @property {UserSummary} addedBy
+ * @property {string} addedAt
+ */
+
+/**
+ * @typedef {Error & {status: number}} ApiError
+ */
+
 const Api = (() => {
   const BASE_URL = 'http://localhost:8080';
 
+  /** @type {string|null} */
   let _tenantId = null;
 
   /**
@@ -37,11 +111,19 @@ const Api = (() => {
     return _parseResponse(response);
   }
 
+  /**
+   * @param {string} path
+   * @param {string} token
+   * @param {RequestInit} options
+   * @returns {Promise<Response>}
+   */
   async function _fetch(path, token, options) {
+    // options.headers は呼び出し元が常にプレーンオブジェクトを渡すためキャストが安全
+    /** @type {Record<string, string>} */
     const headers = {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${token}`,
-      ...options.headers,
+      .../** @type {Record<string, string>} */ (options.headers ?? {}),
     };
 
     if (_tenantId !== null) {
@@ -51,10 +133,16 @@ const Api = (() => {
     return fetch(`${BASE_URL}${path}`, { ...options, headers });
   }
 
+  /**
+   * @param {Response} response
+   * @returns {Promise<any>}
+   */
   async function _parseResponse(response) {
     if (!response.ok) {
       const body = await response.text().catch(() => '');
-      const err = new Error(`${response.status} ${response.statusText}: ${body}`);
+      const err = /** @type {ApiError} */ (
+        new Error(`${response.status} ${response.statusText}: ${body}`)
+      );
       err.status = response.status;
       throw err;
     }
@@ -66,14 +154,25 @@ const Api = (() => {
     return response.text();
   }
 
+  /**
+   * @param {Response} response
+   * @returns {Promise<never>}
+   */
   async function _throwFromResponse(response) {
     const body = await response.text().catch(() => '');
-    const err = new Error(`${response.status} ${response.statusText}: ${body}`);
+    const err = /** @type {ApiError} */ (
+      new Error(`${response.status} ${response.statusText}: ${body}`)
+    );
     err.status = response.status;
     throw err;
   }
 
-  // Returns the raw Response (handles 401 refresh), for callers that need headers.
+  /**
+   * Returns the raw Response (handles 401 refresh), for callers that need headers.
+   * @param {string} path
+   * @param {RequestInit} [options]
+   * @returns {Promise<Response>}
+   */
   async function requestRaw(path, options = {}) {
     const response = await _fetch(path, await Auth.getToken(), options);
     if (response.status === 401) {
@@ -208,10 +307,11 @@ const Api = (() => {
    * PATCH /api/tasks/{id}/visibility — 公開範囲変更(A-17)。
    * @param {number} id
    * @param {string} visibility — Visibility 値
-   * @param {number[]} [stakeholderUserIds] — visibility=STAKEHOLDERS のとき指定
+   * @param {number[]} [stakeholderUserIds] visibility=STAKEHOLDERS のとき指定
    * @returns {Promise<Task>}
    */
   function changeVisibility(id, visibility, stakeholderUserIds) {
+    /** @type {{visibility: string, stakeholderUserIds?: number[]}} */
     const body = { visibility };
     if (stakeholderUserIds) body.stakeholderUserIds = stakeholderUserIds;
     return request(`/api/tasks/${id}/visibility`, { method: 'PATCH', body: JSON.stringify(body) });

--- a/web/js/auth.js
+++ b/web/js/auth.js
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * Keycloak OIDC 認証モジュール
  *
@@ -15,6 +16,7 @@ const Auth = (() => {
   const REALM = 'tasks';
   const CLIENT_ID = 'tasks-webapi';
 
+  /** @type {InstanceType<typeof Keycloak>|null} */
   let _keycloak = null;
 
   function _createKeycloak() {
@@ -53,8 +55,12 @@ const Auth = (() => {
     if (!_keycloak) {
       throw new Error('Auth が初期化されていません。init() を先に呼んでください。');
     }
-    await _keycloak.updateToken(30);
-    return _keycloak.token;
+    // キャプチャして await 後も型が絞られた状態を保つ
+    const kc = _keycloak;
+    await kc.updateToken(30);
+    const token = kc.token;
+    if (!token) throw new Error('トークンを取得できませんでした。');
+    return token;
   }
 
   /**
@@ -66,13 +72,16 @@ const Auth = (() => {
     if (!_keycloak) {
       throw new Error('Auth が初期化されていません。init() を先に呼んでください。');
     }
+    const kc = _keycloak;
     try {
-      await _keycloak.updateToken(-1);
+      await kc.updateToken(-1);
     } catch {
-      _keycloak.login();
+      kc.login();
       throw new Error('Refresh token が失効しました。再ログインが必要です。');
     }
-    return _keycloak.token;
+    const token = kc.token;
+    if (!token) throw new Error('トークンを取得できませんでした。');
+    return token;
   }
 
   /**
@@ -80,7 +89,7 @@ const Auth = (() => {
    * @returns {Object|null}
    */
   function getUser() {
-    return _keycloak ? _keycloak.idTokenParsed : null;
+    return _keycloak ? (_keycloak.idTokenParsed ?? null) : null;
   }
 
   /**
@@ -94,12 +103,14 @@ const Auth = (() => {
 
   // token の有効期限 60 秒前に自動更新するポーリング(30 秒間隔)
   function _scheduleTokenRefresh() {
+    if (!_keycloak) return;
+    const kc = _keycloak;
     setInterval(async () => {
       try {
-        await _keycloak.updateToken(60);
+        await kc.updateToken(60);
       } catch {
         // 更新失敗(セッション失効等)は再ログインで対応
-        _keycloak.login();
+        kc.login();
       }
     }, 30000);
   }

--- a/web/js/dom.js
+++ b/web/js/dom.js
@@ -1,0 +1,19 @@
+// @ts-check
+
+/**
+ * 外部 HTML で定義された要素をセレクタで取得する。要素が存在しない場合は Error をスローする(fail-closed)。
+ *
+ * 使い分け規約:
+ *   - 外部 HTML(index.html / tasks.html など)で宣言した要素を参照する場合 => mustQuery() を使用
+ *   - 自部品(Web Component)が生成した要素を参照する場合 => インライン JSDoc キャストを使用
+ *
+ * @param {ParentNode} root - 検索起点(通常は document)
+ * @param {string} selector - CSS セレクタ
+ * @returns {Element} 一致した要素(null にならない)
+ * @throws {Error} セレクタに一致する要素が見つからない場合
+ */
+function mustQuery(root, selector) {
+  const el = root.querySelector(selector);
+  if (!el) throw new Error(`Required element not found: "${selector}"`);
+  return el;
+}

--- a/web/js/meta.js
+++ b/web/js/meta.js
@@ -1,17 +1,21 @@
+// @ts-check
 // Shared display metadata for task enums (status / priority / visibility).
 // Returns [label, cssClass] for badges, [label, cssClass, iconClass] for visibility.
 const TaskMeta = (() => {
+  /** @type {Record<string, string[]>} */
   const STATUS = {
     NOT_STARTED: ['未着手', 'st-NOT_STARTED'],
     IN_PROGRESS: ['進行中', 'st-IN_PROGRESS'],
     DONE: ['完了', 'st-DONE'],
     ON_HOLD: ['保留', 'st-ON_HOLD'],
   };
+  /** @type {Record<string, string[]>} */
   const PRIORITY = {
     HIGH: ['高', 'pri-HIGH'],
     MEDIUM: ['中', 'pri-MEDIUM'],
     LOW: ['低', 'pri-LOW'],
   };
+  /** @type {Record<string, string[]>} */
   const VISIBILITY = {
     TENANT: ['テナント', 'vis-TENANT', 'bi-globe2'],
     STAKEHOLDERS: ['関係者', 'vis-STAKEHOLDERS', 'bi-people-fill'],
@@ -19,8 +23,11 @@ const TaskMeta = (() => {
   };
 
   return {
+    /** @param {string} s */
     status: (s) => STATUS[s] ?? [s, 'st-NOT_STARTED'],
+    /** @param {string} p */
     priority: (p) => PRIORITY[p] ?? [p, 'pri-LOW'],
+    /** @param {string} v */
     visibility: (v) => VISIBILITY[v] ?? [v, 'vis-TENANT', 'bi-globe2'],
     STATUS_OPTIONS: Object.keys(STATUS).map((v) => ({ v, l: STATUS[v][0] })),
     PRIORITY_OPTIONS: Object.keys(PRIORITY).map((v) => ({ v, l: PRIORITY[v][0] })),

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -15,7 +15,8 @@
       },
       "devDependencies": {
         "@biomejs/biome": "^2.4.16",
-        "html-validate": "^11.5.3"
+        "html-validate": "^11.5.3",
+        "typescript": "^5.8.0"
       },
       "engines": {
         "node": ">=24"
@@ -461,6 +462,20 @@
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
     }
   }
 }

--- a/web/package.json
+++ b/web/package.json
@@ -18,6 +18,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.16",
-    "html-validate": "^11.5.3"
+    "html-validate": "^11.5.3",
+    "typescript": "^5.8.0"
   }
 }

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM"],
+    "module": "none",
+    "allowJs": true,
+    "checkJs": false,
+    "strict": true,
+    "noEmit": true
+  },
+  "include": ["js/**/*.js", "scripts/**/*.js", "types/**/*.d.ts"]
+}

--- a/web/types/globals.d.ts
+++ b/web/types/globals.d.ts
@@ -1,0 +1,39 @@
+/**
+ * Vendor global declarations for classic-script (non-module) environment.
+ *
+ * These libraries are loaded via <script> tags from vendor/ and exposed as globals.
+ * Declarations here let tsc resolve them in files with // @ts-check.
+ */
+
+// --- Keycloak (vendor/keycloak-js/keycloak.min.js) ---
+
+interface KeycloakConfig {
+  url?: string;
+  realm: string;
+  clientId: string;
+}
+
+interface KeycloakInitOptions {
+  onLoad?: 'login-required' | 'check-sso';
+  checkLoginIframe?: boolean;
+  pkceMethod?: 'S256' | false;
+  useNonce?: boolean;
+}
+
+interface KeycloakInstance {
+  authenticated?: boolean;
+  token?: string;
+  idTokenParsed?: Record<string, unknown>;
+  init(options: KeycloakInitOptions): Promise<boolean>;
+  updateToken(minValidity: number): Promise<boolean>;
+  login(options?: { redirectUri?: string }): void;
+  logout(options?: { redirectUri?: string }): void;
+}
+
+declare const Keycloak: {
+  new (config: KeycloakConfig): KeycloakInstance;
+};
+
+// --- Bootstrap (vendor/bootstrap/js/bootstrap.bundle.min.js) ---
+// Used in component files (none of which have // @ts-check).
+declare const bootstrap: Record<string, unknown>;


### PR DESCRIPTION
closes #571

## Summary

- `web/tsconfig.json` 新設 — `strict: true` / `checkJs: false` / `noEmit: true` / `module: none`。`js/**/*.js` + `scripts/**/*.js` + `types/**/*.d.ts` をプログラムに含め、classic script のグローバル解決を実現
- `web/types/globals.d.ts` 新設 — vendor グローバル `Keycloak`(コンストラクタ型含む)と `bootstrap` の ambient 宣言
- `web/js/dom.js` 新設 — `mustQuery()` helper(外部 HTML 参照の fail-closed ガード)。使い分け規約(外部 HTML → `mustQuery` / 自部品生成 DOM → JSDoc キャスト)を JSDoc に明記
- `web/js/api.js` — `// @ts-check` 付与 + API レスポンス DTO `@typedef`(Task / TaskDetail / TaskPage / TenantUser / Stakeholder 等)定義 + `ApiError` typedef + 型エラー 0
- `web/js/auth.js` — `// @ts-check` 付与。`await` 境界をまたぐナローイング維持のため `const kc = _keycloak` キャプチャ、`token: string | undefined` への null ガード追加
- `web/js/meta.js` — `// @ts-check` 付与。`Record<string, string[]>` アノテーションで文字列インデックス型エラーを解消
- `web/package.json` / `package-lock.json` — `typescript ^5.8.0` を devDependencies に追加
- `.github/workflows/web-ci.yml` — `npx tsc --noEmit` ステップを Biome の直後に追加、CI レポートに tsc 行を追記
- `.claude/CLAUDE.md` — `npx tsc --noEmit` コマンドを web/ セクションに追記

## Test plan

- [x] `npx tsc --noEmit` — エラー 0
- [x] `npx biome ci .` — エラー 0
- [x] `npm run html-validate` — エラー 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)