### PR TITLE
fix(iam): tasks-dev-apply に EICE 作成用 ENI 操作権限と SLR 作成権限を追加

### DIFF
--- a/infra/shared/modules/iam_oidc/main.tf
+++ b/infra/shared/modules/iam_oidc/main.tf
@@ -837,6 +837,9 @@ data "aws_iam_policy_document" "tasks_apply" {
       "ec2:UpdateSecurityGroupRuleDescriptionsEgress",
       "ec2:CreateInstanceConnectEndpoint",
       "ec2:DeleteInstanceConnectEndpoint",
+      "ec2:CreateNetworkInterface",
+      "ec2:DeleteNetworkInterface",
+      "ec2:ModifyNetworkInterfaceAttribute",
       "ec2:CreateTags",
       "ec2:DeleteTags",
     ]
@@ -889,6 +892,11 @@ data "aws_iam_policy_document" "tasks_apply" {
     sid       = "RdsSlr"
     actions   = ["iam:CreateServiceLinkedRole"]
     resources = ["arn:aws:iam::${var.account_id}:role/aws-service-role/rds.amazonaws.com/*"]
+  }
+  statement {
+    sid       = "EiceSlr"
+    actions   = ["iam:CreateServiceLinkedRole"]
+    resources = ["arn:aws:iam::${var.account_id}:role/aws-service-role/ec2-instance-connect.amazonaws.com/*"]
   }
 
   # ECR write (ecr: repository / lifecycle policy)


### PR DESCRIPTION
## Summary

- `tasks-dev-apply` ロールの `Ec2Write` ステートメントに `ec2:CreateNetworkInterface` / `ec2:DeleteNetworkInterface` / `ec2:ModifyNetworkInterfaceAttribute` を追加
- `EiceSlr` ステートメントを新設: `iam:CreateServiceLinkedRole` を `ec2-instance-connect.amazonaws.com/*` ARN にスコープして付与

## 背景

PR #652 で追加した `aws_ec2_instance_connect_endpoint` の apply が  
`InstanceConnectEndpointAccessDenied` で失敗し続けていた。  
`aws iam simulate-principal-policy` の結果、以下が `implicitDeny`:

| アクション | 用途 |
|---|---|
| `ec2:CreateNetworkInterface` | EICE 作成時に内部 ENI を作成 |
| `ec2:DeleteNetworkInterface` | EICE 削除時に内部 ENI を削除 |
| `ec2:ModifyNetworkInterfaceAttribute` | ENI 属性更新 |
| `iam:CreateServiceLinkedRole` (ec2-instance-connect.amazonaws.com) | `AWSServiceRoleForEC2InstanceConnect` SLR がアカウント未作成のため初回に必要 |

## Test plan

- [ ] PR #652 のレビュー指摘パターン (R3: IAM と実装を同 PR で) を踏襲し本 PR でセット修正
- [ ] マージ後 tag → Release Build → Deploy workflow で apply が成功することを確認
- [ ] EICE 作成後 `open-tunnel` で MySQL 接続できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)