### PR TITLE
fix(infra): CloudFront origin_path /web/live を追加し invalidation path を修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -523,7 +523,7 @@ jobs:
           if [ -n "${CLOUDFRONT_DISTRIBUTION_ID}" ]; then
             INVALIDATION_ID=$(aws cloudfront create-invalidation \
               --distribution-id "${CLOUDFRONT_DISTRIBUTION_ID}" \
-              --paths "/web/*" \
+              --paths "/*" \
               --query 'Invalidation.Id' \
               --output text)
             echo "✓ CloudFront invalidation created: ${INVALIDATION_ID}"

--- a/infra/modules/frontend/main.tf
+++ b/infra/modules/frontend/main.tf
@@ -120,6 +120,7 @@ resource "aws_cloudfront_distribution" "frontend" {
     domain_name              = aws_s3_bucket.frontend.bucket_regional_domain_name
     origin_id                = local.s3_origin_id
     origin_access_control_id = aws_cloudfront_origin_access_control.frontend.id
+    origin_path              = "/web/live"
   }
 
   default_cache_behavior {


### PR DESCRIPTION
## Summary

- `infra/modules/frontend/main.tf`: CloudFront origin に `origin_path = "/web/live"` を追加
- `.github/workflows/deploy.yml`: CloudFront invalidation path を `"/web/*"` → `"/*"` に修正

## 背景

`deploy.yml` は `s3://tasks-dev-frontend/web/live/` 以下にファイルを配置するが、CloudFront origin に `origin_path` が未設定だったため、CloudFront がバケットルート(`/index.html` 等)を参照して 403 を返していた。

`origin_path = "/web/live"` を設定することで:
- `GET /` → S3: `web/live/index.html`
- `GET /tasks.html` → S3: `web/live/tasks.html`
- SPA fallback (404/403 → `/tasks.html` → 200) も正常動作

また、`origin_path` 設定後の CloudFront キャッシュキーは `/index.html`・`/js/tasks.js` 等になるため、invalidation path を `"/web/*"` から `"/*"` へ修正した。

## 関連

- Closes #530 (CSP Report-Only 検証のブロッカー解消)
- `infra/modules/frontend/main.tf` の既存コメント通り: deploy は `web/live/` に sync

## Test plan

- [ ] deploy ワークフロー実行 → Terraform apply で `origin_path` が反映される
- [ ] `https://tasks-dev.dgz48.xyz` にアクセスして 200 が返ることを確認
- [ ] CSP Report-Only 違反検証を再開

🤖 Generated with [Claude Code](https://claude.com/claude-code)