### PR TITLE
ci: exclude Renovate PRs from Claude review shim

### DIFF
--- a/.github/workflows/bot-claude-review.yml
+++ b/.github/workflows/bot-claude-review.yml
@@ -27,11 +27,14 @@ concurrency:
 jobs:
   review:
     # 起動条件:
-    # (1) PR が opened または ready_for_review、かつ draft 状態でない
+    # (1) PR が opened または ready_for_review、draft 状態でない、かつ Renovate 起票でない
+    #     Renovate PR は機械承認経路 bot-renovate-approve.yml に委譲する。レビュワ Claude を
+    #     起動すると claude-code-action の allowed_bots ガードで failure → needs-human-decision が
+    #     付与され、機械承認 (renovate-approve) が no-op に倒れて詰まるため除外する。
     # (2) issue_comment が PR に投稿された かつ 投稿者が claude-automation-impl[bot] かつ
     #     本文に signal: claude-impl-done を含む(任意のユーザによる起動を防ぐため投稿者を限定)
     if: |
-      (github.event_name == 'pull_request' && github.event.pull_request.draft == false) ||
+      (github.event_name == 'pull_request' && github.event.pull_request.draft == false && github.event.pull_request.user.login != 'renovate[bot]') ||
       (github.event_name == 'issue_comment' && github.event.issue.pull_request != null && github.event.comment.user.login == 'claude-automation-impl[bot]' && contains(github.event.comment.body, 'signal: claude-impl-done'))
     uses: win2cot/claude-automation/.github/workflows/reusable-review.yml@v1
     secrets:


### PR DESCRIPTION
## 概要

レビュワ Claude シム (`bot-claude-review.yml`) が Renovate PR でも起動し、`claude-code-action` の `allowed_bots` ガードで failure → `needs-human-decision` 付与で機械承認 (`renovate-approve`) が詰まる問題を修正する。

`pull_request` 起動条件に `github.event.pull_request.user.login != 'renovate[bot]'` を追加し、Renovate PR は機械承認経路へ委譲する。reusable 側 `allowed_bots` は変更しない。`issue_comment`(impl bot signal)経路は不変。

Closes #603
