### PR TITLE
fix(web/infra): Keycloak URL と CSP connect-src に .tasks. サブドメインを追加

### DIFF
--- a/infra/modules/frontend/main.tf
+++ b/infra/modules/frontend/main.tf
@@ -8,7 +8,7 @@
 locals {
   s3_origin_id = "s3-tasks-${var.env}-frontend"
   # ADR-0022 §3.2 — CSP in Report-Only mode until violations are confirmed zero (§3.4)
-  csp_report_only = "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' data:; font-src 'self'; connect-src 'self' https://api-${var.env}.tasks.${var.base_domain} https://auth-${var.env}.${var.base_domain}; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'"
+  csp_report_only = "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' data:; font-src 'self'; connect-src 'self' https://api-${var.env}.tasks.${var.base_domain} https://auth-${var.env}.tasks.${var.base_domain}; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'"
 }
 
 resource "aws_s3_bucket" "frontend" {

--- a/web/js/auth.js
+++ b/web/js/auth.js
@@ -14,7 +14,7 @@
 const Auth = (() => {
   const _envMatch = window.location.hostname.match(/^tasks(?:-(\w+))?\.dgz48\.xyz$/);
   const KEYCLOAK_URL = _envMatch
-    ? `https://auth${_envMatch[1] ? `-${_envMatch[1]}` : ''}.dgz48.xyz`
+    ? `https://auth${_envMatch[1] ? `-${_envMatch[1]}` : ''}.tasks.dgz48.xyz`
     : 'http://localhost:18080';
   const REALM = 'tasks';
   const CLIENT_ID = 'tasks-webapi';


### PR DESCRIPTION
## Summary

- `web/js/auth.js`: Keycloak URL 導出を `auth-<env>.dgz48.xyz` → `auth-<env>.tasks.dgz48.xyz` に修正
- `infra/modules/frontend/main.tf`: CSP `connect-src` の auth origin を同様に修正

## 原因

Route53 レコードは `auth-${env}.tasks.dgz48.xyz` で定義されているが、`auth.js` の URL 導出と CSP の `connect-src` が `.tasks.` を含まない `auth-${env}.dgz48.xyz` になっていた。結果、ブラウザが `DNS_PROBE_FINISHED_NXDOMAIN` エラー。

## Test plan

- [ ] マージ → Release & Deploy v0.1.6 → dev
- [ ] `https://tasks-dev.dgz48.xyz` で `https://auth-dev.tasks.dgz48.xyz` へリダイレクトされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)