### PR TITLE
infra(terraform): RDS parameter group を追加 — time_zone=Asia/Tokyo / utf8mb4_unicode_ci (S2Infra-9)

### DIFF
--- a/infra/modules/rds/main.tf
+++ b/infra/modules/rds/main.tf
@@ -5,6 +5,34 @@
 # private subnet は /platform/{env}/private-subnet-ids(SSM)から渡される。
 # ---------------------------------------------------------------------------
 
+resource "aws_db_parameter_group" "main" {
+  name        = "tasks-${var.env}-mysql84"
+  family      = "mysql8.4"
+  description = "tasks ${var.env} MySQL 8.4: Asia/Tokyo / utf8mb4_unicode_ci (ADR-0009)"
+
+  parameter {
+    name         = "time_zone"
+    value        = "Asia/Tokyo"
+    apply_method = "immediate"
+  }
+
+  parameter {
+    name         = "character_set_server"
+    value        = "utf8mb4"
+    apply_method = "pending-reboot"
+  }
+
+  parameter {
+    name         = "collation_server"
+    value        = "utf8mb4_unicode_ci"
+    apply_method = "pending-reboot"
+  }
+
+  tags = {
+    Name = "tasks-${var.env}-mysql84"
+  }
+}
+
 resource "aws_db_subnet_group" "main" {
   name        = "tasks-${var.env}-subnet-group"
   subnet_ids  = var.subnet_ids
@@ -31,6 +59,8 @@ resource "aws_db_instance" "main" {
   db_name  = "tasks"
   username = "admin"
   password = var.db_password
+
+  parameter_group_name = aws_db_parameter_group.main.name
 
   # Network
   db_subnet_group_name   = aws_db_subnet_group.main.name

--- a/infra/shared/modules/iam_oidc/main.tf
+++ b/infra/shared/modules/iam_oidc/main.tf
@@ -490,7 +490,7 @@ data "aws_iam_policy_document" "platform_apply" {
     resources = ["*"]
   }
 
-  # RDS write (keycloak_db: DB instance / subnet group)
+  # RDS write (keycloak_db: DB instance / subnet group / parameter group)
   # 規約 R1: 書込み action は完全列挙
   # 規約 R2: 一部 action は resource-level permission 非対応(CreateDBSubnetGroup 等)、残りは apply 時点で対象 ARN が未確定のため Resource: *
   statement {
@@ -502,6 +502,9 @@ data "aws_iam_policy_document" "platform_apply" {
       "rds:CreateDBSubnetGroup",
       "rds:DeleteDBSubnetGroup",
       "rds:ModifyDBSubnetGroup",
+      "rds:CreateDBParameterGroup",
+      "rds:ModifyDBParameterGroup",
+      "rds:DeleteDBParameterGroup",
       "rds:AddTagsToResource",
       "rds:RemoveTagsFromResource",
     ]
@@ -763,7 +766,7 @@ data "aws_iam_policy_document" "tasks_apply" {
     resources = ["*"]
   }
 
-  # RDS write (rds: DB instance / subnet group)
+  # RDS write (rds: DB instance / subnet group / parameter group)
   # 規約 R1: 書込み action は完全列挙
   # 規約 R2: 一部 action は resource-level permission 非対応(CreateDBSubnetGroup 等)、残りは apply 時点で対象 ARN が未確定のため Resource: *
   statement {
@@ -775,6 +778,9 @@ data "aws_iam_policy_document" "tasks_apply" {
       "rds:CreateDBSubnetGroup",
       "rds:DeleteDBSubnetGroup",
       "rds:ModifyDBSubnetGroup",
+      "rds:CreateDBParameterGroup",
+      "rds:ModifyDBParameterGroup",
+      "rds:DeleteDBParameterGroup",
       "rds:AddTagsToResource",
       "rds:RemoveTagsFromResource",
     ]

--- a/infra/shared/modules/keycloak_db/main.tf
+++ b/infra/shared/modules/keycloak_db/main.tf
@@ -23,6 +23,38 @@ resource "aws_security_group" "keycloak_db" {
 }
 
 # ---------------------------------------------------------------------------
+# DB Parameter Group — Asia/Tokyo / utf8mb4_unicode_ci (ADR-0009)
+# ---------------------------------------------------------------------------
+
+resource "aws_db_parameter_group" "keycloak" {
+  name        = "platform-${var.env}-keycloak-db-mysql84"
+  family      = "mysql8.4"
+  description = "platform ${var.env} Keycloak DB MySQL 8.4: Asia/Tokyo / utf8mb4_unicode_ci (ADR-0009)"
+
+  parameter {
+    name         = "time_zone"
+    value        = "Asia/Tokyo"
+    apply_method = "immediate"
+  }
+
+  parameter {
+    name         = "character_set_server"
+    value        = "utf8mb4"
+    apply_method = "pending-reboot"
+  }
+
+  parameter {
+    name         = "collation_server"
+    value        = "utf8mb4_unicode_ci"
+    apply_method = "pending-reboot"
+  }
+
+  tags = {
+    Name = "platform-${var.env}-keycloak-db-mysql84"
+  }
+}
+
+# ---------------------------------------------------------------------------
 # DB Subnet Group — private subnets
 # ---------------------------------------------------------------------------
 
@@ -54,6 +86,8 @@ resource "aws_db_instance" "keycloak" {
   db_name  = "keycloak"
   username = "keycloak_admin"
   password = var.db_password
+
+  parameter_group_name = aws_db_parameter_group.keycloak.name
 
   db_subnet_group_name   = aws_db_subnet_group.keycloak.name
   vpc_security_group_ids = [aws_security_group.keycloak_db.id]


### PR DESCRIPTION
## Summary

- `infra/modules/rds`: `aws_db_parameter_group.main`(`tasks-${env}-mysql84`, family `mysql8.4`)を新設し、`aws_db_instance.main` に `parameter_group_name` を設定
- `infra/shared/modules/keycloak_db`: `aws_db_parameter_group.keycloak`(`platform-${env}-keycloak-db-mysql84`)を新設し、`aws_db_instance.keycloak` に設定
- 両 parameter group に `time_zone=Asia/Tokyo` / `character_set_server=utf8mb4` / `collation_server=utf8mb4_unicode_ci` を設定
- `infra/shared/modules/iam_oidc`: `platform-apply` / `tasks-apply` の `RdsWrite` ステートメントに `rds:CreateDBParameterGroup` / `rds:ModifyDBParameterGroup` / `rds:DeleteDBParameterGroup` を追加(規約 R3 対応)

Closes #494

## 背景

- ADR-0009 (JST 全層統一) とコーディング規約 §12.1 は RDS が `Asia/Tokyo` で稼働することを前提とする
- JDBC URL が `connectionTimeZone=SERVER` のため、DB が UTC のままだと日付判定・保存値がローカル (JST) と dev (UTC) で乖離する
- デフォルト parameter group (`default.mysql8.4`) では `time_zone=UTC` / `collation=utf8mb4_0900_ai_ci` のまま

## Apply 後の手順

> **parameter group 付け替えは reboot が必要**

```bash
# 1. terraform apply
# 2. 両 RDS インスタンスを手動 reboot（コンソール or CLI）
aws rds reboot-db-instance --db-instance-identifier tasks-dev-mysql
aws rds reboot-db-instance --db-instance-identifier platform-dev-keycloak-db
# 3. ECS tasks-webapi を再起動（コネクションプール刷新）
# 4. 反映確認
SELECT @@time_zone, @@character_set_server, @@collation_server;
```

## Test plan

- [ ] `terraform fmt -check` — 通過済み（ローカル確認）
- [ ] `terraform validate` tasks/dev — 通過済み（ローカル確認）
- [ ] `terraform validate` shared/dev — 通過済み（ローカル確認）
- [ ] IAM wildcard gate (`check-iam-wildcards.py`) — 通過済み（ローカル確認）
- [ ] CI (`terraform-lint.yml`) がすべてグリーンであること
- [ ] apply 後、両 RDS reboot → `SELECT @@time_zone` が `Asia/Tokyo` を返すこと
- [ ] `@@character_set_server = utf8mb4` / `@@collation_server = utf8mb4_unicode_ci` であること
- [ ] `terraform plan` が no-change であること

## 未対応レビュー

| 指摘 | 内容 | 状態 |
|---|---|---|
| (なし) | — | — |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
