### PR TITLE
fix(dev): VSCode セットアップ実機検証で判明した設定誤りを修正 (#595)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,8 +18,9 @@
   "[css]": {
     "editor.defaultFormatter": "biomejs.biome"
   },
-  "biome.lsp.bin": "${workspaceFolder}/web/node_modules/@biomejs/biome/bin/biome",
+  "biome.lsp.bin": "web/node_modules/@biomejs/cli-linux-x64/biome",
   "java.format.settings.google.version": "1.34.0",
+  "java.format.settings.google.mode": "jar-file",
   "[terraform]": {
     "editor.defaultFormatter": "hashicorp.terraform",
     "editor.formatOnSave": true

--- a/docs/dev/local-setup.md
+++ b/docs/dev/local-setup.md
@@ -496,7 +496,7 @@ curl -s http://localhost:18080/realms/tasks/.well-known/openid-configuration | g
 | Webapi: Native Build | `webapi/**` `*.gradle*` `gradle/**` `gradlew*` | GraalVM `nativeCompile`(PR 破壊検知) | `./gradlew :webapi:nativeCompile`(10〜15 分) | ✕ |
 | Keycloak: CI | `keycloak/**` `*.gradle*` `gradle/**` `gradlew*` | Spotless(GJF 1.24.0)・`package-info.java` 確認・JUnit | `./gradlew :keycloak:spotlessApply && ./gradlew :keycloak:check` | △ — redhat.java + vscjava.vscode-gradle。format on save は ◎(ただし後述の注意参照) |
 | Web: CI | `web/**` | Biome lint/format・`tsc --noEmit`・html-validate・v.Nu | `cd web && npx biome ci . && npx tsc --noEmit && npm run html-validate` | ◎ — Biome(biomejs.biome)・tsc(内蔵)・html-validate(html-validate.vscode-html-validate)。v.Nu は Docker 要のため ✕ |
-| Markdown: Lint | `**/*.md` `.markdownlint.jsonc` | markdownlint-cli2 | `npx --yes markdownlint-cli2@0.22.1 "**/*.md" "!**/node_modules/**" "!**/build/**" "!**/.cowork-tmp/**" "!docs/reviews/**"` | ◎ — DavidAnson.vscode-markdownlint(`.markdownlint.jsonc` 自動参照) |
+| Markdown: Lint | `**/*.md` `.markdownlint.jsonc` | markdownlint-cli2 | `npx --yes markdownlint-cli2@0.22.1 "**/*.md" '!**/node_modules/**' '!**/build/**' '!**/.cowork-tmp/**' '!docs/reviews/**'` | ◎ — DavidAnson.vscode-markdownlint(`.markdownlint.jsonc` 自動参照) |
 | OpenAPI: Lint | `api/**` | Spectral lint(`api/openapi.yaml`) | `npx --yes @stoplight/spectral-cli@6 lint api/openapi.yaml --format github-actions` | ◎ — stoplight.spectral |
 | Terraform: Lint | `infra/**/*.tf` `*.hcl` `*.tfvars` | `terraform fmt -check -recursive`・init・validate・IAM wildcard ゲート | `terraform fmt -check -recursive infra/` その後 `terraform -chdir=infra/environments/dev init -backend=false && terraform -chdir=infra/environments/dev validate` | ◎ — hashicorp.terraform(fmt/validate) |
 | Terraform: Plan | `infra/**/*.tf` `*.hcl` `*.tfvars` | `terraform plan`(AWS 認証・OIDC 要) | AWS 認証が必要のためローカル再現不可 | ✕ |
@@ -555,7 +555,7 @@ curl -s http://localhost:18080/realms/tasks/.well-known/openid-configuration | g
 |---|---|
 | `webapi/` の Java | `./gradlew :webapi:spotlessApply && ./gradlew :webapi:check` |
 | `web/` の JS / HTML / CSS / JSON | `cd web && npx biome check --write . && npx tsc --noEmit && npm run html-validate` |
-| `**/*.md` | `npx --yes markdownlint-cli2@0.22.1 "**/*.md" "!**/node_modules/**" "!**/build/**" "!**/.cowork-tmp/**" "!docs/reviews/**"` |
+| `**/*.md` | `npx --yes markdownlint-cli2@0.22.1 "**/*.md" '!**/node_modules/**' '!**/build/**' '!**/.cowork-tmp/**' '!docs/reviews/**'` |
 | `api/openapi.yaml` | `npx --yes @stoplight/spectral-cli@6 lint api/openapi.yaml` |
 | `infra/**/*.tf` | `terraform fmt -recursive infra/ && terraform -chdir=infra/environments/dev validate` |
 


### PR DESCRIPTION
## Summary

- `biome.lsp.bin` を `${workspaceFolder}` 変数(展開されない)からネイティブバイナリの相対パス `web/node_modules/@biomejs/cli-linux-x64/biome` に修正
- `java.format.settings.google.mode` を `jar-file` に追加(ネイティブバイナリが Java 25 と非互換 — `LinkageError: no such method: JCTree.getEndPosition`)
- `docs/dev/local-setup.md` の markdownlint-cli2 コマンドの除外パターンをダブルクォート→シングルクォートに修正(bash history expansion による `event not found` エラー回避)

## Test plan

- [x] Biome LSP が `Biome is ready` ログを出力し、lint 違反がエディタに表示される
- [x] Java ファイル保存時に Google Java Format が適用される(`spotlessCheck` との diff ゼロ確認済み)
- [x] markdownlint-cli2 コマンドが bash でエラーなく完走する

Closes #595

🤖 Generated with [Claude Code](https://claude.com/claude-code)