### PR TITLE
fix(infra/web): auth-dev.dgz48.xyz の Route53 レコード追加と URL/CSP を修正

### DIFF
--- a/infra/modules/frontend/main.tf
+++ b/infra/modules/frontend/main.tf
@@ -8,7 +8,7 @@
 locals {
   s3_origin_id = "s3-tasks-${var.env}-frontend"
   # ADR-0022 §3.2 — CSP in Report-Only mode until violations are confirmed zero (§3.4)
-  csp_report_only = "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' data:; font-src 'self'; connect-src 'self' https://api-${var.env}.tasks.${var.base_domain} https://auth-${var.env}.tasks.${var.base_domain}; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'"
+  csp_report_only = "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' data:; font-src 'self'; connect-src 'self' https://api-${var.env}.tasks.${var.base_domain} https://auth-${var.env}.${var.base_domain}; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'"
 }
 
 resource "aws_s3_bucket" "frontend" {

--- a/infra/shared/environments/dev/main.tf
+++ b/infra/shared/environments/dev/main.tf
@@ -186,6 +186,28 @@ resource "aws_ssm_parameter" "keycloak_db_sg_id" {
 }
 
 # ---------------------------------------------------------------------------
+# Route53 — auth-dev.dgz48.xyz → ALB (Keycloak public hostname)
+# Keycloak module の KC_HOSTNAME / ALB リスナールールは auth-dev.dgz48.xyz を使用する。
+# ---------------------------------------------------------------------------
+
+data "aws_route53_zone" "public" {
+  name         = "dgz48.xyz."
+  private_zone = false
+}
+
+resource "aws_route53_record" "keycloak" {
+  zone_id = data.aws_route53_zone.public.zone_id
+  name    = "auth-dev.dgz48.xyz"
+  type    = "A"
+
+  alias {
+    name                   = module.alb.dns_name
+    zone_id                = module.alb.zone_id
+    evaluate_target_health = true
+  }
+}
+
+# ---------------------------------------------------------------------------
 # Platform ECS Cluster — Keycloak ECS Service が乗るクラスタ (ADR-0004 / #322)
 # ---------------------------------------------------------------------------
 

--- a/web/js/auth.js
+++ b/web/js/auth.js
@@ -14,7 +14,7 @@
 const Auth = (() => {
   const _envMatch = window.location.hostname.match(/^tasks(?:-(\w+))?\.dgz48\.xyz$/);
   const KEYCLOAK_URL = _envMatch
-    ? `https://auth${_envMatch[1] ? `-${_envMatch[1]}` : ''}.tasks.dgz48.xyz`
+    ? `https://auth${_envMatch[1] ? `-${_envMatch[1]}` : ''}.dgz48.xyz`
     : 'http://localhost:18080';
   const REALM = 'tasks';
   const CLIENT_ID = 'tasks-webapi';


### PR DESCRIPTION
## Summary

- `infra/shared/environments/dev/main.tf`: `auth-dev.dgz48.xyz` → ALB の Route53 A エイリアスレコードを追加
- `infra/modules/frontend/main.tf`: CSP `connect-src` を `auth-${env}.dgz48.xyz` に修正（`.tasks.` を除去）
- `web/js/auth.js`: Keycloak URL 導出を `auth-${env}.dgz48.xyz` に修正（`.tasks.` を除去）

## 原因

Keycloak の `KC_HOSTNAME` と ALB リスナールール（platform stack）は `auth-dev.dgz48.xyz` で設定されているが、Route53 に DNS レコードが存在しなかった。

| | 修正前 | 修正後 |
|---|---|---|
| `auth.js` 導出 URL | `auth-dev.tasks.dgz48.xyz` | `auth-dev.dgz48.xyz` |
| CSP connect-src | `auth-dev.tasks.dgz48.xyz` | `auth-dev.dgz48.xyz` |
| Route53 レコード | なし | `auth-dev.dgz48.xyz` → ALB |

## Test plan

- [ ] マージ → Release & Deploy v0.1.7 → dev（platform apply で DNS レコード作成）
- [ ] `https://tasks-dev.dgz48.xyz` で `https://auth-dev.dgz48.xyz` へリダイレクトされ Keycloak ログイン画面が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)