### PR TITLE
fix(webapi): native image 起動エラー修正 + ADR-0028 deploy ordering 修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -254,8 +254,8 @@ jobs:
           fi
 
       # ADR-0028 (iii): plan 実行時点の ECS image を記録し apply guard で比較する。
-      # deploy-webapi が同 workflow run で ECS を更新する場合は apply-tasks が
-      # 「baseline or target version image」の両方を許容する(下記 guard 参照)。
+      # deploy-webapi は apply-tasks の後に実行されるため、apply 時点の CURRENT は
+      # 常に BASELINE と一致する(target version への更新は apply-tasks 完了後に deploy-webapi が行う)。
       - name: Capture ECS baseline image (ADR-0028 iii)
         run: |
           aws ecs describe-task-definition \
@@ -291,8 +291,14 @@ jobs:
   # --------------------------------------------------------------------------
   deploy-webapi:
     name: Deploy webapi (${{ inputs.version }})
-    needs: verify
-    if: needs.verify.outputs.deploy_webapi == 'true'
+    # ADR-0028: Terraform apply (apply-tasks) must complete first so it creates a lower revision
+    # than deploy-webapi. This ensures max(revision) always selects the CI-deployed image, not busybox.
+    needs: [verify, apply-tasks]
+    if: |
+      always() &&
+      needs.verify.result == 'success' &&
+      needs.verify.outputs.deploy_webapi == 'true' &&
+      (needs.apply-tasks.result == 'success' || needs.apply-tasks.result == 'skipped')
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     permissions:

--- a/infra/environments/dev/ecs_service.tf
+++ b/infra/environments/dev/ecs_service.tf
@@ -50,12 +50,24 @@ resource "aws_iam_role_policy" "webapi_exec_ssm" {
 
 # ---------------------------------------------------------------------------
 # ADR-0028 巻き戻し防止 (i) — 現行稼働イメージ注入
-# CI deploy pipeline (S2Infra-4/5) 完了後に実装する。
-# それまでは var.bootstrap_image を直接使用し、(ii) max(revision) のみで巻き戻しを防ぐ。
+# apply 前の ECS タスク定義から稼働中イメージを読み取り、
+# Terraform が busybox で上書きするのを防ぐ。
+# 前提: タスク定義ファミリーが存在すること（初回 apply 後は常に存在する）。
 # ---------------------------------------------------------------------------
 
+data "aws_ecs_task_definition" "webapi_pre_apply" {
+  task_definition = "tasks-${var.env}-webapi"
+}
+
 locals {
-  webapi_image = var.bootstrap_image
+  _pre_apply_containers = jsondecode(data.aws_ecs_task_definition.webapi_pre_apply.container_definitions)
+  _pre_apply_image = try(
+    [for c in local._pre_apply_containers : c.image if c.name == "webapi"][0],
+    var.bootstrap_image
+  )
+  # ECR の tasks-webapi リポジトリのイメージが稼働中ならそれを保持する。
+  # busybox 等のブートストラップ用プレースホルダーは保持しない。
+  webapi_image = can(regex("tasks-webapi:", local._pre_apply_image)) ? local._pre_apply_image : var.bootstrap_image
 }
 
 # ---------------------------------------------------------------------------

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/shared/infra/NativeImageHintsConfig.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/shared/infra/NativeImageHintsConfig.java
@@ -1,0 +1,32 @@
+package xyz.dgz48.tasks.webapi.shared.infra;
+
+import org.jspecify.annotations.Nullable;
+import org.springframework.aot.hint.MemberCategory;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.RuntimeHintsRegistrar;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.ImportRuntimeHints;
+
+@Configuration(proxyBeanMethods = false)
+@ImportRuntimeHints(NativeImageHintsConfig.Registrar.class)
+class NativeImageHintsConfig {
+
+  static class Registrar implements RuntimeHintsRegistrar {
+
+    @Override
+    public void registerHints(RuntimeHints hints, @Nullable ClassLoader classLoader) {
+      // JBoss Logging annotation-generated impl; not reached by Spring Boot AOT hints
+      try {
+        hints
+            .reflection()
+            .registerType(
+                Class.forName("org.hibernate.validator.internal.util.logging.Log_$logger"),
+                MemberCategory.values());
+      } catch (ClassNotFoundException ignored) {
+      }
+      // Flyway classpath scanner cannot enumerate directories under the native-image resource:
+      // protocol
+      hints.resources().registerPattern("db/migration/*.sql");
+    }
+  }
+}

--- a/webapi/src/main/resources/application.yml
+++ b/webapi/src/main/resources/application.yml
@@ -23,9 +23,7 @@ spring:
     open-in-view: false
     hibernate:
       ddl-auto: validate
-    properties:
-      hibernate:
-        dialect: org.hibernate.dialect.MySQLDialect
+
   flyway:
     enabled: true
     locations: classpath:db/migration


### PR DESCRIPTION
## Summary

- **`NativeImageHintsConfig`** を追加: GraalVM native image で Hibernate Validator が起動できなかった問題（`Log_$logger` リフレクション未登録）と Flyway マイグレーション SQL がスキャンできなかった問題（`resource:` プロトコル非対応）を修正
- **`application.yml`**: 不要な `hibernate.dialect` 設定を削除（`HHH90000025` 警告の解消）
- **`ecs_service.tf`**: ADR-0028 (i) 実装 — `data "aws_ecs_task_definition" "webapi_pre_apply"` で apply 前の稼働 ECR イメージを読み取り、Terraform が busybox で上書きしないよう保持する
- **`deploy.yml`**: `deploy-webapi` を `apply-tasks` の後に実行するよう変更。Terraform が低リビジョン (busybox) を先に作成し、その後 deploy-webapi が高リビジョン (ECR image) を登録することで `max(revision)` パターンが正しく機能する

## 背景

v0.1.15 デプロイ後、webapi が起動できずにいた。根本原因は 2 つ:

1. **busybox 問題**: `deploy-webapi` と `apply-tasks` が ADR-0028 の設計とは逆順で実行されていた。deploy-webapi (ECR image) が先に高リビジョンを作成 → apply-tasks (Terraform) が後から busybox でさらに高いリビジョンを作成 → `max(revision)` で busybox が選ばれる
2. **Hibernate Validator 起動エラー**: GraalVM native image で `Log_$logger` がリフレクション未登録 + Flyway が `resource:` プロトコルを解釈できず SQL スキャン不可

## Test plan

- [ ] CI (Verify artifacts, compile, spotless) が通ること
- [ ] 所定の手順でデプロイ (tag → Release Build → Deploy)
- [ ] ECS ログで `Started TasksWebapiApplication` が確認できること
- [ ] Flyway マイグレーションが実行されること (`Migrating schema...` ログ)
- [ ] `/actuator/health` が 200 を返すこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)