### PR TITLE
feat(web): ADR-0025 S5 — 残り 13 ファイルへ // @ts-check 拡大(tsc エラー 0)

### DIFF
--- a/web/js/api.js
+++ b/web/js/api.js
@@ -78,6 +78,20 @@
  * @typedef {Error & {status: number}} ApiError
  */
 
+/**
+ * @typedef {object} TenantRef
+ * @property {number} id
+ * @property {string} name
+ * @property {Role} role
+ */
+
+/**
+ * @typedef {object} MeResponse
+ * @property {{ id: number, fullName: string }} user
+ * @property {number|null} activeTenantId
+ * @property {TenantRef[]} tenants
+ */
+
 const Api = (() => {
   const BASE_URL = 'http://localhost:8080';
 
@@ -184,7 +198,7 @@ const Api = (() => {
 
   /**
    * GET /api/auth/me — 認証済みユーザー情報を取得する。
-   * @returns {Promise<Object>}
+   * @returns {Promise<MeResponse>}
    */
   function getMe() {
     return request('/api/auth/me');

--- a/web/js/auth.js
+++ b/web/js/auth.js
@@ -86,10 +86,10 @@ const Auth = (() => {
 
   /**
    * デコード済みの ID token payload を返す。
-   * @returns {Object|null}
+   * @returns {KeycloakUser|null}
    */
   function getUser() {
-    return _keycloak ? (_keycloak.idTokenParsed ?? null) : null;
+    return /** @type {KeycloakUser|null} */ (_keycloak ? (_keycloak.idTokenParsed ?? null) : null);
   }
 
   /**

--- a/web/js/components/app-conflict-banner.js
+++ b/web/js/components/app-conflict-banner.js
@@ -1,3 +1,4 @@
+// @ts-check
 // <app-conflict-banner> — 412-conflict notification banner.
 // Methods: show(), hide()
 // Fires: conflict-reload, conflict-close (both bubbling)
@@ -14,18 +15,26 @@ _conflictTpl.innerHTML = `
 </div>`;
 
 class AppConflictBanner extends HTMLElement {
+  /** @type {Element | null} */
   #alert = null;
 
   connectedCallback() {
     this.replaceChildren(_conflictTpl.content.cloneNode(true));
     this.#alert = this.firstElementChild;
-    this.#alert.querySelector('.btn-reload').addEventListener('click', () => {
-      this.dispatchEvent(new CustomEvent('conflict-reload', { bubbles: true }));
-    });
-    this.#alert.querySelector('.btn-dismiss').addEventListener('click', () => {
-      this.hide();
-      this.dispatchEvent(new CustomEvent('conflict-close', { bubbles: true }));
-    });
+    if (!this.#alert) return;
+    /** @type {HTMLButtonElement} */ (this.#alert.querySelector('.btn-reload')).addEventListener(
+      'click',
+      () => {
+        this.dispatchEvent(new CustomEvent('conflict-reload', { bubbles: true }));
+      },
+    );
+    /** @type {HTMLButtonElement} */ (this.#alert.querySelector('.btn-dismiss')).addEventListener(
+      'click',
+      () => {
+        this.hide();
+        this.dispatchEvent(new CustomEvent('conflict-close', { bubbles: true }));
+      },
+    );
   }
 
   show() {

--- a/web/js/components/app-desc-popover.js
+++ b/web/js/components/app-desc-popover.js
@@ -1,3 +1,4 @@
+// @ts-check
 // <app-desc-popover> — singleton page-level description edit popover.
 // Methods: open(taskId, triggerEl, description), close()
 // Fires: desc-commit { taskId, value }, desc-cancel
@@ -14,8 +15,11 @@ _descPopTpl.innerHTML = `
 </div>`;
 
 class AppDescPopover extends HTMLElement {
+  /** @type {number | null} */
   #taskId = null;
+  /** @type {HTMLElement | null} */
   #overlay = null;
+  /** @type {HTMLTextAreaElement | null} */
   #ta = null;
 
   #handleMousedown = this.#onDocMousedown.bind(this);
@@ -23,11 +27,18 @@ class AppDescPopover extends HTMLElement {
 
   connectedCallback() {
     this.replaceChildren(_descPopTpl.content.cloneNode(true));
-    this.#overlay = this.firstElementChild;
-    this.#ta = this.#overlay.querySelector('textarea');
+    this.#overlay = /** @type {HTMLElement} */ (this.firstElementChild);
+    this.#ta = /** @type {HTMLTextAreaElement} */ (this.#overlay.querySelector('textarea'));
+    if (!this.#overlay || !this.#ta) return;
 
-    this.#overlay.querySelector('.btn-save').addEventListener('click', () => this.#commit());
-    this.#overlay.querySelector('.btn-cancel').addEventListener('click', () => this.close());
+    /** @type {HTMLButtonElement} */ (this.#overlay.querySelector('.btn-save')).addEventListener(
+      'click',
+      () => this.#commit(),
+    );
+    /** @type {HTMLButtonElement} */ (this.#overlay.querySelector('.btn-cancel')).addEventListener(
+      'click',
+      () => this.close(),
+    );
     this.#ta.addEventListener('keydown', this.#handleKeydown);
     document.addEventListener('mousedown', this.#handleMousedown);
   }
@@ -36,8 +47,14 @@ class AppDescPopover extends HTMLElement {
     document.removeEventListener('mousedown', this.#handleMousedown);
   }
 
+  /**
+   * @param {number} taskId
+   * @param {Element} triggerEl
+   * @param {string | null} description
+   */
   open(taskId, triggerEl, description) {
     this.#taskId = taskId;
+    if (!this.#ta || !this.#overlay) return;
     this.#ta.value = description || '';
 
     const rect = triggerEl.getBoundingClientRect();
@@ -66,7 +83,7 @@ class AppDescPopover extends HTMLElement {
 
   #commit() {
     const taskId = this.#taskId;
-    if (taskId === null) return;
+    if (taskId === null || !this.#ta || !this.#overlay) return;
     const value = this.#ta.value.trim() || null;
     this.#overlay.classList.add('d-none');
     this.#taskId = null;
@@ -78,10 +95,12 @@ class AppDescPopover extends HTMLElement {
     );
   }
 
+  /** @param {MouseEvent} e */
   #onDocMousedown(e) {
-    if (this.isOpen && !this.#overlay.contains(e.target)) this.close();
+    if (this.isOpen && !this.#overlay?.contains(/** @type {Node} */ (e.target))) this.close();
   }
 
+  /** @param {KeyboardEvent} e */
   #onTaKeydown(e) {
     if (e.key === 'Escape') {
       e.stopPropagation();

--- a/web/js/components/app-error-banner.js
+++ b/web/js/components/app-error-banner.js
@@ -1,3 +1,4 @@
+// @ts-check
 // <app-error-banner> — dismissible error banner.
 // Methods: show(message), hide()
 // Fires: error-retry (bubbling)
@@ -13,19 +14,25 @@ _errTpl.innerHTML = `
 </div>`;
 
 class AppErrorBanner extends HTMLElement {
+  /** @type {Element | null} */
   #alert = null;
 
   connectedCallback() {
     this.replaceChildren(_errTpl.content.cloneNode(true));
     this.#alert = this.firstElementChild;
-    this.#alert.querySelector('.btn-retry').addEventListener('click', () => {
-      this.dispatchEvent(new CustomEvent('error-retry', { bubbles: true }));
-    });
+    if (!this.#alert) return;
+    /** @type {HTMLButtonElement} */ (this.#alert.querySelector('.btn-retry')).addEventListener(
+      'click',
+      () => {
+        this.dispatchEvent(new CustomEvent('error-retry', { bubbles: true }));
+      },
+    );
   }
 
+  /** @param {string} message */
   show(message) {
     if (!this.#alert) return;
-    this.#alert.querySelector('.err-message').textContent = message;
+    /** @type {HTMLElement} */ (this.#alert.querySelector('.err-message')).textContent = message;
     this.#alert.classList.remove('d-none');
   }
 

--- a/web/js/components/app-pager.js
+++ b/web/js/components/app-pager.js
@@ -1,3 +1,4 @@
+// @ts-check
 // <app-pager> — pagination bar for the task table.
 // Method: update({ currentPage, totalPages, totalElements, pageSize })
 // Fires: page-change { page } (bubbling)
@@ -22,38 +23,49 @@ _pagerTpl.innerHTML = `
 class AppPager extends HTMLElement {
   connectedCallback() {
     this.replaceChildren(_pagerTpl.content.cloneNode(true));
-    this.querySelector('.btn-prev').addEventListener('click', () => {
-      this.dispatchEvent(
-        new CustomEvent('page-change', {
-          bubbles: true,
-          detail: { page: this.#currentPage - 1 },
-        }),
-      );
-    });
-    this.querySelector('.btn-next').addEventListener('click', () => {
-      this.dispatchEvent(
-        new CustomEvent('page-change', {
-          bubbles: true,
-          detail: { page: this.#currentPage + 1 },
-        }),
-      );
-    });
+    /** @type {HTMLButtonElement} */ (this.querySelector('.btn-prev')).addEventListener(
+      'click',
+      () => {
+        this.dispatchEvent(
+          new CustomEvent('page-change', {
+            bubbles: true,
+            detail: { page: this.#currentPage - 1 },
+          }),
+        );
+      },
+    );
+    /** @type {HTMLButtonElement} */ (this.querySelector('.btn-next')).addEventListener(
+      'click',
+      () => {
+        this.dispatchEvent(
+          new CustomEvent('page-change', {
+            bubbles: true,
+            detail: { page: this.#currentPage + 1 },
+          }),
+        );
+      },
+    );
   }
 
   #currentPage = 0;
 
+  /**
+   * @param {{ currentPage: number, totalPages: number, totalElements: number, pageSize: number }} opts
+   */
   update({ currentPage, totalPages, totalElements, pageSize }) {
     this.#currentPage = currentPage;
     const start = totalElements > 0 ? currentPage * pageSize + 1 : 0;
     const end = Math.min((currentPage + 1) * pageSize, totalElements);
 
-    this.querySelector('.pager-info').textContent =
+    /** @type {HTMLElement} */ (this.querySelector('.pager-info')).textContent =
       totalElements > 0 ? `${totalElements} 件中 ${start}–${end} 件を表示` : '0 件';
-    this.querySelector('.pager-pages').textContent =
+    /** @type {HTMLElement} */ (this.querySelector('.pager-pages')).textContent =
       `${currentPage + 1} / ${Math.max(totalPages, 1)}`;
-    this.querySelector('.btn-prev').disabled = currentPage <= 0;
-    this.querySelector('.btn-next').disabled = currentPage >= totalPages - 1;
-    this.querySelector('.pager-size').textContent = `${pageSize} 件 / ページ`;
+    /** @type {HTMLButtonElement} */ (this.querySelector('.btn-prev')).disabled = currentPage <= 0;
+    /** @type {HTMLButtonElement} */ (this.querySelector('.btn-next')).disabled =
+      currentPage >= totalPages - 1;
+    /** @type {HTMLElement} */ (this.querySelector('.pager-size')).textContent =
+      `${pageSize} 件 / ページ`;
   }
 }
 customElements.define('app-pager', AppPager);

--- a/web/js/components/app-priority-badge.js
+++ b/web/js/components/app-priority-badge.js
@@ -1,3 +1,4 @@
+// @ts-check
 // <app-priority-badge priority="MEDIUM" [editable] [task-id="1"]>
 const _priBadgeTpl = document.createElement('template');
 _priBadgeTpl.innerHTML = '<span class="pri-badge" title="編集権限がありません"></span>';
@@ -25,7 +26,9 @@ class AppPriorityBadge extends HTMLElement {
     const [label, cls] = TaskMeta.priority(priority);
 
     if (editable) {
-      const sel = _priSelTpl.content.cloneNode(true).firstElementChild;
+      const sel = /** @type {HTMLSelectElement} */ (
+        /** @type {DocumentFragment} */ (_priSelTpl.content.cloneNode(true)).firstElementChild
+      );
       sel.className = `inline-sel pri-sel-${priority}`;
       sel.dataset.taskId = taskId;
       TaskMeta.PRIORITY_OPTIONS.forEach(({ v, l }) => {
@@ -37,7 +40,9 @@ class AppPriorityBadge extends HTMLElement {
       });
       this.replaceChildren(sel);
     } else {
-      const span = _priBadgeTpl.content.cloneNode(true).firstElementChild;
+      const span = /** @type {HTMLElement} */ (
+        /** @type {DocumentFragment} */ (_priBadgeTpl.content.cloneNode(true)).firstElementChild
+      );
       span.className = `pri-badge ${cls}`;
       span.textContent = label;
       this.replaceChildren(span);

--- a/web/js/components/app-status-badge.js
+++ b/web/js/components/app-status-badge.js
@@ -1,3 +1,4 @@
+// @ts-check
 // <app-status-badge status="NOT_STARTED" [editable] [task-id="1"]>
 // editable=true → inline select; false → read-only badge
 const _stBadgeTpl = document.createElement('template');
@@ -26,7 +27,9 @@ class AppStatusBadge extends HTMLElement {
     const [label, cls] = TaskMeta.status(status);
 
     if (editable) {
-      const sel = _stSelTpl.content.cloneNode(true).firstElementChild;
+      const sel = /** @type {HTMLSelectElement} */ (
+        /** @type {DocumentFragment} */ (_stSelTpl.content.cloneNode(true)).firstElementChild
+      );
       sel.className = `inline-sel st-sel-${status}`;
       sel.dataset.taskId = taskId;
       TaskMeta.STATUS_OPTIONS.forEach(({ v, l }) => {
@@ -38,7 +41,9 @@ class AppStatusBadge extends HTMLElement {
       });
       this.replaceChildren(sel);
     } else {
-      const span = _stBadgeTpl.content.cloneNode(true).firstElementChild;
+      const span = /** @type {HTMLElement} */ (
+        /** @type {DocumentFragment} */ (_stBadgeTpl.content.cloneNode(true)).firstElementChild
+      );
       span.className = `st-badge ${cls}`;
       span.textContent = label;
       this.replaceChildren(span);

--- a/web/js/components/app-task-drawer.js
+++ b/web/js/components/app-task-drawer.js
@@ -1,3 +1,4 @@
+// @ts-check
 // <app-task-drawer> — Bootstrap Offcanvas drawer for task create / detail / edit.
 //
 // Public API:
@@ -13,21 +14,43 @@
 //   drawer-task-deleted  { taskId }      — DELETE succeeded
 //   drawer-closed                        — offcanvas fully hidden
 
-const PRI_LABEL = { HIGH: '高', MEDIUM: '中', LOW: '低' };
-const ST_LABEL = { NOT_STARTED: '未着手', IN_PROGRESS: '進行中', DONE: '完了', ON_HOLD: '保留' };
-const VIS_LABEL = { TENANT: 'テナント', STAKEHOLDERS: '関係者', PRIVATE: '非公開' };
-const VIS_ICON = { TENANT: 'bi-globe2', STAKEHOLDERS: 'bi-people-fill', PRIVATE: 'bi-lock-fill' };
+const PRI_LABEL = /** @type {Record<string, string>} */ ({ HIGH: '高', MEDIUM: '中', LOW: '低' });
+const ST_LABEL = /** @type {Record<string, string>} */ ({
+  NOT_STARTED: '未着手',
+  IN_PROGRESS: '進行中',
+  DONE: '完了',
+  ON_HOLD: '保留',
+});
+const VIS_LABEL = /** @type {Record<string, string>} */ ({
+  TENANT: 'テナント',
+  STAKEHOLDERS: '関係者',
+  PRIVATE: '非公開',
+});
+const VIS_ICON = /** @type {Record<string, string>} */ ({
+  TENANT: 'bi-globe2',
+  STAKEHOLDERS: 'bi-people-fill',
+  PRIVATE: 'bi-lock-fill',
+});
 
 class AppTaskDrawer extends HTMLElement {
+  /** @type {BootstrapOffcanvas | null} */
   #oc = null;
+  /** @type {TaskDetail | null} */
   #task = null;
+  /** @type {string | null} */
   #etag = null;
+  /** @type {TenantUser[]} */
   #tenantUsers = [];
+  /** @type {number | null} */
   #currentUserId = null;
+  /** @type {Stakeholder[]} */
   #stakeholders = [];
-  #selectedSH = []; // [{userId, fullName}] for new-mode stakeholder picker
+  /** @type {Array<{userId: number, fullName: string}>} */
+  #selectedSH = [];
+  /** @type {string | null} */
   #prevPath = null;
   #skipHideUrl = false;
+  /** @type {(() => void) | null} */
   #popHandler = null;
 
   connectedCallback() {
@@ -42,18 +65,20 @@ class AppTaskDrawer extends HTMLElement {
     el.addEventListener('hidden.bs.offcanvas', () => this.#onHidden());
 
     this.#popHandler = () => this.#onPopState();
-    window.addEventListener('popstate', this.#popHandler);
+    window.addEventListener('popstate', /** @type {EventListener} */ (this.#popHandler));
   }
 
   disconnectedCallback() {
-    window.removeEventListener('popstate', this.#popHandler);
+    window.removeEventListener('popstate', /** @type {EventListener} */ (this.#popHandler));
   }
 
   // ---- Public API ----
 
+  /** @param {TenantUser[]} users */
   setUsers(users) {
     this.#tenantUsers = users || [];
   }
+  /** @param {number | null} userId */
   setCurrentUser(userId) {
     this.#currentUserId = userId;
   }
@@ -65,6 +90,7 @@ class AppTaskDrawer extends HTMLElement {
   // List URL to restore when closing after a direct-URL auto-open
   static #LIST_URL = '/tasks.html';
 
+  /** @param {Record<string, string>} [opts] */
   openNew(opts = {}) {
     this.#prevPath = this.#safeListUrl('/tasks/new');
     this.#task = null;
@@ -73,29 +99,31 @@ class AppTaskDrawer extends HTMLElement {
     this.#selectedSH = [];
     this.#renderNew(opts);
     this.#pushUrl('/tasks/new');
-    this.#oc.show();
+    this.#oc?.show();
   }
 
+  /** @param {number} taskId */
   async openDetail(taskId) {
     this.#prevPath = this.#safeListUrl(`/tasks/${taskId}`);
     this.#renderLoading();
     this.#pushUrl(`/tasks/${taskId}`);
-    this.#oc.show();
+    this.#oc?.show();
     await this.#loadAndRenderDetail(taskId);
   }
 
+  /** @param {number} taskId */
   async openEdit(taskId) {
     this.#prevPath = this.#safeListUrl(`/tasks/${taskId}/edit`);
     this.#renderLoading();
     this.#pushUrl(`/tasks/${taskId}/edit`);
-    this.#oc.show();
+    this.#oc?.show();
     if (!this.#task || this.#task.id !== taskId) {
       await this.#loadTaskData(taskId);
     }
     if (this.#task) this.#renderEdit();
   }
 
-  // Return current path unless it matches drawerUrl (direct-URL open), then fall back to list.
+  /** @param {string} drawerUrl */
   #safeListUrl(drawerUrl) {
     const cur = location.pathname + location.search;
     return cur === drawerUrl ? AppTaskDrawer.#LIST_URL : cur;
@@ -104,12 +132,13 @@ class AppTaskDrawer extends HTMLElement {
   // ---- Private helpers ----
 
   get #hdr() {
-    return this.firstElementChild?.querySelector('.offcanvas-header');
+    return /** @type {HTMLElement} */ (this.firstElementChild?.querySelector('.offcanvas-header'));
   }
   get #bdy() {
-    return this.firstElementChild?.querySelector('.offcanvas-body');
+    return /** @type {HTMLElement} */ (this.firstElementChild?.querySelector('.offcanvas-body'));
   }
 
+  /** @param {string} type */
   #can(type) {
     const t = this.#task;
     if (!t) return false;
@@ -121,6 +150,7 @@ class AppTaskDrawer extends HTMLElement {
     return false;
   }
 
+  /** @param {number} taskId */
   async #loadTaskData(taskId) {
     try {
       const [{ task, etag }, stakeholders] = await Promise.all([
@@ -136,6 +166,7 @@ class AppTaskDrawer extends HTMLElement {
     }
   }
 
+  /** @param {number} taskId */
   async #loadAndRenderDetail(taskId) {
     await this.#loadTaskData(taskId);
     if (this.#task) {
@@ -143,9 +174,11 @@ class AppTaskDrawer extends HTMLElement {
     }
   }
 
+  /** @param {string} url */
   #pushUrl(url) {
     history.pushState({ drawer: true }, '', url);
   }
+  /** @param {string} url */
   #replaceUrl(url) {
     history.replaceState({ drawer: true }, '', url);
   }
@@ -177,6 +210,7 @@ class AppTaskDrawer extends HTMLElement {
     return btn;
   }
 
+  /** @param {string} msg */
   #makeErrorMsg(msg) {
     const d = document.createElement('div');
     d.className = 'alert alert-danger py-2 small mb-3';
@@ -185,6 +219,7 @@ class AppTaskDrawer extends HTMLElement {
     return d;
   }
 
+  /** @param {string} [label] */
   #makeSpinner(label = '読み込み中...') {
     const d = document.createElement('div');
     d.className = 'text-center py-5';
@@ -206,6 +241,7 @@ class AppTaskDrawer extends HTMLElement {
     this.#bdy.replaceChildren(this.#makeSpinner());
   }
 
+  /** @param {any} err */
   #renderError(err) {
     const hdr = this.#hdr;
     hdr.replaceChildren();
@@ -225,6 +261,7 @@ class AppTaskDrawer extends HTMLElement {
 
   // ---- NEW MODE ----
 
+  /** @param {Record<string, string>} [opts] */
   #renderNew(opts = {}) {
     const hdr = this.#hdr;
     hdr.replaceChildren();
@@ -238,6 +275,7 @@ class AppTaskDrawer extends HTMLElement {
     this.#bdy.replaceChildren(form);
   }
 
+  /** @param {Record<string, string>} [opts] */
   #buildNewForm(opts = {}) {
     const form = document.createElement('form');
     form.className = 'new-task-form';
@@ -300,7 +338,7 @@ class AppTaskDrawer extends HTMLElement {
     assSel.appendChild(emptyOpt);
     this.#tenantUsers.forEach((u) => {
       const opt = document.createElement('option');
-      opt.value = u.userId;
+      opt.value = String(u.userId);
       opt.textContent = u.fullName;
       assSel.appendChild(opt);
     });
@@ -394,7 +432,7 @@ class AppTaskDrawer extends HTMLElement {
     shSel.appendChild(shOptBlank);
     this.#tenantUsers.forEach((u) => {
       const opt = document.createElement('option');
-      opt.value = u.userId;
+      opt.value = String(u.userId);
       opt.textContent = u.fullName;
       shSel.appendChild(opt);
     });
@@ -408,7 +446,9 @@ class AppTaskDrawer extends HTMLElement {
 
     // Toggle stakeholder section on visibility change
     visBtnGrp.addEventListener('change', () => {
-      const val = form.querySelector('input[name="newVis"]:checked')?.value;
+      const val = /** @type {HTMLInputElement | null} */ (
+        form.querySelector('input[name="newVis"]:checked')
+      )?.value;
       shSection.classList.toggle('d-none', val !== 'STAKEHOLDERS');
       this.#syncNewShPickerOpts(shSel, shChips);
     });
@@ -444,15 +484,23 @@ class AppTaskDrawer extends HTMLElement {
     return form;
   }
 
+  /**
+   * @param {HTMLSelectElement} sel
+   * @param {Element} chipsEl
+   */
   #syncNewShPickerOpts(sel, chipsEl) {
     const currentIds = new Set(this.#selectedSH.map((s) => s.userId));
-    [...sel.options].forEach((o) => {
+    Array.from(sel.options).forEach((o) => {
       if (o.value === '') return;
       o.hidden = currentIds.has(Number(o.value));
     });
     this.#renderNewShChips(chipsEl, sel);
   }
 
+  /**
+   * @param {Element} chipsEl
+   * @param {HTMLSelectElement} sel
+   */
   #renderNewShChips(chipsEl, sel) {
     chipsEl.replaceChildren();
     this.#selectedSH.forEach((sh) => {
@@ -464,30 +512,36 @@ class AppTaskDrawer extends HTMLElement {
     });
   }
 
+  /** @param {HTMLFormElement} form */
   async #submitNew(form) {
-    const errDiv = form.querySelector('#new-form-error');
-    const submitBtn = form.querySelector('[type=submit]');
+    const errDiv = /** @type {HTMLElement} */ (form.querySelector('#new-form-error'));
+    const submitBtn = /** @type {HTMLButtonElement} */ (form.querySelector('[type=submit]'));
     errDiv.className = 'd-none';
 
-    const title = form.querySelector('#newTitle').value.trim();
+    const title = /** @type {HTMLInputElement} */ (form.querySelector('#newTitle')).value.trim();
     if (!title) {
       errDiv.textContent = 'タイトルは必須です';
       errDiv.className = 'alert alert-danger py-2 small mb-3';
       return;
     }
-    const dueDate = form.querySelector('#newDue').value;
+    const dueDate = /** @type {HTMLInputElement} */ (form.querySelector('#newDue')).value;
     if (!dueDate) {
       errDiv.textContent = '期限日は必須です';
       errDiv.className = 'alert alert-danger py-2 small mb-3';
       return;
     }
-    const priority = form.querySelector('input[name="newPri"]:checked')?.value || 'MEDIUM';
-    const visibility = form.querySelector('input[name="newVis"]:checked')?.value || 'TENANT';
-    const assigneeId = form.querySelector('#newAssignee').value
-      ? Number(form.querySelector('#newAssignee').value)
-      : null;
-    const desc = form.querySelector('#newDesc').value.trim() || null;
+    const priority =
+      /** @type {HTMLInputElement | null} */ (form.querySelector('input[name="newPri"]:checked'))
+        ?.value || 'MEDIUM';
+    const visibility =
+      /** @type {HTMLInputElement | null} */ (form.querySelector('input[name="newVis"]:checked'))
+        ?.value || 'TENANT';
+    const assigneeRaw = /** @type {HTMLSelectElement} */ (form.querySelector('#newAssignee')).value;
+    const assigneeId = assigneeRaw ? Number(assigneeRaw) : null;
+    const desc =
+      /** @type {HTMLTextAreaElement} */ (form.querySelector('#newDesc')).value.trim() || null;
 
+    /** @type {{ title: string, dueDate: string, priority: string, visibility: string, description?: string | null, assigneeId?: number | null, stakeholderUserIds?: number[] }} */
     const body = { title, dueDate, priority, visibility };
     if (desc) body.description = desc;
     if (assigneeId) body.assigneeId = assigneeId;
@@ -498,14 +552,14 @@ class AppTaskDrawer extends HTMLElement {
     submitBtn.textContent = '作成中...';
     try {
       const task = await Api.createTask(body);
-      this.#oc.hide();
+      this.#oc?.hide();
       this.dispatchEvent(
         new CustomEvent('drawer-task-created', { bubbles: true, detail: { task } }),
       );
     } catch (err) {
       submitBtn.disabled = false;
       submitBtn.textContent = '作成';
-      errDiv.textContent = `作成に失敗しました: ${err.message || ''}`;
+      errDiv.textContent = `作成に失敗しました: ${/** @type {any} */ (err).message || ''}`;
       errDiv.className = 'alert alert-danger py-2 small mb-3';
     }
   }
@@ -514,6 +568,7 @@ class AppTaskDrawer extends HTMLElement {
 
   #renderDetail() {
     const task = this.#task;
+    if (!task) return;
     const hdr = this.#hdr;
     hdr.replaceChildren();
 
@@ -583,6 +638,7 @@ class AppTaskDrawer extends HTMLElement {
     // Meta fields grid
     const meta = document.createElement('div');
     meta.className = 'drawer-meta-grid mb-3';
+    /** @type {Array<[string, Node]>} */
     const metaFields = [
       ['優先度', this.#makePriBadge(task.priority)],
       ['期限', this.#dueDateEl(task.dueDate)],
@@ -691,7 +747,7 @@ class AppTaskDrawer extends HTMLElement {
       this.#tenantUsers.forEach((u) => {
         if (existIds.has(u.userId)) return;
         const opt = document.createElement('option');
-        opt.value = u.userId;
+        opt.value = String(u.userId);
         opt.textContent = u.fullName;
         sel.appendChild(opt);
       });
@@ -706,9 +762,11 @@ class AppTaskDrawer extends HTMLElement {
     return section;
   }
 
+  /** @param {HTMLElement} visRow */
   #showVisibilityPicker(visRow) {
-    // Replace the row content with an inline selector
     const task = this.#task;
+    if (!task) return;
+    // Replace the row content with an inline selector
     visRow.replaceChildren();
     const lbl = document.createElement('div');
     lbl.className = 'drawer-field-label';
@@ -734,7 +792,7 @@ class AppTaskDrawer extends HTMLElement {
     shSel.appendChild(shOptBlank);
     this.#tenantUsers.forEach((u) => {
       const opt = document.createElement('option');
-      opt.value = u.userId;
+      opt.value = String(u.userId);
       opt.textContent = u.fullName;
       opt.selected = this.#stakeholders.some((s) => s.userId === u.userId);
       shSel.appendChild(opt);
@@ -758,9 +816,12 @@ class AppTaskDrawer extends HTMLElement {
 
     saveBtn.addEventListener('click', async () => {
       const newVis = sel.value;
+      /** @type {number[] | undefined} */
       let shIds;
       if (newVis === 'STAKEHOLDERS') {
-        shIds = [...shSel.selectedOptions].map((o) => Number(o.value)).filter(Boolean);
+        shIds = Array.from(shSel.selectedOptions)
+          .map((o) => Number(o.value))
+          .filter(Boolean);
       }
       saveBtn.disabled = true;
       saveBtn.textContent = '保存中...';
@@ -775,7 +836,9 @@ class AppTaskDrawer extends HTMLElement {
           }),
         );
       } catch (err) {
-        this.#showDetailError(`公開範囲の変更に失敗しました: ${err.message || ''}`);
+        this.#showDetailError(
+          `公開範囲の変更に失敗しました: ${/** @type {any} */ (err).message || ''}`,
+        );
         this.#renderDetail();
       }
     });
@@ -788,11 +851,14 @@ class AppTaskDrawer extends HTMLElement {
     visRow.append(lbl, sel, shSection, btnRow);
   }
 
+  /** @param {HTMLElement} actionsEl */
   #showDeleteConfirm(actionsEl) {
+    const task = this.#task;
+    if (!task) return;
     actionsEl.replaceChildren();
     const msg = document.createElement('span');
     msg.className = 'small text-danger me-2 align-self-center';
-    msg.textContent = `「${this.#task.title}」を削除しますか？`;
+    msg.textContent = `「${task.title}」を削除しますか？`;
     const doBtn = document.createElement('button');
     doBtn.type = 'button';
     doBtn.className = 'btn btn-danger btn-sm';
@@ -803,12 +869,14 @@ class AppTaskDrawer extends HTMLElement {
     cancelBtn.textContent = '取消';
 
     doBtn.addEventListener('click', async () => {
+      const t = this.#task;
+      if (!t) return;
       doBtn.disabled = true;
       doBtn.textContent = '削除中...';
       try {
-        await Api.deleteTask(this.#task.id, this.#etag);
-        const taskId = this.#task.id;
-        this.#oc.hide();
+        await Api.deleteTask(t.id, /** @type {string} */ (this.#etag));
+        const taskId = t.id;
+        this.#oc?.hide();
         this.dispatchEvent(
           new CustomEvent('drawer-task-deleted', {
             bubbles: true,
@@ -816,12 +884,12 @@ class AppTaskDrawer extends HTMLElement {
           }),
         );
       } catch (err) {
-        if (err.status === 412) {
+        if (/** @type {any} */ (err).status === 412) {
           this.#showDetailError(
             '他のユーザーがこのタスクを編集しました。ページを再読み込みしてください。',
           );
         } else {
-          this.#showDetailError(`削除に失敗しました: ${err.message || ''}`);
+          this.#showDetailError(`削除に失敗しました: ${/** @type {any} */ (err).message || ''}`);
         }
         this.#renderDetail();
       }
@@ -831,6 +899,7 @@ class AppTaskDrawer extends HTMLElement {
     actionsEl.append(msg, doBtn, cancelBtn);
   }
 
+  /** @param {string} msg */
   #showDetailError(msg) {
     const errDiv = this.#bdy.querySelector('#detail-error');
     if (!errDiv) return;
@@ -838,8 +907,10 @@ class AppTaskDrawer extends HTMLElement {
     errDiv.className = 'alert alert-danger py-2 small mb-3';
   }
 
+  /** @param {HTMLSelectElement} sel */
   async #changeStatus(sel) {
     const task = this.#task;
+    if (!task) return;
     const prev = task.status;
     sel.disabled = true;
     try {
@@ -856,49 +927,64 @@ class AppTaskDrawer extends HTMLElement {
     } catch (err) {
       sel.value = prev;
       sel.disabled = false;
-      this.#showDetailError(`ステータスの更新に失敗しました: ${err.message || ''}`);
-    }
-  }
-
-  async #addStakeholder(userId) {
-    if (!userId) return;
-    try {
-      const sh = await Api.addStakeholder(this.#task.id, userId);
-      this.#stakeholders = [...this.#stakeholders, sh];
-      this.#renderDetail();
-    } catch (err) {
       this.#showDetailError(
-        err.status === 409
-          ? 'このユーザーはすでに関係者です'
-          : `関係者の追加に失敗しました: ${err.message || ''}`,
+        `ステータスの更新に失敗しました: ${/** @type {any} */ (err).message || ''}`,
       );
     }
   }
 
-  async #removeStakeholder(userId) {
+  /** @param {number} userId */
+  async #addStakeholder(userId) {
+    if (!userId) return;
+    const task = this.#task;
+    if (!task) return;
     try {
-      await Api.removeStakeholder(this.#task.id, userId);
+      const sh = await Api.addStakeholder(task.id, userId);
+      this.#stakeholders = [...this.#stakeholders, sh];
+      this.#renderDetail();
+    } catch (err) {
+      this.#showDetailError(
+        /** @type {any} */ (err).status === 409
+          ? 'このユーザーはすでに関係者です'
+          : `関係者の追加に失敗しました: ${/** @type {any} */ (err).message || ''}`,
+      );
+    }
+  }
+
+  /** @param {number} userId */
+  async #removeStakeholder(userId) {
+    const task = this.#task;
+    if (!task) return;
+    try {
+      await Api.removeStakeholder(task.id, userId);
       this.#stakeholders = this.#stakeholders.filter((s) => s.userId !== userId);
       this.#renderDetail();
     } catch (err) {
-      this.#showDetailError(`関係者の削除に失敗しました: ${err.message || ''}`);
+      this.#showDetailError(
+        `関係者の削除に失敗しました: ${/** @type {any} */ (err).message || ''}`,
+      );
     }
   }
 
   // ---- EDIT MODE ----
 
   #switchToEdit() {
-    this.#replaceUrl(`/tasks/${this.#task.id}/edit`);
+    const task = this.#task;
+    if (!task) return;
+    this.#replaceUrl(`/tasks/${task.id}/edit`);
     this.#renderEdit();
   }
 
   #switchToDetail() {
-    this.#replaceUrl(`/tasks/${this.#task.id}`);
+    const task = this.#task;
+    if (!task) return;
+    this.#replaceUrl(`/tasks/${task.id}`);
     this.#renderDetail();
   }
 
   #renderEdit() {
     const task = this.#task;
+    if (!task) return;
     const hdr = this.#hdr;
     hdr.replaceChildren();
     const title = document.createElement('h5');
@@ -967,7 +1053,7 @@ class AppTaskDrawer extends HTMLElement {
     assSel.appendChild(emptyOpt);
     this.#tenantUsers.forEach((u) => {
       const opt = document.createElement('option');
-      opt.value = u.userId;
+      opt.value = String(u.userId);
       opt.textContent = u.fullName;
       opt.selected = task.assignee?.id === u.userId;
       assSel.appendChild(opt);
@@ -1030,39 +1116,46 @@ class AppTaskDrawer extends HTMLElement {
     });
   }
 
+  /** @param {HTMLFormElement} form */
   async #submitEdit(form) {
-    const errDiv = this.#bdy.querySelector('#edit-form-error');
-    const saveBtn = form.querySelector('[type=submit]');
+    const task = this.#task;
+    if (!task) return;
+    const errDiv = /** @type {HTMLElement} */ (this.#bdy.querySelector('#edit-form-error'));
+    const saveBtn = /** @type {HTMLButtonElement} */ (form.querySelector('[type=submit]'));
     errDiv.className = 'd-none';
 
-    const title = form.querySelector('#editTitle').value.trim();
+    const title = /** @type {HTMLInputElement} */ (form.querySelector('#editTitle')).value.trim();
     if (!title) {
       errDiv.textContent = 'タイトルは必須です';
       errDiv.className = 'alert alert-danger py-2 small mb-3';
       return;
     }
-    const dueDate = form.querySelector('#editDue').value;
+    const dueDate = /** @type {HTMLInputElement} */ (form.querySelector('#editDue')).value;
     if (!dueDate) {
       errDiv.textContent = '期限日は必須です';
       errDiv.className = 'alert alert-danger py-2 small mb-3';
       return;
     }
 
-    const priority = form.querySelector('input[name="editPri"]:checked')?.value;
-    const assigneeId = form.querySelector('#editAssignee').value
-      ? Number(form.querySelector('#editAssignee').value)
-      : null;
-    const desc = form.querySelector('#editDesc').value.trim() || null;
+    const priority = /** @type {HTMLInputElement | null} */ (
+      form.querySelector('input[name="editPri"]:checked')
+    )?.value;
+    const assigneeRaw = /** @type {HTMLSelectElement} */ (form.querySelector('#editAssignee'))
+      .value;
+    const assigneeId = assigneeRaw ? Number(assigneeRaw) : null;
+    const desc =
+      /** @type {HTMLTextAreaElement} */ (form.querySelector('#editDesc')).value.trim() || null;
 
+    /** @type {Record<string, unknown>} */
     const body = {};
-    if (title !== this.#task.title) body.title = title;
-    if (dueDate !== this.#task.dueDate) body.dueDate = dueDate;
-    if (priority !== this.#task.priority) body.priority = priority;
+    if (title !== task.title) body.title = title;
+    if (dueDate !== task.dueDate) body.dueDate = dueDate;
+    if (priority !== task.priority) body.priority = priority;
     // description: null to clear, string to set
-    const prevDesc = this.#task.description || null;
+    const prevDesc = task.description || null;
     if (desc !== prevDesc) body.description = desc;
     // assigneeId: null to clear
-    const prevAss = this.#task.assignee?.id ?? null;
+    const prevAss = task.assignee?.id ?? null;
     if (assigneeId !== prevAss) body.assigneeId = assigneeId;
 
     if (Object.keys(body).length === 0) {
@@ -1074,7 +1167,7 @@ class AppTaskDrawer extends HTMLElement {
     saveBtn.disabled = true;
     saveBtn.textContent = '保存中...';
     try {
-      const updated = await Api.patchTask(this.#task.id, this.#etag, body);
+      const updated = await Api.patchTask(task.id, /** @type {string} */ (this.#etag), body);
       this.#task = updated;
       // Re-fetch ETag from updated task (patchTask returns TaskDetail with version)
       this.#etag = updated.version != null ? `W/"${updated.version}"` : this.#etag;
@@ -1088,13 +1181,13 @@ class AppTaskDrawer extends HTMLElement {
     } catch (err) {
       saveBtn.disabled = false;
       saveBtn.textContent = '保存';
-      if (err.status === 412) {
+      if (/** @type {any} */ (err).status === 412) {
         errDiv.textContent =
           '他のユーザーがこのタスクを編集しました。一旦閉じてから再度開いてください。';
-      } else if (err.status === 403) {
+      } else if (/** @type {any} */ (err).status === 403) {
         errDiv.textContent = '編集権限がありません';
       } else {
-        errDiv.textContent = `保存に失敗しました: ${err.message || ''}`;
+        errDiv.textContent = `保存に失敗しました: ${/** @type {any} */ (err).message || ''}`;
       }
       errDiv.className = 'alert alert-danger py-2 small mb-3';
     }
@@ -1102,6 +1195,11 @@ class AppTaskDrawer extends HTMLElement {
 
   // ---- Utilities ----
 
+  /**
+   * @param {string} id
+   * @param {string} label
+   * @param {boolean} required
+   */
   #fieldGroup(id, label, required) {
     const grp = document.createElement('div');
     grp.className = 'mb-3';
@@ -1120,6 +1218,10 @@ class AppTaskDrawer extends HTMLElement {
     return grp;
   }
 
+  /**
+   * @param {string} label
+   * @param {(() => void) | null} onRemove
+   */
   #makeChip(label, onRemove) {
     const chip = document.createElement('span');
     chip.className = 'drawer-chip';
@@ -1136,6 +1238,7 @@ class AppTaskDrawer extends HTMLElement {
     return chip;
   }
 
+  /** @param {string} priority */
   #makePriBadge(priority) {
     const span = document.createElement('span');
     span.className = `pri-badge pri-${priority}`;
@@ -1143,13 +1246,14 @@ class AppTaskDrawer extends HTMLElement {
     return span;
   }
 
+  /** @param {string | null} dueDate */
   #dueDateEl(dueDate) {
     if (!dueDate) return document.createTextNode('—');
     const today = new Date(
       `${new Intl.DateTimeFormat('en-CA', { timeZone: 'Asia/Tokyo' }).format(new Date())}T00:00:00`,
     );
     const due = new Date(`${dueDate}T00:00:00`);
-    const diff = Math.round((due - today) / 86400000);
+    const diff = Math.round((due.getTime() - today.getTime()) / 86400000);
     const md = dueDate.slice(5).replace('-', '/');
     if (diff < 0) {
       const span = document.createElement('span');
@@ -1166,6 +1270,7 @@ class AppTaskDrawer extends HTMLElement {
     return document.createTextNode(`${dueDate} (あと${diff}日)`);
   }
 
+  /** @param {string | null} iso */
   #fmtDate(iso) {
     if (!iso) return '—';
     return new Intl.DateTimeFormat('ja-JP', {
@@ -1176,6 +1281,7 @@ class AppTaskDrawer extends HTMLElement {
     }).format(new Date(iso));
   }
 
+  /** @param {string | null} iso */
   #fmtDateTime(iso) {
     if (!iso) return '—';
     return new Intl.DateTimeFormat('ja-JP', {

--- a/web/js/components/app-task-row.js
+++ b/web/js/components/app-task-row.js
@@ -1,3 +1,4 @@
+// @ts-check
 // <app-task-row> — renders as display:contents; contains a <tr> for table layout.
 // Usage:
 //   const row = document.createElement('app-task-row');
@@ -49,11 +50,12 @@ function todayJST() {
   return new Date(`${parts}T00:00:00`);
 }
 
+/** @param {string | null | undefined} dueDate */
 function dueLabelNode(dueDate) {
   if (!dueDate) return document.createTextNode('—');
   const today = todayJST();
   const due = new Date(`${dueDate}T00:00:00`);
-  const diff = Math.round((due - today) / 86400000);
+  const diff = Math.round((due.getTime() - today.getTime()) / 86400000);
   const md = dueDate.slice(5).replace('-', '/');
   if (diff < 0) {
     const span = document.createElement('span');
@@ -72,10 +74,14 @@ function dueLabelNode(dueDate) {
 }
 
 class AppTaskRow extends HTMLElement {
+  /** @type {Task | null} */
   #task = null;
+  /** @type {number | null} */
   #currentUserId = null;
+  /** @type {TenantUser[]} */
   #tenantUsers = [];
-  #editState = null; // { td, originalNodes, abort }
+  /** @type {{ td: HTMLElement, originalNodes: Node[], abort: () => void } | null} */
+  #editState = null;
 
   // Bind once so the same reference can be removed in disconnectedCallback
   #handleClick = this.#onClick.bind(this);
@@ -95,6 +101,11 @@ class AppTaskRow extends HTMLElement {
     this.removeEventListener('keydown', this.#handleKeydown);
   }
 
+  /**
+   * @param {Task} task
+   * @param {number | null} currentUserId
+   * @param {TenantUser[]} tenantUsers
+   */
   setTask(task, currentUserId, tenantUsers) {
     this.#task = task;
     this.#currentUserId = currentUserId;
@@ -113,19 +124,23 @@ class AppTaskRow extends HTMLElement {
   #render() {
     this.cancelEdit();
     const task = this.#task;
+    if (!task) return;
     const canEdit = task.editable;
     const canChangeStatus = task.editable || task.assignee?.id === this.#currentUserId;
+    const taskIdStr = String(task.id);
 
-    const tr = _rowTpl.content.cloneNode(true).firstElementChild;
-    tr.dataset.taskId = task.id;
+    const tr = /** @type {HTMLTableRowElement} */ (
+      /** @type {DocumentFragment} */ (_rowTpl.content.cloneNode(true)).firstElementChild
+    );
+    tr.dataset.taskId = taskIdStr;
 
     // --- Status cell ---
-    const statusTd = tr.querySelector('.cell-status');
+    const statusTd = /** @type {HTMLTableCellElement} */ (tr.querySelector('.cell-status'));
     if (canChangeStatus) {
       statusTd.dataset.noRowClick = '';
       const badge = document.createElement('app-status-badge');
       badge.setAttribute('status', task.status);
-      badge.setAttribute('task-id', task.id);
+      badge.setAttribute('task-id', taskIdStr);
       badge.setAttribute('editable', '');
       statusTd.appendChild(badge);
     } else {
@@ -135,23 +150,29 @@ class AppTaskRow extends HTMLElement {
     }
 
     // --- Title + description cell ---
-    const titleTd = tr.querySelector('.cell-title-desc');
+    const titleTd = /** @type {HTMLTableCellElement} */ (tr.querySelector('.cell-title-desc'));
     if (canEdit) {
       titleTd.dataset.noRowClick = '';
-      const titleDiv = _titleEditTpl.content.cloneNode(true).firstElementChild;
-      titleDiv.dataset.taskId = task.id;
+      const titleDiv = /** @type {HTMLElement} */ (
+        /** @type {DocumentFragment} */ (_titleEditTpl.content.cloneNode(true)).firstElementChild
+      );
+      titleDiv.dataset.taskId = taskIdStr;
       titleDiv.textContent = task.title;
       titleTd.appendChild(titleDiv);
 
       if (task.description) {
-        const descDiv = _descEditTpl.content.cloneNode(true).firstElementChild;
-        descDiv.dataset.taskId = task.id;
+        const descDiv = /** @type {HTMLElement} */ (
+          /** @type {DocumentFragment} */ (_descEditTpl.content.cloneNode(true)).firstElementChild
+        );
+        descDiv.dataset.taskId = taskIdStr;
         const preview = task.description.slice(0, 80) + (task.description.length > 80 ? '…' : '');
         descDiv.textContent = preview;
         titleTd.appendChild(descDiv);
       } else {
-        const descDiv = _descEmptyTpl.content.cloneNode(true).firstElementChild;
-        descDiv.dataset.taskId = task.id;
+        const descDiv = /** @type {HTMLElement} */ (
+          /** @type {DocumentFragment} */ (_descEmptyTpl.content.cloneNode(true)).firstElementChild
+        );
+        descDiv.dataset.taskId = taskIdStr;
         titleTd.appendChild(descDiv);
       }
     } else {
@@ -170,19 +191,20 @@ class AppTaskRow extends HTMLElement {
 
     // --- Owner cell ---
     const ownerIni = (task.owner?.fullName || '?').slice(0, 1);
-    const ownerTd = tr.querySelector('.cell-owner');
-    ownerTd.querySelector('.owner-mini').textContent = ownerIni;
-    ownerTd.querySelector('.owner-name').textContent = task.owner?.fullName ?? '—';
+    const ownerTd = /** @type {HTMLTableCellElement} */ (tr.querySelector('.cell-owner'));
+    /** @type {HTMLElement} */ (ownerTd.querySelector('.owner-mini')).textContent = ownerIni;
+    /** @type {HTMLElement} */ (ownerTd.querySelector('.owner-name')).textContent =
+      task.owner?.fullName ?? '—';
 
     // --- Assignee cell ---
-    const assigneeTd = tr.querySelector('.cell-assignee');
+    const assigneeTd = /** @type {HTMLTableCellElement} */ (tr.querySelector('.cell-assignee'));
     const assigneeName = task.assignee?.fullName ?? '—';
     if (canEdit) {
       assigneeTd.dataset.noRowClick = '';
       const span = document.createElement('span');
       span.className = 'edit-cell';
       span.dataset.action = 'cell-edit';
-      span.dataset.taskId = task.id;
+      span.dataset.taskId = taskIdStr;
       span.dataset.field = 'assigneeId';
       span.title = 'クリックして担当者を変更';
       span.textContent = assigneeName;
@@ -195,13 +217,13 @@ class AppTaskRow extends HTMLElement {
     }
 
     // --- Due date cell ---
-    const dueTd = tr.querySelector('.cell-duedate');
+    const dueTd = /** @type {HTMLTableCellElement} */ (tr.querySelector('.cell-duedate'));
     if (canEdit) {
       dueTd.dataset.noRowClick = '';
       const span = document.createElement('span');
       span.className = 'edit-cell';
       span.dataset.action = 'cell-edit';
-      span.dataset.taskId = task.id;
+      span.dataset.taskId = taskIdStr;
       span.dataset.field = 'dueDate';
       span.title = 'クリックして期限を変更';
       span.appendChild(dueLabelNode(task.dueDate));
@@ -211,12 +233,12 @@ class AppTaskRow extends HTMLElement {
     }
 
     // --- Priority cell ---
-    const priorityTd = tr.querySelector('.cell-priority');
+    const priorityTd = /** @type {HTMLTableCellElement} */ (tr.querySelector('.cell-priority'));
     if (canEdit) {
       priorityTd.dataset.noRowClick = '';
       const badge = document.createElement('app-priority-badge');
       badge.setAttribute('priority', task.priority);
-      badge.setAttribute('task-id', task.id);
+      badge.setAttribute('task-id', taskIdStr);
       badge.setAttribute('editable', '');
       priorityTd.appendChild(badge);
     } else {
@@ -226,7 +248,7 @@ class AppTaskRow extends HTMLElement {
     }
 
     // --- Visibility cell ---
-    const visTd = tr.querySelector('.cell-visibility');
+    const visTd = /** @type {HTMLTableCellElement} */ (tr.querySelector('.cell-visibility'));
     const visBadge = document.createElement('app-visibility-badge');
     visBadge.setAttribute('visibility', task.visibility);
     visTd.appendChild(visBadge);
@@ -236,14 +258,19 @@ class AppTaskRow extends HTMLElement {
 
   // ---- Inline cell editing ----
 
+  /**
+   * @param {Element} triggerEl
+   * @param {string} field
+   */
   #activateCellEdit(triggerEl, field) {
     const task = this.#task;
     if (!task?.editable) return;
 
     this.cancelEdit();
 
-    const td = triggerEl.closest('td');
-    const originalNodes = [...td.childNodes].map((n) => n.cloneNode(true));
+    const td = /** @type {HTMLElement} */ (triggerEl.closest('td'));
+    const originalNodes = Array.from(td.childNodes).map((n) => n.cloneNode(true));
+    /** @type {HTMLInputElement | HTMLSelectElement | undefined} */
     let input;
 
     if (field === 'title') {
@@ -266,10 +293,10 @@ class AppTaskRow extends HTMLElement {
       input.appendChild(emptyOpt);
       this.#tenantUsers.forEach((u) => {
         const opt = document.createElement('option');
-        opt.value = u.userId;
+        opt.value = String(u.userId);
         opt.textContent = u.fullName;
         opt.selected = task.assignee?.id === u.userId;
-        input.appendChild(opt);
+        /** @type {HTMLSelectElement} */ (input).appendChild(opt);
       });
       input.value = task.assignee?.id != null ? String(task.assignee.id) : '';
     }
@@ -288,7 +315,7 @@ class AppTaskRow extends HTMLElement {
 
     td.replaceChildren(input);
     input.focus();
-    if (field === 'title') input.select();
+    if (field === 'title') /** @type {HTMLInputElement} */ (input).select();
 
     const doCommit = async () => {
       if (done) return;
@@ -313,13 +340,14 @@ class AppTaskRow extends HTMLElement {
     };
 
     input.addEventListener('keydown', (e) => {
-      if (e.key === 'Escape') {
+      const ke = /** @type {KeyboardEvent} */ (e);
+      if (ke.key === 'Escape') {
         done = true;
         td.replaceChildren(...originalNodes);
         this.#editState = null;
       }
-      if (e.key === 'Enter') {
-        e.preventDefault();
+      if (ke.key === 'Enter') {
+        ke.preventDefault();
         doCommit();
       }
     });
@@ -332,13 +360,16 @@ class AppTaskRow extends HTMLElement {
 
   // ---- Event handlers ----
 
+  /** @param {MouseEvent} e */
   #onClick(e) {
-    const actionEl = e.target.closest('[data-action]');
+    const actionEl = /** @type {HTMLElement | null} */ (
+      /** @type {Element} */ (e.target).closest('[data-action]')
+    );
     if (actionEl) {
       const { action, taskId, field } = actionEl.dataset;
       const id = Number(taskId);
       if (action === 'cell-edit') {
-        this.#activateCellEdit(actionEl, field);
+        this.#activateCellEdit(actionEl, field ?? '');
       } else if (action === 'desc-edit') {
         this.dispatchEvent(
           new CustomEvent('task-desc-open', {
@@ -350,8 +381,10 @@ class AppTaskRow extends HTMLElement {
       return;
     }
     // Row click when not in a no-click cell
-    if (!e.target.closest('[data-no-row-click]')) {
-      const tr = e.target.closest('tr[data-task-id]');
+    if (!(/** @type {Element} */ (e.target).closest('[data-no-row-click]'))) {
+      const tr = /** @type {HTMLElement | null} */ (
+        /** @type {Element} */ (e.target).closest('tr[data-task-id]')
+      );
       if (tr) {
         this.dispatchEvent(
           new CustomEvent('task-row-click', {
@@ -363,8 +396,11 @@ class AppTaskRow extends HTMLElement {
     }
   }
 
+  /** @param {Event} e */
   #onChange(e) {
-    const actionEl = e.target.closest('[data-action]');
+    const actionEl = /** @type {HTMLSelectElement | null} */ (
+      /** @type {Element} */ (e.target).closest('[data-action]')
+    );
     if (!actionEl) return;
     const taskId = Number(actionEl.dataset.taskId);
     if (actionEl.dataset.action === 'status-change') {
@@ -384,9 +420,12 @@ class AppTaskRow extends HTMLElement {
     }
   }
 
+  /** @param {KeyboardEvent} e */
   #onKeydown(e) {
     if (e.key !== 'Enter' && e.key !== ' ') return;
-    const tr = e.target.closest('tr[data-task-id]');
+    const tr = /** @type {HTMLElement | null} */ (
+      /** @type {Element} */ (e.target).closest('tr[data-task-id]')
+    );
     if (tr && e.target === tr) {
       e.preventDefault();
       this.dispatchEvent(

--- a/web/js/components/app-tenant-switcher.js
+++ b/web/js/components/app-tenant-switcher.js
@@ -1,3 +1,4 @@
+// @ts-check
 // <app-tenant-switcher> — dropdown or chip for switching tenants.
 // Method: setData(tenants, activeTenantId)
 // Depends on: Api (Api.selectTenant, Api.setTenantId), Bootstrap 5
@@ -24,20 +25,23 @@ _tsItemTpl.innerHTML = `
   </button>
 </li>`;
 
+/** @param {string} role */
 function _roleLabel(role) {
   return role === 'TENANT_ADMIN' ? '管理者' : 'メンバー';
 }
 
+/** @param {number} tenantId */
 async function _switchTenant(tenantId) {
   try {
     await Api.selectTenant(tenantId);
-    Api.setTenantId(tenantId);
+    Api.setTenantId(String(tenantId));
     window.location.reload();
   } catch (err) {
-    _showErrorToast(`テナント切替に失敗しました: ${err.message}`);
+    _showErrorToast(`テナント切替に失敗しました: ${/** @type {any} */ (err).message}`);
   }
 }
 
+/** @param {string} message */
 function _showErrorToast(message) {
   const toast = document.createElement('div');
   toast.className =
@@ -67,13 +71,19 @@ function _showErrorToast(message) {
 }
 
 class AppTenantSwitcher extends HTMLElement {
+  /**
+   * @param {Array<{id: number, name: string, role: string}> | null} tenants
+   * @param {number | null} activeTenantId
+   */
   setData(tenants, activeTenantId) {
     this.replaceChildren();
     if (!tenants || tenants.length === 0) return;
     this.classList.remove('d-none');
 
     if (tenants.length === 1) {
-      const chip = _tsBadgeTpl.content.cloneNode(true).firstElementChild;
+      const chip = /** @type {HTMLElement} */ (
+        /** @type {DocumentFragment} */ (_tsBadgeTpl.content.cloneNode(true)).firstElementChild
+      );
       chip.textContent = tenants[0].name;
       chip.title = _roleLabel(tenants[0].role);
       this.appendChild(chip);
@@ -81,19 +91,23 @@ class AppTenantSwitcher extends HTMLElement {
     }
 
     const activeTenant = tenants.find((t) => t.id === activeTenantId) ?? null;
-    const wrapper = _tsDropdownTpl.content.cloneNode(true).firstElementChild;
-    wrapper.querySelector('.ts-label').textContent = activeTenant
+    const wrapper = /** @type {HTMLElement} */ (
+      /** @type {DocumentFragment} */ (_tsDropdownTpl.content.cloneNode(true)).firstElementChild
+    );
+    /** @type {HTMLElement} */ (wrapper.querySelector('.ts-label')).textContent = activeTenant
       ? activeTenant.name
       : 'テナントを選択';
 
-    const menu = wrapper.querySelector('.ts-menu');
+    const menu = /** @type {HTMLElement} */ (wrapper.querySelector('.ts-menu'));
     tenants.forEach((t) => {
-      const li = _tsItemTpl.content.cloneNode(true).firstElementChild;
-      const btn = li.querySelector('button');
+      const li = /** @type {HTMLElement} */ (
+        /** @type {DocumentFragment} */ (_tsItemTpl.content.cloneNode(true)).firstElementChild
+      );
+      const btn = /** @type {HTMLButtonElement} */ (li.querySelector('button'));
       const isActive = t.id === activeTenantId;
       if (isActive) btn.classList.add('active');
-      li.querySelector('.ts-item-name').textContent = t.name;
-      const roleEl = li.querySelector('.ts-item-role');
+      /** @type {HTMLElement} */ (li.querySelector('.ts-item-name')).textContent = t.name;
+      const roleEl = /** @type {HTMLElement} */ (li.querySelector('.ts-item-role'));
       roleEl.textContent = _roleLabel(t.role);
       if (isActive) {
         roleEl.classList.remove('text-muted');

--- a/web/js/components/app-visibility-badge.js
+++ b/web/js/components/app-visibility-badge.js
@@ -1,3 +1,4 @@
+// @ts-check
 // <app-visibility-badge visibility="TENANT">
 const _visBadgeTpl = document.createElement('template');
 _visBadgeTpl.innerHTML = '<span class="vis-badge"><i aria-hidden="true"></i></span>';
@@ -17,9 +18,11 @@ class AppVisibilityBadge extends HTMLElement {
   #render() {
     const vis = this.getAttribute('visibility') || 'TENANT';
     const [label, cls, icon] = TaskMeta.visibility(vis);
-    const span = _visBadgeTpl.content.cloneNode(true).firstElementChild;
+    const span = /** @type {HTMLElement} */ (
+      /** @type {DocumentFragment} */ (_visBadgeTpl.content.cloneNode(true)).firstElementChild
+    );
     span.className = `vis-badge ${cls}`;
-    span.querySelector('i').className = `bi ${icon}`;
+    /** @type {HTMLElement} */ (span.querySelector('i')).className = `bi ${icon}`;
     span.appendChild(document.createTextNode(label));
     this.replaceChildren(span);
   }

--- a/web/js/index.js
+++ b/web/js/index.js
@@ -1,35 +1,43 @@
-document.getElementById('btn-logout').addEventListener('click', () => Auth.logout());
+// @ts-check
+/** @type {HTMLElement} */ (mustQuery(document, '#btn-logout')).addEventListener('click', () =>
+  Auth.logout(),
+);
 
 async function main() {
   const authenticated = await Auth.init();
-  document.getElementById('loading').classList.add('d-none');
+  /** @type {HTMLElement} */ (mustQuery(document, '#loading')).classList.add('d-none');
 
   if (!authenticated) {
     return;
   }
 
   const user = Auth.getUser();
-  document.getElementById('nav-username').textContent = user.name || user.preferred_username || '';
-  document.getElementById('nav-username').classList.remove('d-none');
-  document.getElementById('btn-logout').classList.remove('d-none');
-  document.getElementById('content-logged-in').classList.remove('d-none');
+  /** @type {HTMLElement} */ (mustQuery(document, '#nav-username')).textContent =
+    user?.name || user?.preferred_username || '';
+  /** @type {HTMLElement} */ (mustQuery(document, '#nav-username')).classList.remove('d-none');
+  /** @type {HTMLElement} */ (mustQuery(document, '#btn-logout')).classList.remove('d-none');
+  /** @type {HTMLElement} */ (mustQuery(document, '#content-logged-in')).classList.remove('d-none');
 
   try {
     const me = await Api.getMe();
 
     if (me.activeTenantId !== null) {
-      Api.setTenantId(me.activeTenantId);
+      Api.setTenantId(String(me.activeTenantId));
       window.location.replace('tasks.html');
       return;
     }
 
     // テナント未選択: テナント選択 UI を表示
-    document.getElementById('user-info').textContent =
+    /** @type {HTMLElement} */ (mustQuery(document, '#user-info')).textContent =
       'テナントを選択してタスク一覧を開いてください。';
 
-    document.getElementById('tenant-switcher').setData(me.tenants, me.activeTenantId);
+    /** @type {AppTenantSwitcherElement} */ (mustQuery(document, '#tenant-switcher')).setData(
+      me.tenants,
+      me.activeTenantId,
+    );
   } catch (err) {
-    document.getElementById('user-info').textContent = `API 呼び出しエラー: ${err.message}`;
+    /** @type {HTMLElement} */ (mustQuery(document, '#user-info')).textContent =
+      `API 呼び出しエラー: ${/** @type {any} */ (err).message}`;
   }
 }
 

--- a/web/js/tasks.js
+++ b/web/js/tasks.js
@@ -1,3 +1,4 @@
+// @ts-check
 // ---- Page state ----
 let currentPage = 0;
 let currentSort = 'dueDate,asc';
@@ -8,25 +9,32 @@ const PAGE_SIZE = 50;
 // ---- Task / user state ----
 const taskMap = new Map(); // taskId(number) → Task object
 const rowMap = new Map(); // taskId(number) → app-task-row element
+/** @type {number | null} */
 let currentUserId = null;
+/** @type {TenantUser[]} */
 let tenantUsers = [];
 
 // ---- CE references ----
-const errorBanner = document.getElementById('error-banner');
-const conflictBanner = document.getElementById('conflict-banner');
-const descPopover = document.getElementById('desc-popover');
-const taskDrawer = document.getElementById('task-drawer');
-const pager = document.getElementById('task-pager');
-const tbody = document.getElementById('task-tbody');
+const errorBanner = /** @type {AppErrorBannerElement} */ (mustQuery(document, '#error-banner'));
+const conflictBanner = /** @type {AppConflictBannerElement} */ (
+  mustQuery(document, '#conflict-banner')
+);
+const descPopover = /** @type {AppDescPopoverElement} */ (mustQuery(document, '#desc-popover'));
+const taskDrawer = /** @type {AppTaskDrawerElement} */ (mustQuery(document, '#task-drawer'));
+const pager = /** @type {AppPagerElement} */ (mustQuery(document, '#task-pager'));
+const tbody = /** @type {HTMLElement} */ (mustQuery(document, '#task-tbody'));
 
 // ETag format per ADR-0012: W/"<version>"
+/** @param {{ version: number }} task */
 function buildEtag(task) {
   return `W/"${task.version}"`;
 }
 
 // ---- Render task list from API response ----
+/** @param {Task[]} tasks */
 function renderTasks(tasks) {
-  document.getElementById('total-count').textContent = `${totalElements} 件`;
+  /** @type {HTMLElement} */ (mustQuery(document, '#total-count')).textContent =
+    `${totalElements} 件`;
   rowMap.clear();
 
   if (!tasks || tasks.length === 0) {
@@ -45,7 +53,7 @@ function renderTasks(tasks) {
   }
 
   const rows = tasks.map((task) => {
-    const row = document.createElement('app-task-row');
+    const row = /** @type {AppTaskRowElement} */ (document.createElement('app-task-row'));
     row.setTask(task, currentUserId, tenantUsers);
     rowMap.set(task.id, row);
     return row;
@@ -54,6 +62,7 @@ function renderTasks(tasks) {
 }
 
 // ---- Re-render a single row after a successful PATCH ----
+/** @param {number} taskId */
 function rerenderRow(taskId) {
   const task = taskMap.get(taskId);
   const row = rowMap.get(taskId);
@@ -62,6 +71,11 @@ function rerenderRow(taskId) {
 }
 
 // ---- Inline status change (PATCH /api/tasks/{id}/status) ----
+/**
+ * @param {number} taskId
+ * @param {string} status
+ * @param {HTMLSelectElement} selectEl
+ */
 async function onStatusChange(taskId, status, selectEl) {
   selectEl.disabled = true;
   try {
@@ -71,12 +85,18 @@ async function onStatusChange(taskId, status, selectEl) {
   } catch (err) {
     rerenderRow(taskId); // revert
     // PATCH /api/tasks/{id}/status は ADR-0012 の If-Match 対象外のため 412 は理論上返らない
-    if (err.status === 412) conflictBanner.show();
-    else errorBanner.show(`ステータスの更新に失敗しました: ${err.message || ''}`);
+    if (/** @type {any} */ (err).status === 412) conflictBanner.show();
+    else
+      errorBanner.show(`ステータスの更新に失敗しました: ${/** @type {any} */ (err).message || ''}`);
   }
 }
 
 // ---- Inline priority change (PATCH /api/tasks/{id} with ETag) ----
+/**
+ * @param {number} taskId
+ * @param {string} priority
+ * @param {HTMLSelectElement} selectEl
+ */
 async function onPriorityChange(taskId, priority, selectEl) {
   const task = taskMap.get(taskId);
   if (!task) return;
@@ -87,16 +107,22 @@ async function onPriorityChange(taskId, priority, selectEl) {
     rerenderRow(taskId);
   } catch (err) {
     rerenderRow(taskId);
-    if (err.status === 412) conflictBanner.show();
-    else errorBanner.show(`優先度の更新に失敗しました: ${err.message || ''}`);
+    if (/** @type {any} */ (err).status === 412) conflictBanner.show();
+    else errorBanner.show(`優先度の更新に失敗しました: ${/** @type {any} */ (err).message || ''}`);
   }
 }
 
 // ---- Field commit (title / dueDate / assigneeId via app-task-row) ----
+/**
+ * @param {number} taskId
+ * @param {string} field
+ * @param {string | null} value
+ */
 async function onFieldCommit(taskId, field, value) {
   const task = taskMap.get(taskId);
   if (!task) return;
 
+  /** @type {Record<string, unknown> | undefined} */
   let body;
   if (field === 'assigneeId') body = { assigneeId: value ? Number(value) : null };
   else if (field === 'dueDate') body = { dueDate: value };
@@ -109,12 +135,16 @@ async function onFieldCommit(taskId, field, value) {
     rerenderRow(taskId);
   } catch (err) {
     rerenderRow(taskId);
-    if (err.status === 412) conflictBanner.show();
-    else errorBanner.show(`更新に失敗しました: ${err.message || ''}`);
+    if (/** @type {any} */ (err).status === 412) conflictBanner.show();
+    else errorBanner.show(`更新に失敗しました: ${/** @type {any} */ (err).message || ''}`);
   }
 }
 
 // ---- Description save (from app-desc-popover) ----
+/**
+ * @param {number} taskId
+ * @param {string | null} value
+ */
 async function onDescCommit(taskId, value) {
   const task = taskMap.get(taskId);
   if (!task) return;
@@ -124,8 +154,8 @@ async function onDescCommit(taskId, value) {
     taskMap.set(taskId, updated);
     rerenderRow(taskId);
   } catch (err) {
-    if (err.status === 412) conflictBanner.show();
-    else errorBanner.show(`説明の更新に失敗しました: ${err.message || ''}`);
+    if (/** @type {any} */ (err).status === 412) conflictBanner.show();
+    else errorBanner.show(`説明の更新に失敗しました: ${/** @type {any} */ (err).message || ''}`);
   }
 }
 
@@ -136,9 +166,13 @@ function cancelAllEdits() {
 }
 
 // ---- UI state helpers (design-system.md §6.11) ----
+/** @param {boolean} on */
 function showLoading(on) {
-  document.getElementById('loading-skeleton').classList.toggle('d-none', !on);
-  document.getElementById('task-panel').classList.toggle('d-none', on);
+  /** @type {HTMLElement} */ (mustQuery(document, '#loading-skeleton')).classList.toggle(
+    'd-none',
+    !on,
+  );
+  /** @type {HTMLElement} */ (mustQuery(document, '#task-panel')).classList.toggle('d-none', on);
 }
 
 // ---- Task list (GET /api/tasks) ----
@@ -160,12 +194,13 @@ async function loadTasks() {
     pager.update({ currentPage, totalPages, totalElements, pageSize: PAGE_SIZE });
     showLoading(false);
   } catch (err) {
-    document.getElementById('loading-skeleton').classList.add('d-none');
-    errorBanner.show(err.message || 'タスクの取得に失敗しました');
+    /** @type {HTMLElement} */ (mustQuery(document, '#loading-skeleton')).classList.add('d-none');
+    errorBanner.show(/** @type {any} */ (err).message || 'タスクの取得に失敗しました');
   }
 }
 
 // ---- Sort ----
+/** @param {string} value */
 function onSortChange(value) {
   currentSort = value;
   currentPage = 0;
@@ -173,11 +208,12 @@ function onSortChange(value) {
   loadTasks();
 }
 
+/** @param {string} field */
 function cycleSort(field) {
   const [f, d] = currentSort.split(',');
   currentSort = f === field ? `${field},${d === 'asc' ? 'desc' : 'asc'}` : `${field},asc`;
-  const sel = document.getElementById('sortSel');
-  const match = [...sel.options].find((o) => o.value === currentSort);
+  const sel = /** @type {HTMLSelectElement} */ (mustQuery(document, '#sortSel'));
+  const match = Array.from(sel.options).find((o) => o.value === currentSort);
   if (match) sel.value = currentSort;
   currentPage = 0;
   updateSortCarets();
@@ -199,6 +235,7 @@ function updateSortCarets() {
 }
 
 // ---- Row click → open detail drawer (S-05) ----
+/** @param {number} id */
 function onRowClick(id) {
   taskDrawer.openDetail(id);
 }
@@ -206,24 +243,33 @@ function onRowClick(id) {
 // ---- Event listeners on CEs ----
 
 // app-task-row events (bubble up through tbody)
-tbody.addEventListener('task-status-change', (e) =>
-  onStatusChange(e.detail.taskId, e.detail.status, e.detail.selectEl),
+tbody.addEventListener('task-status-change', (e) => {
+  const { taskId, status, selectEl } = /** @type {CustomEvent} */ (e).detail;
+  onStatusChange(taskId, status, selectEl);
+});
+tbody.addEventListener('task-priority-change', (e) => {
+  const { taskId, priority, selectEl } = /** @type {CustomEvent} */ (e).detail;
+  onPriorityChange(taskId, priority, selectEl);
+});
+tbody.addEventListener('task-field-commit', (e) => {
+  const { taskId, field, value } = /** @type {CustomEvent} */ (e).detail;
+  onFieldCommit(taskId, field, value);
+});
+tbody.addEventListener('task-row-click', (e) =>
+  onRowClick(/** @type {CustomEvent} */ (e).detail.taskId),
 );
-tbody.addEventListener('task-priority-change', (e) =>
-  onPriorityChange(e.detail.taskId, e.detail.priority, e.detail.selectEl),
-);
-tbody.addEventListener('task-field-commit', (e) =>
-  onFieldCommit(e.detail.taskId, e.detail.field, e.detail.value),
-);
-tbody.addEventListener('task-row-click', (e) => onRowClick(e.detail.taskId));
 tbody.addEventListener('task-desc-open', (e) => {
-  const task = taskMap.get(e.detail.taskId);
+  const { taskId, triggerEl } = /** @type {CustomEvent} */ (e).detail;
+  const task = taskMap.get(taskId);
   if (!task?.editable) return;
-  descPopover.open(e.detail.taskId, e.detail.triggerEl, task.description);
+  descPopover.open(taskId, triggerEl, task.description);
 });
 
 // app-desc-popover events
-descPopover.addEventListener('desc-commit', (e) => onDescCommit(e.detail.taskId, e.detail.value));
+descPopover.addEventListener('desc-commit', (e) => {
+  const { taskId, value } = /** @type {CustomEvent} */ (e).detail;
+  onDescCommit(taskId, value);
+});
 
 // app-error-banner retry
 errorBanner.addEventListener('error-retry', loadTasks);
@@ -238,7 +284,7 @@ conflictBanner.addEventListener('conflict-reload', () => {
 taskDrawer.addEventListener('drawer-task-created', () => loadTasks());
 taskDrawer.addEventListener('drawer-task-deleted', () => loadTasks());
 taskDrawer.addEventListener('drawer-task-updated', (e) => {
-  const updated = e.detail?.task;
+  const updated = /** @type {CustomEvent} */ (e).detail?.task;
   if (!updated) {
     loadTasks();
     return;
@@ -249,29 +295,40 @@ taskDrawer.addEventListener('drawer-task-updated', (e) => {
 
 // app-pager
 pager.addEventListener('page-change', (e) => {
-  const p = e.detail.page;
+  const p = /** @type {CustomEvent} */ (e).detail.page;
   if (p < 0 || p >= totalPages) return;
   currentPage = p;
   loadTasks();
 });
 
 // Static controls
-document.getElementById('btn-logout').addEventListener('click', () => Auth.logout());
-document.getElementById('sortSel').addEventListener('change', (e) => onSortChange(e.target.value));
-document.getElementById('btn-new-task').addEventListener('click', () => taskDrawer.open());
-document.getElementById('th-dueDate').addEventListener('click', () => cycleSort('dueDate'));
-document.getElementById('th-priority').addEventListener('click', () => cycleSort('priority'));
+/** @type {HTMLElement} */ (mustQuery(document, '#btn-logout')).addEventListener('click', () =>
+  Auth.logout(),
+);
+/** @type {HTMLElement} */ (mustQuery(document, '#sortSel')).addEventListener('change', (e) =>
+  onSortChange(/** @type {HTMLSelectElement} */ (e.target).value),
+);
+/** @type {HTMLElement} */ (mustQuery(document, '#btn-new-task')).addEventListener('click', () =>
+  taskDrawer.open(),
+);
+/** @type {HTMLElement} */ (mustQuery(document, '#th-dueDate')).addEventListener('click', () =>
+  cycleSort('dueDate'),
+);
+/** @type {HTMLElement} */ (mustQuery(document, '#th-priority')).addEventListener('click', () =>
+  cycleSort('priority'),
+);
 
 // ---- Init ----
 async function main() {
   const authenticated = await Auth.init();
   if (!authenticated) return;
 
+  /** @type {MeResponse} */
   let me;
   try {
     me = await Api.getMe();
   } catch (err) {
-    errorBanner.show(`ユーザー情報の取得に失敗しました: ${err.message}`);
+    errorBanner.show(`ユーザー情報の取得に失敗しました: ${/** @type {any} */ (err).message}`);
     return;
   }
 
@@ -280,16 +337,20 @@ async function main() {
 
   const user = Auth.getUser();
   const displayName = user?.name || user?.preferred_username || '';
-  document.getElementById('nav-username').textContent = displayName;
-  document.getElementById('user-avatar').textContent = displayName.slice(0, 1) || '?';
+  /** @type {HTMLElement} */ (mustQuery(document, '#nav-username')).textContent = displayName;
+  /** @type {HTMLElement} */ (mustQuery(document, '#user-avatar')).textContent =
+    displayName.slice(0, 1) || '?';
 
   if (!me.activeTenantId) {
     window.location.replace('index.html');
     return;
   }
-  Api.setTenantId(me.activeTenantId);
+  Api.setTenantId(String(me.activeTenantId));
 
-  document.getElementById('tenant-switcher').setData(me.tenants, me.activeTenantId);
+  /** @type {AppTenantSwitcherElement} */ (mustQuery(document, '#tenant-switcher')).setData(
+    me.tenants,
+    me.activeTenantId,
+  );
 
   // Reflect Tenant Admin role in sidebar
   const activeTenant = me.tenants?.find((t) => t.id === me.activeTenantId);

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -15,6 +15,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "^2.4.16",
+        "@types/node": "^25.9.3",
         "html-validate": "^11.5.3",
         "typescript": "^5.8.0"
       },
@@ -238,6 +239,16 @@
       },
       "peerDependencies": {
         "ajv": "^8.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.9.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
+      "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "node_modules/ajv": {
@@ -476,6 +487,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/web/package.json
+++ b/web/package.json
@@ -18,6 +18,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.16",
+    "@types/node": "^25.9.3",
     "html-validate": "^11.5.3",
     "typescript": "^5.8.0"
   }

--- a/web/scripts/copy-vendor.js
+++ b/web/scripts/copy-vendor.js
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * deploy 時に node_modules の dist ファイルを vendor/ へコピーするスクリプト。
  * バンドラ不要。S3 アップロード前に実行する。
@@ -10,6 +11,10 @@ const path = require('node:path');
 const nm = path.resolve(__dirname, '../node_modules');
 const dst = path.resolve(__dirname, '../vendor');
 
+/**
+ * @param {string} from
+ * @param {string} to
+ */
 function cp(from, to) {
   const src = path.join(nm, from);
   const out = path.join(dst, to);

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -6,7 +6,8 @@
     "allowJs": true,
     "checkJs": false,
     "strict": true,
-    "noEmit": true
+    "noEmit": true,
+    "skipLibCheck": true
   },
   "include": ["js/**/*.js", "scripts/**/*.js", "types/**/*.d.ts"]
 }

--- a/web/types/globals.d.ts
+++ b/web/types/globals.d.ts
@@ -34,6 +34,83 @@ declare const Keycloak: {
   new (config: KeycloakConfig): KeycloakInstance;
 };
 
+// --- Keycloak ID token payload ---
+interface KeycloakUser {
+  name?: string;
+  preferred_username?: string;
+  sub?: string;
+  [key: string]: unknown;
+}
+
 // --- Bootstrap (vendor/bootstrap/js/bootstrap.bundle.min.js) ---
-// Used in component files (none of which have // @ts-check).
-declare const bootstrap: Record<string, unknown>;
+
+interface BootstrapOffcanvas {
+  show(): void;
+  hide(): void;
+  dispose(): void;
+}
+
+interface BootstrapToast {
+  show(): void;
+  dispose(): void;
+}
+
+declare const bootstrap: {
+  Offcanvas: {
+    new (element: Element, options?: Record<string, unknown>): BootstrapOffcanvas;
+    getInstance(element: Element | null): BootstrapOffcanvas | null;
+    getOrCreateInstance(element: Element): BootstrapOffcanvas;
+  };
+  Toast: {
+    new (element: Element, options?: Record<string, unknown>): BootstrapToast;
+  };
+};
+
+// --- Custom Element consumer interfaces (used by tasks.js / index.js) ---
+
+interface AppErrorBannerElement extends HTMLElement {
+  show(message: string): void;
+  hide(): void;
+}
+
+interface AppConflictBannerElement extends HTMLElement {
+  show(): void;
+  hide(): void;
+}
+
+interface AppDescPopoverElement extends HTMLElement {
+  readonly isOpen: boolean | null;
+  open(taskId: number, triggerEl: Element, description: string | null): void;
+  close(): void;
+}
+
+interface AppTaskDrawerElement extends HTMLElement {
+  setCurrentUser(userId: number | null): void;
+  setUsers(users: TenantUser[]): void;
+  open(): void;
+  openNew(opts?: Record<string, string>): void;
+  openDetail(taskId: number): Promise<void>;
+  openEdit(taskId: number): Promise<void>;
+}
+
+interface AppPagerElement extends HTMLElement {
+  update(opts: {
+    currentPage: number;
+    totalPages: number;
+    totalElements: number;
+    pageSize: number;
+  }): void;
+}
+
+interface AppTenantSwitcherElement extends HTMLElement {
+  setData(
+    tenants: Array<Record<string, unknown>> | null,
+    activeTenantId: number | null,
+  ): void;
+}
+
+interface AppTaskRowElement extends HTMLElement {
+  setTask(task: Task, currentUserId: number | null, tenantUsers: TenantUser[]): void;
+  cancelEdit(): void;
+}
+


### PR DESCRIPTION
## Summary

- Issue #572 対応。components 10 部品 + `index.js` / `tasks.js` / `scripts/copy-vendor.js` に `// @ts-check` を付与し、`npx tsc --noEmit` エラー 0 を達成
- 全 16 JS ファイル(+ `dom.js`)が `// @ts-check` 済みとなり、ADR-0025 S4 の型検査目標を完全充足

## 主な変更内容

### 型基盤 (`globals.d.ts` / `tsconfig.json`)
- CE consumer インターフェイス追加(`AppErrorBannerElement` / `AppConflictBannerElement` / `AppDescPopoverElement` / `AppTaskDrawerElement` / `AppPagerElement` / `AppTenantSwitcherElement` / `AppTaskRowElement`)
- Bootstrap 型 (`BootstrapOffcanvas` / `BootstrapToast`) と `KeycloakUser` を具体的なインターフェイスで宣言
- `skipLibCheck: true` 追加(Node.js `@types/node` v25 の undici-types 解決問題への対応)
- `@types/node` devDependency 追加(`copy-vendor.js` の Node.js 型解決用)

### 型注釈パターン(#571 規約準拠)
- **外部 HTML 要素**: `mustQuery(document, '#id')` + CE インターフェイスキャスト
- **自部品生成要素**: インライン JSDoc キャスト(`/** @type {T} */ (expr)`)
- **private フィールド**: `/** @type {T | null} */` で型推論 `null` を回避 + 使用箇所で null ガード
- **catch ブロック**: `/** @type {any} */ (err).message` / `.status`
- **Custom Event detail**: `/** @type {CustomEvent} */ (e).detail` でアクセス
- **Date 演算**: `.getTime()` で `TS2362` を解消
- **NodeList / HTMLCollection**: `Array.from()` で spread の `TS2488` を回避
- **定数オブジェクトの文字列インデックス**: `/** @type {Record<string,string>} */` キャスト

## Test plan

- [x] `npx tsc --noEmit` — エラー 0
- [x] `npx biome ci .` — エラー 0
- [ ] CI (GitHub Actions web-ci.yml) グリーン確認

## 関連 Issue

- Close #572
- 引き継ぎメモ → #593(3/3 フェーズ着手前の既知課題)

🤖 Generated with [Claude Code](https://claude.com/claude-code)