### PR TITLE
fix(terraform): tasks-apply に logs:ListTagsForResource / ListTagsLogGroup を追加 (#620 追補)

### DIFF
--- a/infra/shared/modules/iam_oidc/main.tf
+++ b/infra/shared/modules/iam_oidc/main.tf
@@ -1052,6 +1052,8 @@ data "aws_iam_policy_document" "tasks_apply" {
       "logs:UntagLogGroup",
       "logs:TagResource",
       "logs:UntagResource",
+      "logs:ListTagsLogGroup",
+      "logs:ListTagsForResource",
     ]
     resources = [
       "arn:aws:logs:${var.region}:${var.account_id}:log-group:/aws/lambda/tasks-${var.env}-*",


### PR DESCRIPTION
## 原因

#622 の apply 時に以下のエラーが発生:

```
logs:ListTagsForResource on resource: arn:aws:logs:ap-northeast-1:...:log-group:/aws/lambda/tasks-dev-ecs-scheduler
is not authorized ... because no identity-based policy allows the logs:ListTagsForResource action
```

`iam_oidc` の `tasks_apply` ロールに追加した `LogsWriteLambda` statement に、Terraform が state 読取で呼ぶ `logs:ListTagsForResource` と `logs:ListTagsLogGroup` が漏れていた。

## 修正

`LogsWriteLambda` の `actions` に 2 action を追記し、既存の `LogsWrite`(ECS 向け)と同セットに揃えた。

```diff
+      "logs:ListTagsLogGroup",
+      "logs:ListTagsForResource",
```

## 備考

- IAM ポリシーは `infra/shared` 側の apply(platform stack)で更新されるため、次回 tasks/dev apply 前に platform apply が必要
- Terraform 規約 R3: リソースと同 PR で必要 action を揃えるべきだったが追補対応

Closes #620 (apply 疎通完了の確認用)

🤖 Generated with [Claude Code](https://claude.com/claude-code)