### PR TITLE
fix(terraform): ADR-0028 (i) webapi_current data source を削除 — 初回 apply エラー修正

### DIFF
--- a/infra/environments/dev/ecs_service.tf
+++ b/infra/environments/dev/ecs_service.tf
@@ -49,31 +49,13 @@ resource "aws_iam_role_policy" "webapi_exec_ssm" {
 }
 
 # ---------------------------------------------------------------------------
-# ADR-0028 巻き戻し防止 (i) — 現行稼働イメージ読取
-#
-# 初回 apply では Task Definition family が未存在のため data source read が失敗する。
-# ブートストラップ手順 (一度だけ):
-#   aws ecs register-task-definition \
-#     --family tasks-${env}-webapi \
-#     --requires-compatibilities FARGATE \
-#     --network-mode awsvpc \
-#     --cpu 512 --memory 1024 \
-#     --container-definitions '[{"name":"webapi","image":"<var.bootstrap_image>","essential":true}]'
-# 登録後に terraform apply を実行すると以降は CI デプロイ済みイメージを自動注入する。
+# ADR-0028 巻き戻し防止 (i) — 現行稼働イメージ注入
+# CI deploy pipeline (S2Infra-4/5) 完了後に実装する。
+# それまでは var.bootstrap_image を直接使用し、(ii) max(revision) のみで巻き戻しを防ぐ。
 # ---------------------------------------------------------------------------
 
-data "aws_ecs_task_definition" "webapi_current" {
-  task_definition = "tasks-${var.env}-webapi"
-}
-
-data "aws_ecs_container_definition" "webapi_current" {
-  task_definition = data.aws_ecs_task_definition.webapi_current.id
-  container_name  = "webapi"
-}
-
 locals {
-  # ADR-0028 (i): inject currently running image to prevent rollback when Terraform applies env-var changes.
-  webapi_image = try(data.aws_ecs_container_definition.webapi_current.image, var.bootstrap_image)
+  webapi_image = var.bootstrap_image
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 概要

#619 (S2Infra-2) で実装した `data "aws_ecs_task_definition" "webapi_current"` が、初回 apply で `tasks-dev-webapi` family 未存在のため plan フェーズでエラーになる問題を修正する。

```
Error: reading ECS Task Definition (tasks-dev-webapi): couldn't find resource
```

## 原因

Terraform の data source read エラーは plan フェーズで発生するため、`try()` では捕捉できない。`webapi_current` data source は family が存在しない初回 apply では動作しない。

## 対応

`data "aws_ecs_task_definition" "webapi_current"` / `data "aws_ecs_container_definition" "webapi_current"` を削除し、`local.webapi_image = var.bootstrap_image` に差し替える。

ADR-0028 (i) のイメージ注入(現行稼働イメージを Terraform が作る新 revision に引き継ぐ)は、CI deploy pipeline が稼働する S2Infra-4/5 完了後に実装する。それまでは (ii) の `max(revision)` パターンのみで巻き戻しを防ぐ。

## Test plan

- [ ] `terraform plan` がクリーン(plan フェーズで data source read エラーが出ない)
- [ ] `terraform apply` が成功し ECS Service が起動する

Relates to #479