### PR TITLE
infra(ci-cd): ADR-0031 フロー B — deploy workflow + app-deploy IAM ロール (#635)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,657 @@
+name: Deploy
+
+# ADR-0031 フロー B — workflow_dispatch で version + environment を指定し、
+# 変更のあるコンポーネントのみ対象環境へデプロイする。
+# 旧 #481/#482/#483 を集約し、terraform-apply.yml の infra dispatch も本 workflow に取り込む。
+#
+# 必要な GitHub Environments (repo Settings → Environments):
+#   dev / (stg) / (prd)   : required reviewers 設定(stg/prd のみ)
+#   platform-plan         : 既存、platform-dev-plan IAM ロールと紐付け
+#   tasks-plan            : 既存、tasks-dev-plan IAM ロールと紐付け
+#   platform-apply        : 既存、platform-dev-apply IAM ロールと紐付け
+#   tasks-apply           : 既存、tasks-dev-apply IAM ロールと紐付け
+#
+# 必要な GitHub Environment Variables (dev 環境):
+#   CLOUDFRONT_DISTRIBUTION_ID : CloudFront distribution ID (CF invalidation に使用)
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Deploy version (e.g. v0.1.0)'
+        required: true
+        type: string
+      environment:
+        description: 'Target environment'
+        required: true
+        type: environment
+
+# 同一環境へのデプロイは直列化(割り込みによる中途半端な状態を防ぐ)
+concurrency:
+  group: deploy-${{ inputs.environment }}
+  cancel-in-progress: false
+
+env:
+  LANG: ja_JP.UTF-8
+  TZ: Asia/Tokyo
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  AWS_REGION: ap-northeast-1
+  ECR_REGISTRY: 138285070797.dkr.ecr.ap-northeast-1.amazonaws.com
+  AWS_ACCOUNT_ID: "138285070797"
+  TF_PLUGIN_CACHE_DIR: ~/.terraform.d/plugin-cache
+
+# --------------------------------------------------------------------------
+# verify — 成果物の存在確認 (ECR image + S3 bundle)。fail-closed。
+# deploy_webapi / deploy_keycloak / deploy_web を output に出力し
+# 各 deploy job の if 条件として利用する。
+# --------------------------------------------------------------------------
+jobs:
+  verify:
+    name: Verify artifacts (${{ inputs.version }} → ${{ inputs.environment }})
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    permissions:
+      id-token: write
+      contents: read
+      deployments: write
+    outputs:
+      deploy_webapi: ${{ steps.check.outputs.deploy_webapi }}
+      deploy_keycloak: ${{ steps.check.outputs.deploy_keycloak }}
+      deploy_web: ${{ steps.check.outputs.deploy_web }}
+
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/tasks-${{ inputs.environment }}-deploy
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Check artifacts for ${{ inputs.version }}
+        id: check
+        env:
+          VERSION: ${{ inputs.version }}
+          ENV: ${{ inputs.environment }}
+        run: |
+          # webapi ECR image
+          if aws ecr describe-images \
+            --repository-name tasks-webapi \
+            --image-ids imageTag="${VERSION}" \
+            --query 'imageDetails[0].imageDigest' \
+            --output text 2>/dev/null | grep -q '^sha256:'; then
+            echo "deploy_webapi=true" >> "$GITHUB_OUTPUT"
+            echo "✓ webapi image ${VERSION} found in ECR"
+          else
+            echo "deploy_webapi=false" >> "$GITHUB_OUTPUT"
+            echo "– webapi image ${VERSION} not found (component unchanged in this release)"
+          fi
+
+          # keycloak ECR image
+          if aws ecr describe-images \
+            --repository-name keycloak-custom \
+            --image-ids imageTag="${VERSION}" \
+            --query 'imageDetails[0].imageDigest' \
+            --output text 2>/dev/null | grep -q '^sha256:'; then
+            echo "deploy_keycloak=true" >> "$GITHUB_OUTPUT"
+            echo "✓ keycloak image ${VERSION} found in ECR"
+          else
+            echo "deploy_keycloak=false" >> "$GITHUB_OUTPUT"
+            echo "– keycloak image ${VERSION} not found (component unchanged in this release)"
+          fi
+
+          # web S3 bundle (tasks-<env>-frontend/web/<version>/)
+          BUCKET="tasks-${ENV}-frontend"
+          if aws s3 ls "s3://${BUCKET}/web/${VERSION}/" --recursive 2>/dev/null | grep -q '.'; then
+            echo "deploy_web=true" >> "$GITHUB_OUTPUT"
+            echo "✓ web bundle ${VERSION} found in s3://${BUCKET}/web/${VERSION}/"
+          else
+            echo "deploy_web=false" >> "$GITHUB_OUTPUT"
+            echo "– web bundle ${VERSION} not found (component unchanged in this release)"
+          fi
+
+  # --------------------------------------------------------------------------
+  # plan-platform — platform/shared terraform plan (artifact に保存して apply job へ渡す)
+  # TODO: infra/shared/environments/<env> を parameterize して stg/prd に対応する (#635 follow-up)
+  # --------------------------------------------------------------------------
+  plan-platform:
+    name: Terraform plan (platform/dev)
+    needs: verify
+    if: inputs.environment == 'dev'
+    runs-on: ubuntu-latest
+    environment: platform-plan
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.version }}
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: '1.11.4'
+          terraform_wrapper: false
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/platform-dev-plan
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Create plugin cache dir
+        run: mkdir -p ~/.terraform.d/plugin-cache
+
+      - name: Restore Terraform plugin cache (shared/dev)
+        uses: actions/cache@v4
+        with:
+          path: ~/.terraform.d/plugin-cache
+          key: tf-plugins-shared-dev-${{ hashFiles('infra/shared/environments/dev/.terraform.lock.hcl') }}
+          restore-keys: tf-plugins-shared-dev-
+
+      - name: terraform init (platform/dev)
+        working-directory: infra/shared/environments/dev
+        run: terraform init -no-color
+
+      - name: terraform plan (platform/dev)
+        id: plan
+        working-directory: infra/shared/environments/dev
+        shell: bash
+        run: |
+          set +e
+          terraform plan -detailed-exitcode -out=tfplan.binary -no-color 2>&1 | tee plan.txt
+          echo "exit_code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+
+      - name: Check plan result
+        shell: bash
+        run: |
+          CODE="${{ steps.plan.outputs.exit_code }}"
+          if [ "$CODE" = "1" ]; then
+            echo "::error::terraform plan (platform/dev) failed"
+            exit 1
+          elif [ "$CODE" = "2" ]; then
+            echo "Plan has changes — apply-platform will proceed"
+            grep -E '^(Plan:|No changes\.|Error:)' infra/shared/environments/dev/plan.txt | head -3 || true
+          else
+            echo "No changes in platform/dev"
+          fi
+
+      - name: Upload tfplan artifact (platform)
+        uses: actions/upload-artifact@v4
+        with:
+          name: tfplan-platform-${{ inputs.environment }}
+          path: |
+            infra/shared/environments/dev/tfplan.binary
+            infra/shared/environments/dev/plan.txt
+          retention-days: 7
+
+  # --------------------------------------------------------------------------
+  # plan-tasks — tasks terraform plan (artifact に保存 + ADR-0028 iii baseline 記録)
+  # TODO: infra/environments/<env> を parameterize して stg/prd に対応する (#635 follow-up)
+  # --------------------------------------------------------------------------
+  plan-tasks:
+    name: Terraform plan (tasks/dev)
+    needs: verify
+    if: inputs.environment == 'dev'
+    runs-on: ubuntu-latest
+    environment: tasks-plan
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.version }}
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: '1.11.4'
+          terraform_wrapper: false
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/tasks-dev-plan
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Create plugin cache dir
+        run: mkdir -p ~/.terraform.d/plugin-cache
+
+      - name: Restore Terraform plugin cache (tasks/dev)
+        uses: actions/cache@v4
+        with:
+          path: ~/.terraform.d/plugin-cache
+          key: tf-plugins-tasks-dev-${{ hashFiles('infra/environments/dev/.terraform.lock.hcl') }}
+          restore-keys: tf-plugins-tasks-dev-
+
+      - name: terraform init (tasks/dev)
+        working-directory: infra/environments/dev
+        run: terraform init -no-color
+
+      - name: terraform plan (tasks/dev)
+        id: plan
+        working-directory: infra/environments/dev
+        shell: bash
+        run: |
+          set +e
+          terraform plan -detailed-exitcode -out=tfplan.binary -no-color 2>&1 | tee plan.txt
+          echo "exit_code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+
+      - name: Check plan result
+        shell: bash
+        run: |
+          CODE="${{ steps.plan.outputs.exit_code }}"
+          if [ "$CODE" = "1" ]; then
+            echo "::error::terraform plan (tasks/dev) failed"
+            exit 1
+          elif [ "$CODE" = "2" ]; then
+            echo "Plan has changes — apply-tasks will proceed"
+            grep -E '^(Plan:|No changes\.|Error:)' infra/environments/dev/plan.txt | head -3 || true
+          else
+            echo "No changes in tasks/dev"
+          fi
+
+      # ADR-0028 (iii): plan 実行時点の ECS image を記録し apply guard で比較する。
+      # deploy-webapi が同 workflow run で ECS を更新する場合は apply-tasks が
+      # 「baseline or target version image」の両方を許容する(下記 guard 参照)。
+      - name: Capture ECS baseline image (ADR-0028 iii)
+        run: |
+          aws ecs describe-task-definition \
+            --task-definition tasks-dev-webapi \
+            --query 'taskDefinition.containerDefinitions[0].image' \
+            --output text > baseline_image.txt
+          echo "Baseline ECS image: $(cat baseline_image.txt)"
+
+      - name: Upload tfplan artifact (tasks)
+        uses: actions/upload-artifact@v4
+        with:
+          name: tfplan-tasks-${{ inputs.environment }}
+          path: |
+            infra/environments/dev/tfplan.binary
+            infra/environments/dev/plan.txt
+            baseline_image.txt
+          retention-days: 7
+
+  # --------------------------------------------------------------------------
+  # deploy-webapi — ECS task definition を新バージョンのイメージに更新する。
+  # 目標 digest と現行 digest が一致する場合は no-op(rolling update なし)。
+  # --------------------------------------------------------------------------
+  deploy-webapi:
+    name: Deploy webapi (${{ inputs.version }})
+    needs: verify
+    if: needs.verify.outputs.deploy_webapi == 'true'
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    permissions:
+      id-token: write
+      contents: read
+      deployments: write
+
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/tasks-${{ inputs.environment }}-deploy
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Deploy webapi to ECS
+        env:
+          VERSION: ${{ inputs.version }}
+          ENV: ${{ inputs.environment }}
+        run: |
+          CLUSTER="tasks-${ENV}-cluster"
+          SERVICE="tasks-${ENV}-webapi"
+          FAMILY="tasks-${ENV}-webapi"
+          CONTAINER="webapi"
+          NEW_IMAGE="${ECR_REGISTRY}/tasks-webapi:${VERSION}"
+
+          # 目標イメージの digest を取得
+          TARGET_DIGEST=$(aws ecr describe-images \
+            --repository-name tasks-webapi \
+            --image-ids imageTag="${VERSION}" \
+            --query 'imageDetails[0].imageDigest' \
+            --output text)
+          echo "Target  digest: ${TARGET_DIGEST}"
+
+          # 現行 task definition のイメージを取得
+          CURRENT_TD=$(aws ecs describe-task-definition \
+            --task-definition "${FAMILY}" \
+            --query 'taskDefinition' \
+            --output json)
+          CURRENT_IMAGE=$(echo "${CURRENT_TD}" | jq -r \
+            ".containerDefinitions[] | select(.name==\"${CONTAINER}\") | .image")
+          echo "Current image: ${CURRENT_IMAGE}"
+
+          # 現行イメージの digest を取得して比較(digest 一致 = no-op)
+          CURRENT_DIGEST=""
+          if echo "${CURRENT_IMAGE}" | grep -q "${ECR_REGISTRY}/tasks-webapi:v"; then
+            CURRENT_TAG="${CURRENT_IMAGE##*:}"
+            CURRENT_DIGEST=$(aws ecr describe-images \
+              --repository-name tasks-webapi \
+              --image-ids imageTag="${CURRENT_TAG}" \
+              --query 'imageDetails[0].imageDigest' \
+              --output text 2>/dev/null || echo "")
+          fi
+          echo "Current digest: ${CURRENT_DIGEST:-<unknown>}"
+
+          if [ -n "${CURRENT_DIGEST}" ] && [ "${TARGET_DIGEST}" = "${CURRENT_DIGEST}" ]; then
+            echo "Same digest — ECS is already running this image. No-op."
+            exit 0
+          fi
+
+          # 新 task definition を登録(イメージ URI のみ差し替え)
+          # .tags を削除: CI リビジョンに tags を付与しないことで ecs:TagResource 不要(最小権限)
+          NEW_TD=$(echo "${CURRENT_TD}" | jq \
+            --arg image "${NEW_IMAGE}" \
+            --arg name "${CONTAINER}" \
+            'del(.taskDefinitionArn,.revision,.status,.requiresAttributes,.placementConstraints,.compatibilities,.registeredAt,.registeredBy,.tags) |
+             .containerDefinitions |= map(if .name == $name then .image = $image else . end)')
+
+          NEW_REVISION=$(aws ecs register-task-definition \
+            --cli-input-json "${NEW_TD}" \
+            --query 'taskDefinition.revision' \
+            --output text)
+          echo "Registered ${FAMILY}:${NEW_REVISION} with image ${NEW_IMAGE}"
+
+          # ECS サービスを新 revision に更新
+          aws ecs update-service \
+            --cluster "${CLUSTER}" \
+            --service "${SERVICE}" \
+            --task-definition "${FAMILY}:${NEW_REVISION}" \
+            --query 'service.taskDefinition' \
+            --output text
+
+          echo "Waiting for service stability..."
+          aws ecs wait services-stable \
+            --cluster "${CLUSTER}" \
+            --services "${SERVICE}"
+          echo "✓ webapi deployed: ${NEW_IMAGE}"
+
+  # --------------------------------------------------------------------------
+  # deploy-keycloak — platform cluster の keycloak ECS を新バージョンに更新する。
+  # lifecycle.ignore_changes = [task_definition] により Terraform drift なし。
+  # --------------------------------------------------------------------------
+  deploy-keycloak:
+    name: Deploy keycloak (${{ inputs.version }})
+    needs: verify
+    if: needs.verify.outputs.deploy_keycloak == 'true'
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    permissions:
+      id-token: write
+      contents: read
+      deployments: write
+
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/platform-${{ inputs.environment }}-deploy
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Deploy keycloak to ECS
+        env:
+          VERSION: ${{ inputs.version }}
+          ENV: ${{ inputs.environment }}
+        run: |
+          CLUSTER="platform-${ENV}-cluster"
+          SERVICE="platform-${ENV}-keycloak"
+          FAMILY="platform-${ENV}-keycloak"
+          CONTAINER="keycloak"
+          NEW_IMAGE="${ECR_REGISTRY}/keycloak-custom:${VERSION}"
+
+          TARGET_DIGEST=$(aws ecr describe-images \
+            --repository-name keycloak-custom \
+            --image-ids imageTag="${VERSION}" \
+            --query 'imageDetails[0].imageDigest' \
+            --output text)
+          echo "Target  digest: ${TARGET_DIGEST}"
+
+          CURRENT_TD=$(aws ecs describe-task-definition \
+            --task-definition "${FAMILY}" \
+            --query 'taskDefinition' \
+            --output json)
+          CURRENT_IMAGE=$(echo "${CURRENT_TD}" | jq -r \
+            ".containerDefinitions[] | select(.name==\"${CONTAINER}\") | .image")
+          echo "Current image: ${CURRENT_IMAGE}"
+
+          CURRENT_DIGEST=""
+          if echo "${CURRENT_IMAGE}" | grep -q "${ECR_REGISTRY}/keycloak-custom:v"; then
+            CURRENT_TAG="${CURRENT_IMAGE##*:}"
+            CURRENT_DIGEST=$(aws ecr describe-images \
+              --repository-name keycloak-custom \
+              --image-ids imageTag="${CURRENT_TAG}" \
+              --query 'imageDetails[0].imageDigest' \
+              --output text 2>/dev/null || echo "")
+          fi
+          echo "Current digest: ${CURRENT_DIGEST:-<unknown>}"
+
+          if [ -n "${CURRENT_DIGEST}" ] && [ "${TARGET_DIGEST}" = "${CURRENT_DIGEST}" ]; then
+            echo "Same digest — keycloak is already running this image. No-op."
+            exit 0
+          fi
+
+          # .tags を削除: CI リビジョンに tags を付与しないことで ecs:TagResource 不要(最小権限)
+          NEW_TD=$(echo "${CURRENT_TD}" | jq \
+            --arg image "${NEW_IMAGE}" \
+            --arg name "${CONTAINER}" \
+            'del(.taskDefinitionArn,.revision,.status,.requiresAttributes,.placementConstraints,.compatibilities,.registeredAt,.registeredBy,.tags) |
+             .containerDefinitions |= map(if .name == $name then .image = $image else . end)')
+
+          NEW_REVISION=$(aws ecs register-task-definition \
+            --cli-input-json "${NEW_TD}" \
+            --query 'taskDefinition.revision' \
+            --output text)
+          echo "Registered ${FAMILY}:${NEW_REVISION} with image ${NEW_IMAGE}"
+
+          aws ecs update-service \
+            --cluster "${CLUSTER}" \
+            --service "${SERVICE}" \
+            --task-definition "${FAMILY}:${NEW_REVISION}" \
+            --query 'service.taskDefinition' \
+            --output text
+
+          echo "Waiting for service stability..."
+          aws ecs wait services-stable \
+            --cluster "${CLUSTER}" \
+            --services "${SERVICE}"
+          echo "✓ keycloak deployed: ${NEW_IMAGE}"
+
+  # --------------------------------------------------------------------------
+  # deploy-web — S3 バンドルを live/ prefix に sync + CloudFront invalidation。
+  # バージョン付きアセットは immutable cache、index.html は no-cache で配信。
+  # --------------------------------------------------------------------------
+  deploy-web:
+    name: Deploy web (${{ inputs.version }})
+    needs: verify
+    if: needs.verify.outputs.deploy_web == 'true'
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    permissions:
+      id-token: write
+      contents: read
+      deployments: write
+
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/tasks-${{ inputs.environment }}-deploy
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Sync web bundle to live prefix
+        env:
+          VERSION: ${{ inputs.version }}
+          ENV: ${{ inputs.environment }}
+          CLOUDFRONT_DISTRIBUTION_ID: ${{ vars.CLOUDFRONT_DISTRIBUTION_ID }}
+        run: |
+          BUCKET="tasks-${ENV}-frontend"
+          SRC="s3://${BUCKET}/web/${VERSION}/"
+          DST="s3://${BUCKET}/web/live/"
+
+          echo "Syncing ${SRC} → ${DST}"
+
+          # バージョン付きアセット(JS/CSS/フォント等): 長期 immutable cache
+          # index.html は後続ステップで上書きするので --exclude で除外
+          aws s3 sync "${SRC}" "${DST}" \
+            --delete \
+            --cache-control "public, max-age=31536000, immutable" \
+            --exclude "index.html"
+
+          # index.html: 常に最新を取得させる(no-cache)
+          aws s3 cp \
+            "${SRC}index.html" \
+            "${DST}index.html" \
+            --cache-control "no-cache, no-store, must-revalidate"
+
+          echo "S3 sync complete"
+
+          # CloudFront invalidation(CLOUDFRONT_DISTRIBUTION_ID が未設定の場合はスキップ)
+          if [ -n "${CLOUDFRONT_DISTRIBUTION_ID}" ]; then
+            INVALIDATION_ID=$(aws cloudfront create-invalidation \
+              --distribution-id "${CLOUDFRONT_DISTRIBUTION_ID}" \
+              --paths "/web/*" \
+              --query 'Invalidation.Id' \
+              --output text)
+            echo "✓ CloudFront invalidation created: ${INVALIDATION_ID}"
+          else
+            echo "::warning::CLOUDFRONT_DISTRIBUTION_ID not set — skipping CloudFront invalidation"
+          fi
+
+  # --------------------------------------------------------------------------
+  # apply-platform — 両 plan 成功後、承認ゲートを経て platform terraform を apply する。
+  # TODO: stg/prd 対応時は role-to-assume と working-directory を parameterize する。
+  # --------------------------------------------------------------------------
+  apply-platform:
+    name: Terraform apply (platform/dev)
+    needs: [plan-platform, plan-tasks]
+    if: inputs.environment == 'dev'
+    runs-on: ubuntu-latest
+    environment: platform-apply
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.version }}
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: '1.11.4'
+          terraform_wrapper: false
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/platform-dev-apply
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Create plugin cache dir
+        run: mkdir -p ~/.terraform.d/plugin-cache
+
+      - name: Restore Terraform plugin cache (shared/dev)
+        uses: actions/cache@v4
+        with:
+          path: ~/.terraform.d/plugin-cache
+          key: tf-plugins-shared-dev-${{ hashFiles('infra/shared/environments/dev/.terraform.lock.hcl') }}
+          restore-keys: tf-plugins-shared-dev-
+
+      - name: Download tfplan artifact (platform)
+        uses: actions/download-artifact@v4
+        with:
+          name: tfplan-platform-${{ inputs.environment }}
+          path: .
+
+      - name: terraform init (platform/dev)
+        working-directory: infra/shared/environments/dev
+        run: terraform init -no-color
+
+      - name: terraform apply (platform/dev)
+        working-directory: infra/shared/environments/dev
+        run: terraform apply -auto-approve -no-color tfplan.binary
+
+  # --------------------------------------------------------------------------
+  # apply-tasks — platform apply 後に tasks terraform を apply する。
+  # ADR-0028 (iii): apply 直前に ECS image を再確認し、plan 後の割り込みを検知して fail-closed。
+  #   許容パターン:
+  #     (a) 現行 = baseline (ECS 変化なし)
+  #     (b) 現行 = 今回デプロイする target version (同 workflow run の deploy-webapi が先行)
+  #   それ以外 = 別デプロイによる割り込み → fail
+  # --------------------------------------------------------------------------
+  apply-tasks:
+    name: Terraform apply (tasks/dev)
+    needs: apply-platform
+    if: inputs.environment == 'dev'
+    runs-on: ubuntu-latest
+    environment: tasks-apply
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.version }}
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: '1.11.4'
+          terraform_wrapper: false
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/tasks-dev-apply
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Create plugin cache dir
+        run: mkdir -p ~/.terraform.d/plugin-cache
+
+      - name: Restore Terraform plugin cache (tasks/dev)
+        uses: actions/cache@v4
+        with:
+          path: ~/.terraform.d/plugin-cache
+          key: tf-plugins-tasks-dev-${{ hashFiles('infra/environments/dev/.terraform.lock.hcl') }}
+          restore-keys: tf-plugins-tasks-dev-
+
+      - name: Download tfplan artifact (tasks)
+        uses: actions/download-artifact@v4
+        with:
+          name: tfplan-tasks-${{ inputs.environment }}
+          path: .
+
+      - name: ADR-0028 (iii) apply guard — ECS image mismatch check
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          BASELINE=$(cat baseline_image.txt)
+          EXPECTED="${ECR_REGISTRY}/tasks-webapi:${VERSION}"
+          CURRENT=$(aws ecs describe-task-definition \
+            --task-definition tasks-dev-webapi \
+            --query 'taskDefinition.containerDefinitions[0].image' \
+            --output text)
+          echo "Baseline (plan 時):       ${BASELINE}"
+          echo "Expected (このデプロイ):   ${EXPECTED}"
+          echo "Current  (現在の ECS):     ${CURRENT}"
+
+          if [ "${CURRENT}" != "${BASELINE}" ] && [ "${CURRENT}" != "${EXPECTED}" ]; then
+            echo "::error::ECS image が plan 後に予期しない値に変化しました (ADR-0028 iii)。"
+            echo "::error::別の deploy workflow が割り込んだ可能性があります。"
+            echo "::error::再度 deploy を実行してください。"
+            exit 1
+          fi
+          echo "Image guard passed."
+
+      - name: terraform init (tasks/dev)
+        working-directory: infra/environments/dev
+        run: terraform init -no-color
+
+      - name: terraform apply (tasks/dev)
+        working-directory: infra/environments/dev
+        run: terraform apply -auto-approve -no-color tfplan.binary

--- a/infra/shared/modules/iam_oidc/main.tf
+++ b/infra/shared/modules/iam_oidc/main.tf
@@ -21,11 +21,13 @@ locals {
 
 data "aws_iam_policy_document" "trust" {
   for_each = {
-    platform_plan  = "platform-plan"
-    platform_apply = "platform-apply"
-    tasks_plan     = "tasks-plan"
-    tasks_apply    = "tasks-apply"
-    release_build  = "release-build"
+    platform_plan   = "platform-plan"
+    platform_apply  = "platform-apply"
+    tasks_plan      = "tasks-plan"
+    tasks_apply     = "tasks-apply"
+    release_build   = "release-build"
+    tasks_deploy    = var.env # "dev" → environment:dev OIDC sub (webapi ECS + web S3/CF + artifact verify)
+    platform_deploy = var.env # "dev" → environment:dev OIDC sub (keycloak ECS on platform cluster)
   }
 
   statement {
@@ -1238,4 +1240,163 @@ resource "aws_iam_role_policy" "release_build" {
   name   = "release-build-policy"
   role   = aws_iam_role.release_build.id
   policy = data.aws_iam_policy_document.release_build.json
+}
+
+# ---------------------------------------------------------------------------
+# tasks-<env>-deploy  (write; deploy workflow — webapi ECS + web S3/CF + verify)
+# Trust: environment:<env> (e.g. "dev") — GitHub Environment for the deploy target
+# Used by deploy.yml jobs: verify / deploy-webapi / deploy-web
+# ---------------------------------------------------------------------------
+
+resource "aws_iam_role" "tasks_deploy" {
+  name               = "tasks-${var.env}-deploy"
+  assume_role_policy = data.aws_iam_policy_document.trust["tasks_deploy"].json
+
+  tags = {
+    Name = "tasks-${var.env}-deploy"
+  }
+}
+
+data "aws_iam_policy_document" "tasks_deploy" {
+  # ECR read — both repos for artifact verify + no-op digest check
+  # ecr:DescribeImages のみ使用(aws ecr describe-images); BatchGetImage / GetAuthorizationToken 不要
+  statement {
+    sid     = "EcrRead"
+    actions = ["ecr:DescribeImages"]
+    resources = [
+      "arn:aws:ecr:${var.region}:${var.account_id}:repository/tasks-webapi",
+      "arn:aws:ecr:${var.region}:${var.account_id}:repository/keycloak-custom",
+    ]
+  }
+
+  # ECS — webapi task definition 更新 + サービス安定待ち
+  # 規約 R1: 書込み action は完全列挙
+  # 規約 R2: RegisterTaskDefinition / DescribeTaskDefinition は resource-level 非対応 → Resource: *
+  statement {
+    sid = "EcsTasksWebapi"
+    actions = [
+      "ecs:DescribeTaskDefinition",
+      "ecs:RegisterTaskDefinition",
+      "ecs:UpdateService",
+      "ecs:DescribeServices",
+    ]
+    resources = ["*"]
+  }
+
+  # IAM PassRole — ecs:RegisterTaskDefinition 時に task execution role / task role を指定するために必要
+  # 規約 R1: 書込み action は完全列挙
+  # 規約 R2: tasks-<env>-webapi-* ロール ARN にスコープ
+  statement {
+    sid     = "IamPassRole"
+    actions = ["iam:PassRole"]
+    resources = [
+      "arn:aws:iam::${var.account_id}:role/tasks-${var.env}-webapi-exec-role",
+      "arn:aws:iam::${var.account_id}:role/tasks-${var.env}-webapi-task-role",
+    ]
+  }
+
+  # S3: web バンドルの読み書き(web/<version>/ から web/live/ へ sync)
+  # 規約 R1: 書込み action は完全列挙
+  # GetObject: コピー元バージョン prefix (web/<version>/) の読み取り
+  # PutObject: コピー先 live/ への書き込み
+  # DeleteObject: sync --delete で live/ 内の旧ファイル削除; バージョン prefix は削除不可
+  statement {
+    sid     = "S3WebBundleReadWrite"
+    actions = ["s3:GetObject", "s3:PutObject"]
+    resources = [
+      "arn:aws:s3:::tasks-${var.env}-frontend/web/*",
+    ]
+  }
+  statement {
+    sid     = "S3WebLiveDelete"
+    actions = ["s3:DeleteObject"]
+    resources = [
+      "arn:aws:s3:::tasks-${var.env}-frontend/web/live/*",
+    ]
+  }
+  # s3:ListBucket は resource-level prefix 制限を condition で行う
+  statement {
+    sid       = "S3WebBundleList"
+    actions   = ["s3:ListBucket"]
+    resources = ["arn:aws:s3:::tasks-${var.env}-frontend"]
+    condition {
+      test     = "StringLike"
+      variable = "s3:prefix"
+      values   = ["web/*"]
+    }
+  }
+
+  # CloudFront invalidation — live/ prefix を無効化して新バンドルを即時配信
+  # 規約 R1: 書込み action は完全列挙
+  # 規約 R2: distribution ID は apply 時点で未確定のため Resource: *
+  statement {
+    sid       = "CloudFrontInvalidate"
+    actions   = ["cloudfront:CreateInvalidation"]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy" "tasks_deploy" {
+  name   = "tasks-${var.env}-deploy-policy"
+  role   = aws_iam_role.tasks_deploy.id
+  policy = data.aws_iam_policy_document.tasks_deploy.json
+}
+
+# ---------------------------------------------------------------------------
+# platform-<env>-deploy  (write; deploy workflow — keycloak ECS on platform cluster)
+# Trust: environment:<env> (e.g. "dev") — GitHub Environment for the deploy target
+# Used by deploy.yml job: deploy-keycloak
+# ---------------------------------------------------------------------------
+
+resource "aws_iam_role" "platform_deploy" {
+  name               = "platform-${var.env}-deploy"
+  assume_role_policy = data.aws_iam_policy_document.trust["platform_deploy"].json
+
+  tags = {
+    Name = "platform-${var.env}-deploy"
+  }
+}
+
+data "aws_iam_policy_document" "platform_deploy" {
+  # ECR read — keycloak-custom のみ(no-op digest check)
+  # ecr:DescribeImages のみ使用(aws ecr describe-images); BatchGetImage / GetAuthorizationToken 不要
+  statement {
+    sid     = "EcrRead"
+    actions = ["ecr:DescribeImages"]
+    resources = [
+      "arn:aws:ecr:${var.region}:${var.account_id}:repository/keycloak-custom",
+    ]
+  }
+
+  # ECS — platform cluster の keycloak task definition 更新
+  # 規約 R1: 書込み action は完全列挙
+  # 規約 R2: RegisterTaskDefinition / DescribeTaskDefinition は resource-level 非対応 → Resource: *
+  statement {
+    sid = "EcsPlatformKeycloak"
+    actions = [
+      "ecs:DescribeTaskDefinition",
+      "ecs:RegisterTaskDefinition",
+      "ecs:UpdateService",
+      "ecs:DescribeServices",
+    ]
+    resources = ["*"]
+  }
+
+  # IAM PassRole — ecs:RegisterTaskDefinition 時に keycloak 実行ロールを指定するために必要
+  # 規約 R1: 書込み action は完全列挙
+  # 規約 R2: platform-<env>-keycloak-* ロール ARN にスコープ
+  statement {
+    sid     = "IamPassRole"
+    actions = ["iam:PassRole"]
+    resources = [
+      "arn:aws:iam::${var.account_id}:role/platform-${var.env}-keycloak-exec-role",
+      "arn:aws:iam::${var.account_id}:role/platform-${var.env}-keycloak-task-role",
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "platform_deploy" {
+  name   = "platform-${var.env}-deploy-policy"
+  role   = aws_iam_role.platform_deploy.id
+  policy = data.aws_iam_policy_document.platform_deploy.json
 }

--- a/infra/shared/modules/iam_oidc/main.tf
+++ b/infra/shared/modules/iam_oidc/main.tf
@@ -1334,11 +1334,13 @@ data "aws_iam_policy_document" "tasks_deploy" {
 
   # CloudFront invalidation — live/ prefix を無効化して新バンドルを即時配信
   # 規約 R1: 書込み action は完全列挙
-  # 規約 R2: distribution ID は apply 時点で未確定のため Resource: *
+  # 規約 R2: distribution ID は apply 時点で未確定のため account-scope pattern で最小化
   statement {
-    sid       = "CloudFrontInvalidate"
-    actions   = ["cloudfront:CreateInvalidation"]
-    resources = ["*"]
+    sid     = "CloudFrontInvalidate"
+    actions = ["cloudfront:CreateInvalidation"]
+    resources = [
+      "arn:aws:cloudfront::${var.account_id}:distribution/*",
+    ]
   }
 }
 

--- a/infra/shared/modules/iam_oidc/main.tf
+++ b/infra/shared/modules/iam_oidc/main.tf
@@ -1273,14 +1273,20 @@ data "aws_iam_policy_document" "tasks_deploy" {
   # 規約 R1: 書込み action は完全列挙
   # 規約 R2: RegisterTaskDefinition / DescribeTaskDefinition は resource-level 非対応 → Resource: *
   statement {
-    sid = "EcsTasksWebapi"
-    actions = [
-      "ecs:DescribeTaskDefinition",
-      "ecs:RegisterTaskDefinition",
-      "ecs:UpdateService",
-      "ecs:DescribeServices",
-    ]
+    sid     = "EcsTaskDefinition"
+    actions = ["ecs:DescribeTaskDefinition", "ecs:RegisterTaskDefinition"]
+    # RegisterTaskDefinition / DescribeTaskDefinition は resource-level permission 非対応
     resources = ["*"]
+  }
+
+  # 規約 R2: UpdateService / DescribeServices は resource-level 対応 → クラスター/サービス ARN にスコープ
+  statement {
+    sid     = "EcsServiceUpdate"
+    actions = ["ecs:UpdateService", "ecs:DescribeServices"]
+    resources = [
+      "arn:aws:ecs:${var.region}:${var.account_id}:cluster/tasks-${var.env}-cluster",
+      "arn:aws:ecs:${var.region}:${var.account_id}:service/tasks-${var.env}-cluster/tasks-${var.env}-webapi",
+    ]
   }
 
   # IAM PassRole — ecs:RegisterTaskDefinition 時に task execution role / task role を指定するために必要
@@ -1372,14 +1378,20 @@ data "aws_iam_policy_document" "platform_deploy" {
   # 規約 R1: 書込み action は完全列挙
   # 規約 R2: RegisterTaskDefinition / DescribeTaskDefinition は resource-level 非対応 → Resource: *
   statement {
-    sid = "EcsPlatformKeycloak"
-    actions = [
-      "ecs:DescribeTaskDefinition",
-      "ecs:RegisterTaskDefinition",
-      "ecs:UpdateService",
-      "ecs:DescribeServices",
-    ]
+    sid     = "EcsTaskDefinition"
+    actions = ["ecs:DescribeTaskDefinition", "ecs:RegisterTaskDefinition"]
+    # RegisterTaskDefinition / DescribeTaskDefinition は resource-level permission 非対応
     resources = ["*"]
+  }
+
+  # 規約 R2: UpdateService / DescribeServices は resource-level 対応 → クラスター/サービス ARN にスコープ
+  statement {
+    sid     = "EcsServiceUpdate"
+    actions = ["ecs:UpdateService", "ecs:DescribeServices"]
+    resources = [
+      "arn:aws:ecs:${var.region}:${var.account_id}:cluster/platform-${var.env}-cluster",
+      "arn:aws:ecs:${var.region}:${var.account_id}:service/platform-${var.env}-cluster/platform-${var.env}-keycloak",
+    ]
   }
 
   # IAM PassRole — ecs:RegisterTaskDefinition 時に keycloak 実行ロールを指定するために必要

--- a/infra/shared/modules/iam_oidc/outputs.tf
+++ b/infra/shared/modules/iam_oidc/outputs.tf
@@ -27,3 +27,13 @@ output "release_build_role_arn" {
   description = "ARN of the release-build IAM role (used by release-build.yml workflow)"
   value       = aws_iam_role.release_build.arn
 }
+
+output "tasks_deploy_role_arn" {
+  description = "ARN of the tasks-<env>-deploy IAM role (used by deploy.yml: verify / deploy-webapi / deploy-web)"
+  value       = aws_iam_role.tasks_deploy.arn
+}
+
+output "platform_deploy_role_arn" {
+  description = "ARN of the platform-<env>-deploy IAM role (used by deploy.yml: deploy-keycloak)"
+  value       = aws_iam_role.platform_deploy.arn
+}


### PR DESCRIPTION
## Summary

- **`.github/workflows/deploy.yml`** (新規): `workflow_dispatch` で `version` + `environment` を入力し、差分のあるコンポーネントのみデプロイする ADR-0031 フロー B workflow
- **`infra/shared/modules/iam_oidc/main.tf`**: `tasks-dev-deploy` / `platform-dev-deploy` IAM ロール追加 (OIDC trust: `environment:dev`)
- **`infra/shared/modules/iam_oidc/outputs.tf`**: 上記ロールの ARN output 追加

## deploy.yml ジョブ構成

```
verify (environment: <選択>)
├─→ plan-platform (if: env==dev, environment: platform-plan)
├─→ plan-tasks    (if: env==dev, environment: tasks-plan)
├─→ deploy-webapi   (if: deploy_webapi=true, digest 差分時のみ ECS 更新)
├─→ deploy-keycloak (if: deploy_keycloak=true, digest 差分時のみ ECS 更新)
└─→ deploy-web      (if: deploy_web=true, S3 sync + CF invalidation)

plan-platform + plan-tasks
└─→ apply-platform (environment: platform-apply, 承認ゲート)
    └─→ apply-tasks (environment: tasks-apply, ADR-0028 iii guard)
```

## IAM 最小権限ポイント

- `ecr:DescribeImages` のみ (BatchGetImage・GetAuthorizationToken は deploy では不要)
- `s3:DeleteObject` は `web/live/*` に限定 (バージョン prefix は削除不可)
- `iam:PassRole` は webapi/keycloak の実行ロール ARN にスコープ
- ECS register-task-definition で `.tags` を除去 → `ecs:TagResource` 不要
- `ecs:UpdateService` / `ecs:DescribeServices` はクラスター/サービス ARN にスコープ (R2 準拠・e4b832c)
- `cloudfront:CreateInvalidation` は account-scope ARN にスコープ (R2 準拠・fc7b275)

## ADR-0028 (iii) guard の適応

plan 後の割り込み検知: `current ≠ baseline AND current ≠ target-version-image` のときのみ fail。  
同 workflow run 内の `deploy-webapi` が先行した場合(current = target) は pass とする。

## セットアップ手順 (マージ後)

1. `terraform apply` (shared/dev) で IAM ロールを作成
2. GitHub → Settings → Environments → `dev` を作成し、`CLOUDFRONT_DISTRIBUTION_ID` 変数を設定
3. Actions → Deploy → Run workflow で動作確認

## Test plan

- [ ] `terraform fmt -check` / `terraform validate` / IAM wildcard gate が CI で pass すること
- [ ] dispatch(version=v0.1.0, environment=dev) で差分コンポーネントのみデプロイされること
- [ ] 未変更コンポーネント(digest 一致)は ECS rolling update が発生しないこと
- [ ] `CLOUDFRONT_DISTRIBUTION_ID` 未設定時に warning で継続すること

## 未対応レビュー

| # | 指摘 | 状態 |
|---|------|------|
| 1 | R2 違反: EcsTasksWebapi / EcsPlatformKeycloak statement に UpdateService / DescribeServices を `"*"` で混在 | ✅ 対応済 (e4b832c) |
| 2 | R2 違反: CloudFrontInvalidate statement の `resources = ["*"]` — account-scope ARN に変更が必要 | ✅ 対応済 (fc7b275) |

Closes #635

🤖 Generated with [Claude Code](https://claude.com/claude-code)
