### PR TITLE
ci: Terraform provider プラグインキャッシュを導入(terraform-lint / plan)

### DIFF
--- a/.github/workflows/terraform-lint.yml
+++ b/.github/workflows/terraform-lint.yml
@@ -9,6 +9,7 @@ env:
   LANG: ja_JP.UTF-8
   TZ: Asia/Tokyo
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  TF_PLUGIN_CACHE_DIR: ~/.terraform.d/plugin-cache
 
 permissions:
   contents: read
@@ -57,6 +58,17 @@ jobs:
         id: fmt
         run: terraform fmt -check -recursive infra/
         continue-on-error: true
+
+      - name: Create plugin cache dir
+        run: mkdir -p ~/.terraform.d/plugin-cache
+
+      - name: Restore Terraform plugin cache (lint)
+        uses: actions/cache@v4
+        with:
+          path: ~/.terraform.d/plugin-cache
+          key: tf-plugins-lint-${{ hashFiles('infra/environments/dev/.terraform.lock.hcl', 'infra/shared/environments/dev/.terraform.lock.hcl') }}
+          restore-keys: |
+            tf-plugins-lint-
 
       - name: init + lockfile check (tasks/dev)
         id: init_tasks

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -7,6 +7,7 @@ env:
   LANG: ja_JP.UTF-8
   TZ: Asia/Tokyo
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  TF_PLUGIN_CACHE_DIR: ~/.terraform.d/plugin-cache
 
 permissions:
   id-token: write
@@ -53,6 +54,17 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::138285070797:role/platform-dev-plan
           aws-region: ap-northeast-1
+
+      - name: Create plugin cache dir
+        run: mkdir -p ~/.terraform.d/plugin-cache
+
+      - name: Restore Terraform plugin cache (shared/dev)
+        uses: actions/cache@v4
+        with:
+          path: ~/.terraform.d/plugin-cache
+          key: tf-plugins-shared-dev-${{ hashFiles('infra/shared/environments/dev/.terraform.lock.hcl') }}
+          restore-keys: |
+            tf-plugins-shared-dev-
 
       - name: terraform init (platform/dev)
         id: init
@@ -145,6 +157,17 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::138285070797:role/tasks-dev-plan
           aws-region: ap-northeast-1
+
+      - name: Create plugin cache dir
+        run: mkdir -p ~/.terraform.d/plugin-cache
+
+      - name: Restore Terraform plugin cache (tasks/dev)
+        uses: actions/cache@v4
+        with:
+          path: ~/.terraform.d/plugin-cache
+          key: tf-plugins-tasks-dev-${{ hashFiles('infra/environments/dev/.terraform.lock.hcl') }}
+          restore-keys: |
+            tf-plugins-tasks-dev-
 
       - name: terraform init (tasks/dev)
         id: init


### PR DESCRIPTION
## Summary

- `TF_PLUGIN_CACHE_DIR=~/.terraform.d/plugin-cache` を `terraform-lint.yml` / `terraform-plan.yml` の `env` に追加
- `actions/cache@v4` で provider プラグインをキャッシュ(lockfile ハッシュ連動キー)
- `terraform-plan` の platform/tasks 並列ジョブは環境別キー(`tf-plugins-shared-dev-*` / `tf-plugins-tasks-dev-*`)で save 競合を回避
- キャッシュディレクトリは init 前に `mkdir -p` で作成(未作成だと cache が効かない)

Closes #601

## Test plan

- [ ] PR を開いて `terraform-lint` / `terraform-plan` が正常に完了することを確認
- [ ] 2回目の実行で "Cache restored" がログに出ることを確認(キャッシュ hit)
- [ ] platform ジョブと tasks ジョブのキャッシュキーが異なることをログで確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)