### PR TITLE
infra(terraform): CloudFront Response Headers Policy を新設 (ADR-0022)

### DIFF
--- a/infra/modules/frontend/main.tf
+++ b/infra/modules/frontend/main.tf
@@ -7,6 +7,8 @@
 
 locals {
   s3_origin_id = "s3-tasks-${var.env}-frontend"
+  # ADR-0022 §3.2 — CSP in Report-Only mode until violations are confirmed zero (§3.4)
+  csp_report_only = "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' data:; font-src 'self'; connect-src 'self' https://api-${var.env}.tasks.${var.base_domain} https://auth-${var.env}.${var.base_domain}; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'"
 }
 
 resource "aws_s3_bucket" "frontend" {
@@ -35,6 +37,67 @@ resource "aws_cloudfront_origin_access_control" "frontend" {
   origin_access_control_origin_type = "s3"
   signing_behavior                  = "always"
   signing_protocol                  = "sigv4"
+}
+
+# ---------------------------------------------------------------------------
+# Response Headers Policy — security headers per ADR-0022 §3.2
+# CSP is issued as Report-Only via custom_headers_config until violations are
+# confirmed zero; switch to security_headers_config.content_security_policy
+# (enforce) after verification (ADR-0022 §3.4).
+# ---------------------------------------------------------------------------
+
+resource "aws_cloudfront_response_headers_policy" "frontend" {
+  name    = "tasks-${var.env}-frontend-security-headers"
+  comment = "ADR-0022 §3.2 — security headers for tasks-${var.env} frontend"
+
+  security_headers_config {
+    strict_transport_security {
+      access_control_max_age_sec = var.hsts_max_age_sec
+      include_subdomains         = true
+      preload                    = false
+      override                   = true
+    }
+
+    content_type_options {
+      override = true
+    }
+
+    referrer_policy {
+      referrer_policy = "no-referrer"
+      override        = true
+    }
+
+    frame_options {
+      frame_option = "DENY"
+      override     = true
+    }
+  }
+
+  custom_headers_config {
+    items {
+      header   = "Content-Security-Policy-Report-Only"
+      value    = local.csp_report_only
+      override = true
+    }
+
+    items {
+      header   = "Permissions-Policy"
+      value    = "camera=(), microphone=(), geolocation=(), payment=(), usb=(), accelerometer=(), gyroscope=(), magnetometer=()"
+      override = true
+    }
+
+    items {
+      header   = "Cross-Origin-Opener-Policy"
+      value    = "same-origin"
+      override = true
+    }
+
+    items {
+      header   = "Cross-Origin-Resource-Policy"
+      value    = "same-origin"
+      override = true
+    }
+  }
 }
 
 # ---------------------------------------------------------------------------
@@ -68,6 +131,8 @@ resource "aws_cloudfront_distribution" "frontend" {
 
     # AWS-managed CachingOptimized policy (ID is the same across all accounts/regions)
     cache_policy_id = "658327ea-f89d-4fab-a63d-7e88639e58f6"
+
+    response_headers_policy_id = aws_cloudfront_response_headers_policy.frontend.id
   }
 
   custom_error_response {

--- a/infra/modules/frontend/variables.tf
+++ b/infra/modules/frontend/variables.tf
@@ -13,3 +13,9 @@ variable "acm_certificate_arn" {
   type        = string
   description = "ARN of ACM certificate in us-east-1 for CloudFront (from route53 module output tasks_cloudfront_cert_arn)"
 }
+
+variable "hsts_max_age_sec" {
+  type        = number
+  description = "max-age for Strict-Transport-Security. dev: 300 (short-term), prd: 31536000 (1 year)"
+  default     = 300
+}

--- a/infra/shared/modules/iam_oidc/main.tf
+++ b/infra/shared/modules/iam_oidc/main.tf
@@ -957,7 +957,7 @@ data "aws_iam_policy_document" "tasks_apply" {
     resources = ["arn:aws:s3:::tasks-${var.env}-frontend"]
   }
 
-  # CloudFront write (frontend: distribution + OAC)
+  # CloudFront write (frontend: distribution + OAC + Response Headers Policy)
   # 規約 R1: 書込み action は完全列挙
   # 規約 R2: 一部 action は resource-level permission 非対応(CreateDistribution 等)、残りは apply 時点で対象 ARN が未確定のため Resource: *
   statement {
@@ -971,6 +971,9 @@ data "aws_iam_policy_document" "tasks_apply" {
       "cloudfront:CreateOriginAccessControl",
       "cloudfront:UpdateOriginAccessControl",
       "cloudfront:DeleteOriginAccessControl",
+      "cloudfront:CreateResponseHeadersPolicy",   # ADR-0022 §3.2
+      "cloudfront:UpdateResponseHeadersPolicy",   # ADR-0022 §3.2
+      "cloudfront:DeleteResponseHeadersPolicy",   # ADR-0022 §3.2
     ]
     resources = ["*"]
   }

--- a/infra/shared/modules/iam_oidc/main.tf
+++ b/infra/shared/modules/iam_oidc/main.tf
@@ -971,9 +971,9 @@ data "aws_iam_policy_document" "tasks_apply" {
       "cloudfront:CreateOriginAccessControl",
       "cloudfront:UpdateOriginAccessControl",
       "cloudfront:DeleteOriginAccessControl",
-      "cloudfront:CreateResponseHeadersPolicy",   # ADR-0022 §3.2
-      "cloudfront:UpdateResponseHeadersPolicy",   # ADR-0022 §3.2
-      "cloudfront:DeleteResponseHeadersPolicy",   # ADR-0022 §3.2
+      "cloudfront:CreateResponseHeadersPolicy",
+      "cloudfront:UpdateResponseHeadersPolicy",
+      "cloudfront:DeleteResponseHeadersPolicy",
     ]
     resources = ["*"]
   }


### PR DESCRIPTION
## Summary

- `aws_cloudfront_response_headers_policy` を新設し `aws_cloudfront_distribution.frontend` の `default_cache_behavior` へ紐付け (ADR-0022 §3.2)
- `security_headers_config`: HSTS / `X-Content-Type-Options: nosniff` / `Referrer-Policy: no-referrer` / `X-Frame-Options: DENY`
- `custom_headers_config`: `Content-Security-Policy-Report-Only` (CSP は ADR-0022 §3.4 の指示に従い Report-Only で先行付与) / `Permissions-Policy` / `Cross-Origin-Opener-Policy: same-origin` / `Cross-Origin-Resource-Policy: same-origin`
- `connect-src` は `var.env` + `var.base_domain` でテンプレート化(API origin / Keycloak origin)
- `hsts_max_age_sec` 変数を追加(dev デフォルト `300`、prd は `31536000` で上書き予定)
- COEP は ADR-0022 §3.2 決定どおり付与しない
- `infra/shared/modules/iam_oidc/main.tf` の `CloudFrontWrite` ステートメントに `CreateResponseHeadersPolicy` / `UpdateResponseHeadersPolicy` / `DeleteResponseHeadersPolicy` を追加(Terraform 規約 R3 対応)

## CSP Report-Only → Enforce 切替手順 (ADR-0022 §3.4)

1. 本 PR を dev に apply し `Content-Security-Policy-Report-Only` を付与
2. DevTools で決めたフロー(Keycloak ログイン / タスク CRUD / モーダル等)を一巡して違反 0 を確認
3. `custom_headers_config` の `Content-Security-Policy-Report-Only` を削除し、`security_headers_config.content_security_policy` へ移行して enforce に切替

## Test plan

- [ ] `terraform validate` — 済み (CI でも確認)
- [ ] `terraform plan` で `aws_cloudfront_response_headers_policy` 新規作成・`aws_cloudfront_distribution` 更新のみ差分が出ることを確認
- [ ] dev apply 後、`curl -sI https://tasks-dev.dgz48.xyz` でレスポンスヘッダーに `Content-Security-Policy-Report-Only` / `Strict-Transport-Security` / `X-Content-Type-Options` 等が含まれることを確認

## 未対応レビュー

| 指摘 | 内容 | 状態 |
|---|---|---|
| (なし) | | |

Closes #529

🤖 Generated with [Claude Code](https://claude.com/claude-code)
