### PR TITLE
fix(ci): plan 時生成の Lambda ZIP をアーティファクト経由で apply に渡す (#635)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -274,6 +274,17 @@ jobs:
             baseline_image.txt
           retention-days: 7
 
+      # archive_file が plan 時に生成した決定性 ZIP をアーティファクトに保存する。
+      # apply runner(別ランナー)では archive_file が再実行されないケースがあるため、
+      # plan 時点と同一 ZIP を apply-platform / apply-tasks で使い回す。
+      # (zip コマンドではタイムスタンプが変わり Lambda が毎回更新されるため不可)
+      - name: Upload Lambda ZIP artifact (scheduler)
+        uses: actions/upload-artifact@v4
+        with:
+          name: lambda-zip-scheduler-${{ inputs.environment }}
+          path: infra/modules/scheduler/lambda/handler.zip
+          retention-days: 7
+
   # --------------------------------------------------------------------------
   # deploy-webapi — ECS task definition を新バージョンのイメージに更新する。
   # 目標 digest と現行 digest が一致する場合は no-op(rolling update なし)。
@@ -567,6 +578,16 @@ jobs:
           name: tfplan-platform-${{ inputs.environment }}
           path: infra/shared/environments/${{ inputs.environment }}
 
+      # apply runner は fresh なため archive_file が生成した handler.zip が存在しない。
+      # plan-tasks がアーティファクトに保存した決定性 ZIP を配置してから apply する。
+      # (同じ handler.js からは archive_file が常に同一バイナリを生成するため
+      #  source_code_hash は変わらず、コード未変更時に Lambda は更新されない)
+      - name: Download Lambda ZIP artifact (scheduler)
+        uses: actions/download-artifact@v4
+        with:
+          name: lambda-zip-scheduler-${{ inputs.environment }}
+          path: infra/modules/scheduler/lambda
+
       - name: terraform init (platform/dev)
         working-directory: infra/shared/environments/dev
         run: terraform init -no-color
@@ -647,6 +668,16 @@ jobs:
             exit 1
           fi
           echo "Image guard passed."
+
+      # apply runner は fresh なため archive_file が生成した handler.zip が存在しない。
+      # plan-tasks がアーティファクトに保存した決定性 ZIP を配置してから apply する。
+      # (同じ handler.js からは archive_file が常に同一バイナリを生成するため
+      #  source_code_hash は変わらず、コード未変更時に Lambda は更新されない)
+      - name: Download Lambda ZIP artifact (scheduler)
+        uses: actions/download-artifact@v4
+        with:
+          name: lambda-zip-scheduler-${{ inputs.environment }}
+          path: infra/modules/scheduler/lambda
 
       - name: terraform init (tasks/dev)
         working-directory: infra/environments/dev


### PR DESCRIPTION
## 問題

`apply-tasks` が `aws_lambda_function.scheduler` の apply 時に以下で失敗。

```
Error: reading ZIP file (../../modules/scheduler/lambda/handler.zip):
open ../../modules/scheduler/lambda/handler.zip: no such file or directory
```

apply runner は fresh なため、`plan-tasks` 実行ランナーで `data "archive_file"` が生成した `handler.zip` が存在しない。

## zip コマンドでの再生成が NG な理由

`zip` コマンドはタイムスタンプ等のメタデータを実行時刻で埋めるため、`handler.js` に変更がなくても ZIP のバイナリが毎回変わり、`source_code_hash` が変化して Lambda が毎回更新される。

## 解決策

`archive_file` はタイムスタンプをゼロ化した**決定性 ZIP** を生成する（hashicorp/archive provider の仕様）。`plan-tasks` 完了後に ZIP をアーティファクト保存し、`apply-platform` / `apply-tasks` 双方でダウンロードしてから `terraform apply` を実行。

- `handler.js` 未変更 → archive_file が同一ハッシュの ZIP を生成 → `source_code_hash` 変化なし → Lambda 更新なし ✓
- `handler.js` 変更あり → ハッシュ変化 → Lambda 更新 ✓

## 補足: deploy ロール破壊の問題 (別 Issue)

`apply-platform` のログに `tasks_deploy`・`platform_deploy` ロール削除が含まれている。これは `v0.1.0` タグが #642(deploy ロール追加)以前を指しているため、チェックアウトしたコードに定義がなく state 上の既存ロールを削除している。この PR マージ後に**新タグを切って**デプロイする必要がある。

## Test plan

- [ ] `workflow_dispatch` で deploy を実行し `apply-tasks` の `Terraform apply (tasks/dev)` が成功することを確認
- [ ] Lambda `tasks-dev-scheduler` が作成されることを確認
- [ ] 2回目のデプロイで Lambda が更新されないことを確認（コード変更なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)