### PR TITLE
infra(terraform): tasks-webapi ECS Service + Task Definition + Exec Role (S2Infra-2)

### DIFF
--- a/infra/environments/dev/ecs_service.tf
+++ b/infra/environments/dev/ecs_service.tf
@@ -102,9 +102,9 @@ resource "aws_ecs_task_definition" "webapi" {
     }]
 
     environment = [
-      { name = "SERVER_PORT",                value = "8080" },
-      { name = "TZ",                         value = "Asia/Tokyo" },
-      { name = "SPRING_DATASOURCE_URL",      value = "jdbc:mysql://db.tasks.internal:3306/tasks" },
+      { name = "SERVER_PORT", value = "8080" },
+      { name = "TZ", value = "Asia/Tokyo" },
+      { name = "SPRING_DATASOURCE_URL", value = "jdbc:mysql://db.tasks.internal:3306/tasks" },
       { name = "SPRING_DATASOURCE_USERNAME", value = "tasks_webapi" },
     ]
 

--- a/infra/environments/dev/ecs_service.tf
+++ b/infra/environments/dev/ecs_service.tf
@@ -1,0 +1,186 @@
+# ---------------------------------------------------------------------------
+# ECS Task Execution Role — ECR pull + CloudWatch Logs + SSM secrets injection
+# Separate from Task Role (webapi_task in iam.tf) which is the app's runtime identity.
+# ---------------------------------------------------------------------------
+
+resource "aws_iam_role" "webapi_exec" {
+  name = "tasks-${var.env}-webapi-exec-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "ecs-tasks.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+
+  tags = {
+    Name = "tasks-${var.env}-webapi-exec-role"
+  }
+}
+
+# AWS managed policy: ECR pull + CloudWatch Logs agent delivery
+resource "aws_iam_role_policy_attachment" "webapi_exec_managed" {
+  role       = aws_iam_role.webapi_exec.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+# Inline policy: SSM read for secrets injected via container `secrets` block
+resource "aws_iam_role_policy" "webapi_exec_ssm" {
+  name = "tasks-${var.env}-webapi-exec-ssm"
+  role = aws_iam_role.webapi_exec.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "SsmSecrets"
+        Effect = "Allow"
+        Action = ["ssm:GetParameter", "ssm:GetParameters"]
+        Resource = [
+          "arn:aws:ssm:${var.region}:${data.aws_caller_identity.current.account_id}:parameter/tasks/${var.env}/app/jwt-issuer",
+          "arn:aws:ssm:${var.region}:${data.aws_caller_identity.current.account_id}:parameter/tasks/${var.env}/app/tenant-default-id",
+          "arn:aws:ssm:${var.region}:${data.aws_caller_identity.current.account_id}:parameter/tasks/${var.env}/keycloak/oauth-client-secret",
+        ]
+      },
+    ]
+  })
+}
+
+# ---------------------------------------------------------------------------
+# ADR-0028 巻き戻し防止 (i) — 現行稼働イメージ読取
+#
+# 初回 apply では Task Definition family が未存在のため data source read が失敗する。
+# ブートストラップ手順 (一度だけ):
+#   aws ecs register-task-definition \
+#     --family tasks-${env}-webapi \
+#     --requires-compatibilities FARGATE \
+#     --network-mode awsvpc \
+#     --cpu 512 --memory 1024 \
+#     --container-definitions '[{"name":"webapi","image":"<var.bootstrap_image>","essential":true}]'
+# 登録後に terraform apply を実行すると以降は CI デプロイ済みイメージを自動注入する。
+# ---------------------------------------------------------------------------
+
+data "aws_ecs_task_definition" "webapi_current" {
+  task_definition = "tasks-${var.env}-webapi"
+}
+
+data "aws_ecs_container_definition" "webapi_current" {
+  task_definition = data.aws_ecs_task_definition.webapi_current.id
+  container_name  = "webapi"
+}
+
+locals {
+  # ADR-0028 (i): inject currently running image to prevent rollback when Terraform applies env-var changes.
+  webapi_image = try(data.aws_ecs_container_definition.webapi_current.image, var.bootstrap_image)
+}
+
+# ---------------------------------------------------------------------------
+# ECS Task Definition — tasks-webapi (ADR-0028 / S2Infra-2)
+# CPU 512 / Memory 1024; Spring Boot 4 + GraalVM Native Image (ADR-0021)
+# Spring プロファイル不使用確定前提 — 環境差は env vars で注入(infrastructure-plan §1 確定前提 5)
+# ---------------------------------------------------------------------------
+
+resource "aws_ecs_task_definition" "webapi" {
+  family                   = "tasks-${var.env}-webapi"
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = "512"
+  memory                   = "1024"
+  execution_role_arn       = aws_iam_role.webapi_exec.arn
+  task_role_arn            = aws_iam_role.webapi_task.arn
+
+  container_definitions = jsonencode([{
+    name      = "webapi"
+    image     = local.webapi_image
+    essential = true
+
+    portMappings = [{
+      containerPort = 8080
+      protocol      = "tcp"
+    }]
+
+    environment = [
+      { name = "SERVER_PORT",                value = "8080" },
+      { name = "TZ",                         value = "Asia/Tokyo" },
+      { name = "SPRING_DATASOURCE_URL",      value = "jdbc:mysql://db.tasks.internal:3306/tasks" },
+      { name = "SPRING_DATASOURCE_USERNAME", value = "tasks_webapi" },
+    ]
+
+    secrets = [
+      {
+        name      = "SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUER_URI"
+        valueFrom = "arn:aws:ssm:${var.region}:${data.aws_caller_identity.current.account_id}:parameter/tasks/${var.env}/app/jwt-issuer"
+      },
+      {
+        name      = "APP_TENANT_DEFAULT_ID"
+        valueFrom = "arn:aws:ssm:${var.region}:${data.aws_caller_identity.current.account_id}:parameter/tasks/${var.env}/app/tenant-default-id"
+      },
+      {
+        name      = "KEYCLOAK_CLIENT_SECRET"
+        valueFrom = "arn:aws:ssm:${var.region}:${data.aws_caller_identity.current.account_id}:parameter/tasks/${var.env}/keycloak/oauth-client-secret"
+      },
+    ]
+
+    logConfiguration = {
+      logDriver = "awslogs"
+      options = {
+        "awslogs-group"         = module.ecs_cluster.webapi_log_group_name
+        "awslogs-region"        = var.region
+        "awslogs-stream-prefix" = "webapi"
+      }
+    }
+  }])
+
+  tags = {
+    Name = "tasks-${var.env}-webapi-task-def"
+  }
+}
+
+# ---------------------------------------------------------------------------
+# ADR-0028 巻き戻し防止 (ii) — max(revision) パターン用 data source
+# ECS Service の task_definition 属性は「Terraform が作った revision」と
+# 「稼働中最新 revision」のうち大きい方を指す。巻き戻し方向への repoint を構造的に排除。
+# ---------------------------------------------------------------------------
+
+data "aws_ecs_task_definition" "webapi" {
+  task_definition = aws_ecs_task_definition.webapi.family
+  depends_on      = [aws_ecs_task_definition.webapi]
+}
+
+# ---------------------------------------------------------------------------
+# ECS Service — tasks-webapi Fargate Service (S2Infra-2)
+# TG / Listener Rule は module.route53 が所有(priority 100, api-<env>.tasks.dgz48.xyz)
+# ---------------------------------------------------------------------------
+
+resource "aws_ecs_service" "webapi" {
+  name          = "tasks-${var.env}-webapi"
+  cluster       = module.ecs_cluster.cluster_arn
+  desired_count = 1
+  launch_type   = "FARGATE"
+
+  # ADR-0028 (ii): max(revision) で巻き戻し方向への repoint を構造的に排除
+  task_definition = "${aws_ecs_task_definition.webapi.family}:${max(
+    aws_ecs_task_definition.webapi.revision,
+    data.aws_ecs_task_definition.webapi.revision,
+  )}"
+
+  network_configuration {
+    subnets          = split(",", data.aws_ssm_parameter.private_subnet_ids.value)
+    security_groups  = [module.security_group.ecs_sg_id]
+    assign_public_ip = false
+  }
+
+  load_balancer {
+    target_group_arn = module.route53.webapi_tg_arn
+    container_name   = "webapi"
+    container_port   = 8080
+  }
+
+  depends_on = [module.route53]
+
+  tags = {
+    Name = "tasks-${var.env}-webapi-service"
+  }
+}

--- a/infra/environments/dev/variables.tf
+++ b/infra/environments/dev/variables.tf
@@ -73,3 +73,13 @@ variable "tenant_default_id" {
   default     = "1"
   description = "Default tenant ID"
 }
+
+# ---------------------------------------------------------------------------
+# ECS Task Definition — bootstrap image (ADR-0028)
+# ---------------------------------------------------------------------------
+
+variable "bootstrap_image" {
+  type        = string
+  default     = "public.ecr.aws/docker/library/busybox:latest"
+  description = "Placeholder image for initial Task Definition bootstrap. Used only on first apply before CI pushes the real ECR image."
+}

--- a/infra/shared/modules/iam_oidc/main.tf
+++ b/infra/shared/modules/iam_oidc/main.tf
@@ -749,7 +749,7 @@ data "aws_iam_policy_document" "tasks_apply" {
     resources = ["*"]
   }
 
-  # ECS write (ecs_cluster: Cluster / capacity providers。Service / Task Definition は S2Infra-2 で追加)
+  # ECS write (ecs_cluster: Cluster / capacity providers + webapi: Service / Task Definition (S2Infra-2))
   # 規約 R1: 書込み action は完全列挙
   # 規約 R2: 一部 action は resource-level permission 非対応(PutClusterCapacityProviders 等)、残りは apply 時点で対象 ARN が未確定のため Resource: *
   statement {
@@ -760,6 +760,11 @@ data "aws_iam_policy_document" "tasks_apply" {
       "ecs:UpdateCluster",
       "ecs:UpdateClusterSettings",
       "ecs:PutClusterCapacityProviders",
+      "ecs:RegisterTaskDefinition",
+      "ecs:DeregisterTaskDefinition",
+      "ecs:CreateService",
+      "ecs:UpdateService",
+      "ecs:DeleteService",
       "ecs:TagResource",
       "ecs:UntagResource",
     ]


### PR DESCRIPTION
## 概要

Issue #479 (S2Infra-2) — tasks-webapi の ECS Service + Task Definition + Task Execution Role を Terraform で構築する。

- **Task Execution Role** (`tasks-dev-webapi-exec-role`): ECR pull + CloudWatch Logs + SSM secrets injection
- **ECS Task Definition** (`tasks-dev-webapi`): CPU 512 / Memory 1024, Spring Boot 4 + GraalVM Native Image 想定
- **ECS Service** (`tasks-dev-webapi`): Fargate, private subnet, SG-ECS
- **ADR-0028 巻き戻し防止**: (i) 現行稼働イメージ data source 注入 + `try()` bootstrap fallback / (ii) `max(revision)` パターンで Service が巻き戻し方向に repoint しない構造
- **Terraform 規約 R3**: `tasks_apply.EcsWrite` に `RegisterTaskDefinition` / `DeregisterTaskDefinition` / `CreateService` / `UpdateService` / `DeleteService` を追加

## 変更ファイル

| ファイル | 内容 |
|---|---|
| `infra/environments/dev/ecs_service.tf` (新規) | Exec Role / Task Definition / ECS Service |
| `infra/environments/dev/variables.tf` | `bootstrap_image` 変数追加 |
| `infra/shared/modules/iam_oidc/main.tf` | `tasks_apply.EcsWrite` に Service/TaskDef アクション追加 |

## 設計ポイント

**TG / Listener Rule は module.route53 が既存所有**
`infra/modules/route53/main.tf` に `aws_lb_target_group.webapi` (port 8080, `/actuator/health`) と `aws_lb_listener_rule.api` (priority 100, `api-dev.tasks.dgz48.xyz`) が実装済みのため、ecs_service.tf では `module.route53.webapi_tg_arn` を参照するだけでよい。

**DB hostname**: Route53 PHZ `db.tasks.internal` (CNAME → RDS endpoint)

**IAM PassRole スコープ**: 既存の `IamRoles` statement (`arn:aws:iam::<account>:role/tasks-*`) が exec role `tasks-dev-webapi-exec-role` と task role `tasks-dev-webapi-task-role` 両方をカバー済み。追加不要。

**初回 apply の bootstrap**: `data "aws_ecs_task_definition" "webapi_current"` は family 未存在時に plan が失敗する。ecs_service.tf のコメントに AWS CLI による事前登録手順を記載。

## 未対応レビュー

| 指摘 | 内容 | 対応 |
|---|---|---|
| ~~[BLOCKER] terraform fmt -check 失敗~~ | ~~`ecs_service.tf` の environment block インデント不整合~~ | ~~closed: 703b7c8 で修正済み~~ |

## Test plan

- [ ] 共有スタック apply (`infra/shared/environments/dev/`) — `tasks_apply` ポリシー更新を反映
- [ ] `terraform plan` が tasks スタックでクリーン
- [ ] dev に apply 後 ECS Service が起動し `api-dev.tasks.dgz48.xyz/actuator/health` が 200 応答
- [ ] env vars のみ変更して再 apply しても稼働イメージが巻き戻らない (ADR-0028)

Closes #479

🤖 Generated with [Claude Code](https://claude.com/claude-code)
