### PR TITLE
fix(ci-cd): deploy.yml terraform plan に -lock=false を追加

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -159,7 +159,7 @@ jobs:
         shell: bash
         run: |
           set +e
-          terraform plan -detailed-exitcode -out=tfplan.binary -no-color 2>&1 | tee plan.txt
+          terraform plan -detailed-exitcode -lock=false -out=tfplan.binary -no-color 2>&1 | tee plan.txt
           echo "exit_code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
 
       - name: Check plan result
@@ -236,7 +236,7 @@ jobs:
         shell: bash
         run: |
           set +e
-          terraform plan -detailed-exitcode -out=tfplan.binary -no-color 2>&1 | tee plan.txt
+          terraform plan -detailed-exitcode -lock=false -out=tfplan.binary -no-color 2>&1 | tee plan.txt
           echo "exit_code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
 
       - name: Check plan result


### PR DESCRIPTION
## Summary

- `plan-platform` / `plan-tasks` の両 terraform plan ステップに `-lock=false` を追加

## 原因

`terraform plan` はデフォルトで state lock を取得しようとする（`-refresh=true` によるリフレッシュ書き戻しのため）。plan ロール (`tasks-dev-plan` / `platform-dev-plan`) は最小権限設計で `s3:GetObject` のみ持ち `s3:PutObject` を持たないため、lock ファイル書き込みが AccessDenied で失敗していた。

既存の `terraform-apply.yml` の plan ステップも `-lock=false` で揃えており、今回の deploy.yml はその踏襲が漏れていた。

## Test plan

- [ ] `Deploy` workflow を再実行して `plan-platform` / `plan-tasks` が成功すること

Closes #635

🤖 Generated with [Claude Code](https://claude.com/claude-code)