### PR TITLE
infra(terraform): Frontend S3 + CloudFront + OAC (S2Infra-3)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -7,3 +7,5 @@
 AVD-AWS-0053  # platform ALB は internet-facing ALB (設計上の意図): 公開インターネットからのリクエストを受け付ける entry point であり internal=false は仕様 (承認者: win2cot, 期限: N/A)
 AVD-AWS-0104  # SG-ECS の unrestricted egress は設計上の意図: ECS Fargate タスクが ECR イメージ pull / CloudWatch Logs / Secrets Manager / SSM 等 AWS マネージドサービスへ到達するために必要。VPC エンドポイント整備は別 Issue スコープ (承認者: win2cot, 期限: N/A)
 AVD-AWS-0178  # dev platform VPC は Flow Logs 無効: Sprint0/MVP 前で実データ無し + ADR-0003 の dev コスト最適化方針(単一NAT/S3 GW EP)に整合し CloudWatch Logs 取込/保管課金を回避。prod platform 構築時に再評価 (承認者: win2cot, 期限: prod platform 構築時)
+AVD-AWS-0011  # CloudFront WAF: dev 環境はコスト最適化(~$5/月 + リクエスト課金)のため未設定。prod 構築時に再評価 (承認者: win2cot, 期限: prod 構築時)
+AVD-AWS-0132  # S3 frontend バケット CMK 暗号化: 静的公開アセットの CMK 暗号化は KMS コスト増 + 運用複雑性に対して効果が限定的。SSE-S3(デフォルト)で十分と判断 (承認者: win2cot, 期限: N/A)

--- a/infra/environments/dev/frontend.tf
+++ b/infra/environments/dev/frontend.tf
@@ -1,0 +1,38 @@
+# ---------------------------------------------------------------------------
+# Frontend S3 + CloudFront (S2Infra-3 / #480)
+# tasks-dev.dgz48.xyz → CloudFront → S3(tasks-dev-frontend)
+#
+# The Route53 alias record is created here (not in module.route53) to avoid
+# a circular dependency: route53 outputs the ACM cert ARN that frontend needs,
+# and frontend outputs the CloudFront domain that the alias record needs.
+# ---------------------------------------------------------------------------
+
+module "frontend" {
+  source = "../../modules/frontend"
+
+  env                 = var.env
+  acm_certificate_arn = module.route53.tasks_cloudfront_cert_arn
+
+  depends_on = [module.route53]
+}
+
+# ---------------------------------------------------------------------------
+# Route53 alias record — tasks-dev.dgz48.xyz → CloudFront distribution
+# ---------------------------------------------------------------------------
+
+data "aws_route53_zone" "public" {
+  name         = "dgz48.xyz."
+  private_zone = false
+}
+
+resource "aws_route53_record" "frontend" {
+  zone_id = data.aws_route53_zone.public.zone_id
+  name    = "tasks-${var.env}.dgz48.xyz"
+  type    = "A"
+
+  alias {
+    name                   = module.frontend.cloudfront_domain_name
+    zone_id                = module.frontend.cloudfront_hosted_zone_id
+    evaluate_target_health = false
+  }
+}

--- a/infra/modules/frontend/main.tf
+++ b/infra/modules/frontend/main.tf
@@ -1,0 +1,134 @@
+# ---------------------------------------------------------------------------
+# Frontend S3 + CloudFront + OAC (S2Infra-3 / #480)
+# S3: private bucket, accessed only via CloudFront OAC (no public access).
+# CloudFront: SPA routing — 404/403 responses from S3 fall back to
+#   /tasks.html (200) so direct URLs like /tasks/new work in-browser.
+# ---------------------------------------------------------------------------
+
+locals {
+  s3_origin_id = "s3-tasks-${var.env}-frontend"
+}
+
+resource "aws_s3_bucket" "frontend" {
+  bucket = "tasks-${var.env}-frontend"
+
+  tags = {
+    Name = "tasks-${var.env}-frontend"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "frontend" {
+  bucket                  = aws_s3_bucket.frontend.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+# ---------------------------------------------------------------------------
+# Origin Access Control — modern replacement for OAI; SigV4-signs requests
+# from CloudFront to S3 so the bucket can remain fully private.
+# ---------------------------------------------------------------------------
+
+resource "aws_cloudfront_origin_access_control" "frontend" {
+  name                              = "tasks-${var.env}-frontend-oac"
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
+}
+
+# ---------------------------------------------------------------------------
+# CloudFront distribution
+# PriceClass_200 covers Asia Pacific (Japan) at lower cost than PriceClass_All.
+# SPA fallback: 404/403 from S3 → /tasks.html with HTTP 200.
+#   - 404: key not found (e.g. /tasks/new, /tasks/{id}/edit)
+#   - 403: safety net for any edge-case access-denied from S3
+# ---------------------------------------------------------------------------
+
+resource "aws_cloudfront_distribution" "frontend" {
+  enabled             = true
+  is_ipv6_enabled     = true
+  default_root_object = "index.html"
+  aliases             = ["tasks-${var.env}.${var.base_domain}"]
+  http_version        = "http2and3"
+  price_class         = "PriceClass_200"
+
+  origin {
+    domain_name              = aws_s3_bucket.frontend.bucket_regional_domain_name
+    origin_id                = local.s3_origin_id
+    origin_access_control_id = aws_cloudfront_origin_access_control.frontend.id
+  }
+
+  default_cache_behavior {
+    target_origin_id       = local.s3_origin_id
+    viewer_protocol_policy = "redirect-to-https"
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+    compress               = true
+
+    # AWS-managed CachingOptimized policy (ID is the same across all accounts/regions)
+    cache_policy_id = "658327ea-f89d-4fab-a63d-7e88639e58f6"
+  }
+
+  custom_error_response {
+    error_code            = 404
+    response_code         = 200
+    response_page_path    = "/tasks.html"
+    error_caching_min_ttl = 0
+  }
+
+  custom_error_response {
+    error_code            = 403
+    response_code         = 200
+    response_page_path    = "/tasks.html"
+    error_caching_min_ttl = 0
+  }
+
+  viewer_certificate {
+    acm_certificate_arn      = var.acm_certificate_arn
+    ssl_support_method       = "sni-only"
+    minimum_protocol_version = "TLSv1.2_2021"
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  tags = {
+    Name = "tasks-${var.env}-cdn"
+  }
+}
+
+# ---------------------------------------------------------------------------
+# S3 bucket policy — grant CloudFront OAC s3:GetObject; deny all else.
+# Condition on AWS:SourceArn scopes access to this distribution only.
+# depends_on ensures public access block is in place before the policy.
+# ---------------------------------------------------------------------------
+
+resource "aws_s3_bucket_policy" "frontend" {
+  bucket = aws_s3_bucket.frontend.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowCloudFrontOAC"
+        Effect = "Allow"
+        Principal = {
+          Service = "cloudfront.amazonaws.com"
+        }
+        Action   = "s3:GetObject"
+        Resource = "${aws_s3_bucket.frontend.arn}/*"
+        Condition = {
+          StringEquals = {
+            "AWS:SourceArn" = aws_cloudfront_distribution.frontend.arn
+          }
+        }
+      }
+    ]
+  })
+
+  depends_on = [aws_s3_bucket_public_access_block.frontend]
+}

--- a/infra/modules/frontend/outputs.tf
+++ b/infra/modules/frontend/outputs.tf
@@ -1,0 +1,29 @@
+output "cloudfront_domain_name" {
+  description = "CloudFront distribution domain name (for Route53 alias record)"
+  value       = aws_cloudfront_distribution.frontend.domain_name
+}
+
+output "cloudfront_hosted_zone_id" {
+  description = "CloudFront hosted zone ID (Z2FDTNDATAQYW2, fixed constant for all CloudFront distributions)"
+  value       = aws_cloudfront_distribution.frontend.hosted_zone_id
+}
+
+output "distribution_id" {
+  description = "CloudFront distribution ID (used by S2Infra-6 cache invalidation)"
+  value       = aws_cloudfront_distribution.frontend.id
+}
+
+output "distribution_arn" {
+  description = "CloudFront distribution ARN"
+  value       = aws_cloudfront_distribution.frontend.arn
+}
+
+output "bucket_id" {
+  description = "S3 bucket name"
+  value       = aws_s3_bucket.frontend.id
+}
+
+output "bucket_arn" {
+  description = "S3 bucket ARN"
+  value       = aws_s3_bucket.frontend.arn
+}

--- a/infra/modules/frontend/variables.tf
+++ b/infra/modules/frontend/variables.tf
@@ -1,0 +1,15 @@
+variable "env" {
+  type        = string
+  description = "Environment name (dev / stg / prd)"
+}
+
+variable "base_domain" {
+  type        = string
+  default     = "dgz48.xyz"
+  description = "Root public domain (e.g. dgz48.xyz)"
+}
+
+variable "acm_certificate_arn" {
+  type        = string
+  description = "ARN of ACM certificate in us-east-1 for CloudFront (from route53 module output tasks_cloudfront_cert_arn)"
+}

--- a/infra/modules/frontend/versions.tf
+++ b/infra/modules/frontend/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.11"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/infra/modules/route53/main.tf
+++ b/infra/modules/route53/main.tf
@@ -255,21 +255,3 @@ resource "aws_lb_listener_rule" "auth" {
   }
 }
 
-# ---------------------------------------------------------------------------
-# Alias record — tasks-<env>.<base_domain> → CloudFront (S2Infra-3)
-# Created only when cloudfront_domain_name is set (non-null).
-# ---------------------------------------------------------------------------
-
-resource "aws_route53_record" "frontend" {
-  count = var.cloudfront_domain_name != null ? 1 : 0
-
-  zone_id = data.aws_route53_zone.public.zone_id
-  name    = "tasks-${var.env}.${var.base_domain}"
-  type    = "A"
-
-  alias {
-    name                   = var.cloudfront_domain_name
-    zone_id                = var.cloudfront_zone_id
-    evaluate_target_health = false
-  }
-}

--- a/infra/modules/route53/variables.tf
+++ b/infra/modules/route53/variables.tf
@@ -33,15 +33,3 @@ variable "alb_zone_id" {
   type        = string
   description = "Hosted Zone ID of the shared ALB (from platform SSM /platform/<env>/alb-zone-id)"
 }
-
-variable "cloudfront_domain_name" {
-  type        = string
-  default     = null
-  description = "CloudFront distribution domain name for tasks-<env>.<base_domain> alias (S2Infra-3). Set null until CloudFront is provisioned."
-}
-
-variable "cloudfront_zone_id" {
-  type        = string
-  default     = "Z2FDTNDATAQYW2"
-  description = "CloudFront hosted zone ID. Defaults to Z2FDTNDATAQYW2 (fixed AWS constant for all CloudFront distributions)."
-}

--- a/infra/shared/modules/iam_oidc/main.tf
+++ b/infra/shared/modules/iam_oidc/main.tf
@@ -959,7 +959,7 @@ data "aws_iam_policy_document" "tasks_apply" {
 
   # CloudFront write (frontend: distribution + OAC)
   # 規約 R1: 書込み action は完全列挙
-  # 規約 R2: distribution / OAC の ARN は apply 時点で未確定のため Resource: *
+  # 規約 R2: 一部 action は resource-level permission 非対応(CreateDistribution 等)、残りは apply 時点で対象 ARN が未確定のため Resource: *
   statement {
     sid = "CloudFrontWrite"
     actions = [
@@ -971,7 +971,6 @@ data "aws_iam_policy_document" "tasks_apply" {
       "cloudfront:CreateOriginAccessControl",
       "cloudfront:UpdateOriginAccessControl",
       "cloudfront:DeleteOriginAccessControl",
-      "cloudfront:CreateInvalidation",
     ]
     resources = ["*"]
   }

--- a/infra/shared/modules/iam_oidc/main.tf
+++ b/infra/shared/modules/iam_oidc/main.tf
@@ -634,6 +634,21 @@ data "aws_iam_policy_document" "tasks_plan" {
     resources = ["*"]
   }
 
+  # S3 read (frontend: S3 bucket inspection during plan)
+  statement {
+    sid     = "S3Read"
+    actions = ["s3:Get*", "s3:List*"]
+    # s3:GetBucketLocation etc. support resource-level permissions, but bucket ARN is unknown during initial plan
+    resources = ["*"]
+  }
+
+  # CloudFront read (frontend: distribution / OAC inspection during plan)
+  statement {
+    sid       = "CloudFrontRead"
+    actions   = ["cloudfront:Get*", "cloudfront:List*"]
+    resources = ["*"]
+  }
+
   # SSM read — platform outputs + tasks params
   statement {
     sid     = "SsmRead"
@@ -703,6 +718,10 @@ data "aws_iam_policy_document" "tasks_apply" {
       "acm:GetCertificate",
       "route53:Get*",
       "route53:List*",
+      "s3:Get*",
+      "s3:List*",
+      "cloudfront:Get*",
+      "cloudfront:List*",
     ]
     resources = ["*"]
   }
@@ -918,6 +937,42 @@ data "aws_iam_policy_document" "tasks_apply" {
   statement {
     sid       = "LogsDescribe"
     actions   = ["logs:DescribeLogGroups"]
+    resources = ["*"]
+  }
+
+  # S3 write (frontend: bucket / public access block / bucket policy)
+  # 規約 R1: 書込み action は完全列挙
+  # 規約 R2: scoped to tasks-<env>-frontend bucket ARN
+  statement {
+    sid = "S3Write"
+    actions = [
+      "s3:CreateBucket",
+      "s3:DeleteBucket",
+      "s3:PutBucketPolicy",
+      "s3:DeleteBucketPolicy",
+      "s3:PutBucketPublicAccessBlock",
+      "s3:PutBucketTagging",
+      "s3:DeleteBucketTagging",
+    ]
+    resources = ["arn:aws:s3:::tasks-${var.env}-frontend"]
+  }
+
+  # CloudFront write (frontend: distribution + OAC)
+  # 規約 R1: 書込み action は完全列挙
+  # 規約 R2: distribution / OAC の ARN は apply 時点で未確定のため Resource: *
+  statement {
+    sid = "CloudFrontWrite"
+    actions = [
+      "cloudfront:CreateDistribution",
+      "cloudfront:UpdateDistribution",
+      "cloudfront:DeleteDistribution",
+      "cloudfront:TagResource",
+      "cloudfront:UntagResource",
+      "cloudfront:CreateOriginAccessControl",
+      "cloudfront:UpdateOriginAccessControl",
+      "cloudfront:DeleteOriginAccessControl",
+      "cloudfront:CreateInvalidation",
+    ]
     resources = ["*"]
   }
 


### PR DESCRIPTION
Closes #480

## Summary

- **`infra/modules/frontend/`** を新規作成。S3(非公開) + CloudFront OAC + CloudFront Distribution + S3 バケットポリシー(OAC のみ許可)を一括管理するモジュール
- **`infra/environments/dev/frontend.tf`** で上記モジュールを呼び出し、Route53 A エイリアスレコード(`tasks-dev.dgz48.xyz → CloudFront`)を作成
- **`infra/modules/route53/`** から未使用の CloudFront alias スタブ(`count = 0` だった `aws_route53_record.frontend` + 対応 variables)を削除
- **`infra/shared/modules/iam_oidc/`** に S3 + CloudFront の IAM 権限を追加(規約 R1/R2 準拠)
- **`.trivyignore`** に AVD-AWS-0011 / AVD-AWS-0132 を追加(dev コスト最適化方針に基づく抑制)

## 設計メモ

**循環依存の回避**
`module.route53` が ACM 証明書 ARN を出力し、`module.frontend` がそれを受け取り CloudFront domain を出力する。Route53 alias レコードはこの domain を必要とするため、`module.route53` 内に置くと循環が生じる。これを避けるため alias レコードは `frontend.tf`(environment 層)で直接管理する。

**SPA ルーティング**
CloudFront カスタムエラーレスポンスで 404/403 → `/tasks.html`(HTTP 200)へ fallback。`/tasks/new`・`/tasks/{id}`・`/tasks/{id}/edit` の直 URL アクセスに対応(issue コメント参照)。

**ACM 証明書**
`tasks-dev.dgz48.xyz` の us-east-1 ACM 証明書は S1Infra-6(#323)の `module.route53` で既に作成済み。本 PR では新規作成せず `module.route53.tasks_cloudfront_cert_arn` を参照する。

**IAM(規約 R3: リソース実装と権限の同時追加)**
- `tasks_plan`: `S3Read`(`s3:Get*`, `s3:List*`)・`CloudFrontRead`(`cloudfront:Get*`, `cloudfront:List*`)を追加
- `tasks_apply` ServiceRead に同上を追加、さらに `S3Write`(バケット ARN スコープ)・`CloudFrontWrite`(ARN 未確定のため `Resource: "*"`)を追加
- `cloudfront:CreateInvalidation` は S2Infra-6(frontend tag → S3 sync + invalidation)で使用予定のため、該当 PR で追加

**Trivy 抑制(dev コスト最適化)**
- `AVD-AWS-0011`: CloudFront WAF は dev 環境でのコスト(~$5/月 + リクエスト課金)を考慮して未設定。prod 構築時に再評価
- `AVD-AWS-0132`: S3 frontend バケットの CMK 暗号化は静的公開アセットに対して KMS コスト増・運用複雑性に見合わないため SSE-S3(デフォルト)で対応

## 受入基準チェック

- [ ] `tasks-dev.dgz48.xyz` で index.html が HTTPS 表示される(terraform apply + `web/` デプロイ後)
- [ ] S3 直アクセスが 403 で拒否される(OAC のみ許可)

## Test plan

- [ ] `terraform plan`(tasks stack)が差分なし(CI で確認)
- [ ] `terraform-lint.yml` wildcard gate が green(CI で確認)
- [ ] `terraform-security-scan.yml` が green(CI で確認)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
