### PR TITLE
fix(ci-cd): bootBuildImage --imageName で ECR タグ直接指定 — -Pversion 上書き問題を修正

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -216,10 +216,10 @@ jobs:
       - name: Build webapi image (bootBuildImage)
         if: env.BUILD_WEBAPI == 'true' && steps.webapi-exists.outputs.skip != 'true'
         run: |
-          VERSION_BARE="${VERSION#v}"
           chmod +x ./gradlew
-          ./gradlew :webapi:bootBuildImage -Pversion="${VERSION_BARE}" --no-daemon
-          docker tag "tasks-webapi:${VERSION_BARE}" "${ECR_REGISTRY}/tasks-webapi:${VERSION}"
+          ./gradlew :webapi:bootBuildImage \
+            --imageName="${ECR_REGISTRY}/tasks-webapi:${VERSION}" \
+            --no-daemon
           docker push "${ECR_REGISTRY}/tasks-webapi:${VERSION}"
 
       - name: Retag webapi (no source change — reuse previous digest)


### PR DESCRIPTION
## 問題

`v0.1.0` タグで release-build workflow を実行したところ `build-containers` ジョブの webapi ビルドステップが失敗。

**原因**: `webapi/build.gradle` に `version = '0.0.1-SNAPSHOT'` が直書きされており、コマンドライン `-Pversion=0.1.0` がビルドスクリプトの代入に上書きされる。結果として `bootBuildImage` が作成するイメージ名は `tasks-webapi:0.0.1-SNAPSHOT` となり、後続の `docker tag "tasks-webapi:0.1.0"` が失敗する。

## 修正

`bootBuildImage` の `--imageName` フラグで ECR タグを直接指定することで `build.gradle` の `version` 設定に依存しないようにした。`docker tag` ステップも不要になり削除。

```bash
# Before
./gradlew :webapi:bootBuildImage -Pversion="${VERSION_BARE}" --no-daemon
docker tag "tasks-webapi:${VERSION_BARE}" "${ECR_REGISTRY}/tasks-webapi:${VERSION}"
docker push "${ECR_REGISTRY}/tasks-webapi:${VERSION}"

# After
./gradlew :webapi:bootBuildImage \
  --imageName="${ECR_REGISTRY}/tasks-webapi:${VERSION}" \
  --no-daemon
docker push "${ECR_REGISTRY}/tasks-webapi:${VERSION}"
```

## Test plan

- [ ] `v0.1.0` タグで release-build workflow を再実行し、webapi イメージが ECR に `v0.1.0` タグで push されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)