### PR TITLE
fix(web): index.html / tasks.html に dom.js の読み込みを追加

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -41,6 +41,7 @@
 
     <script src="vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
     <script src="vendor/keycloak-js/keycloak.min.js"></script>
+    <script src="js/dom.js"></script>
     <script src="js/auth.js"></script>
     <script src="js/api.js"></script>
     <script src="js/meta.js"></script>

--- a/web/tasks.html
+++ b/web/tasks.html
@@ -150,6 +150,7 @@
 
 <script src="vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
 <script src="vendor/keycloak-js/keycloak.min.js"></script>
+<script src="js/dom.js"></script>
 <script src="js/auth.js"></script>
 <script src="js/api.js"></script>
 <script src="js/meta.js"></script>


### PR DESCRIPTION
## Summary

- `web/index.html` と `web/tasks.html` に `<script src="js/dom.js"></script>` を追加

## 原因

`mustQuery` 関数は `js/dom.js` で定義されているが、両 HTML にその読み込みタグがなかった。結果、ページロード時に `Uncaught ReferenceError: mustQuery is not defined` が発生した。

## Test plan

- [ ] マージ → v0.1.4 リリース → dev デプロイ
- [ ] `https://tasks-dev.dgz48.xyz` でコンソールエラーなしにページが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)