### PR TITLE
fix(web): Keycloak/API URL をホスト名から自動導出(localhost ハードコード解消)

### DIFF
--- a/web/js/api.js
+++ b/web/js/api.js
@@ -92,7 +92,10 @@
  */
 
 const Api = (() => {
-  const BASE_URL = 'http://localhost:8080';
+  const _envMatch = window.location.hostname.match(/^tasks(?:-(\w+))?\.dgz48\.xyz$/);
+  const BASE_URL = _envMatch
+    ? `https://api${_envMatch[1] ? `-${_envMatch[1]}` : ''}.tasks.dgz48.xyz`
+    : 'http://localhost:8080';
 
   /** @type {string|null} */
   let _tenantId = null;

--- a/web/js/auth.js
+++ b/web/js/auth.js
@@ -2,7 +2,8 @@
  * Keycloak OIDC 認証モジュール
  *
  * 設定:
- *   KEYCLOAK_URL  — Keycloak の base URL (デフォルト: http://localhost:18080)
+ *   KEYCLOAK_URL  — ホスト名から自動導出。tasks[-<env>].dgz48.xyz → auth[-<env>].dgz48.xyz
+ *                   それ以外(localhost 等)は http://localhost:18080 にフォールバック
  *   REALM         — realm 名 (デフォルト: tasks)
  *   CLIENT_ID     — public client ID (デフォルト: tasks-webapi)
  *
@@ -11,7 +12,10 @@
  */
 
 const Auth = (() => {
-  const KEYCLOAK_URL = 'http://localhost:18080';
+  const _envMatch = window.location.hostname.match(/^tasks(?:-(\w+))?\.dgz48\.xyz$/);
+  const KEYCLOAK_URL = _envMatch
+    ? `https://auth${_envMatch[1] ? `-${_envMatch[1]}` : ''}.dgz48.xyz`
+    : 'http://localhost:18080';
   const REALM = 'tasks';
   const CLIENT_ID = 'tasks-webapi';
 


### PR DESCRIPTION
## Summary

- `web/js/auth.js`: `KEYCLOAK_URL` をホスト名から自動導出
- `web/js/api.js`: `BASE_URL` をホスト名から自動導出

## 導出ルール

| ホスト名 | Keycloak URL | API URL |
|---|---|---|
| `tasks-dev.dgz48.xyz` | `https://auth-dev.dgz48.xyz` | `https://api-dev.tasks.dgz48.xyz` |
| `tasks-stg.dgz48.xyz` | `https://auth-stg.dgz48.xyz` | `https://api-stg.tasks.dgz48.xyz` |
| `tasks.dgz48.xyz` (prd) | `https://auth.dgz48.xyz` | `https://api.tasks.dgz48.xyz` |
| `localhost` 等 | `http://localhost:18080` | `http://localhost:8080` |

## Test plan

- [ ] マージ → Release & Deploy v0.1.5 → dev
- [ ] `https://tasks-dev.dgz48.xyz` で Keycloak ログインが `https://auth-dev.dgz48.xyz` へリダイレクトされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)