### PR TITLE
fix(webapi): Jackson 3.x で削除された write-dates-as-timestamps 設定を除去

### DIFF
--- a/webapi/src/main/resources/application.yml
+++ b/webapi/src/main/resources/application.yml
@@ -17,8 +17,6 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
   jackson:
     time-zone: Asia/Tokyo
-    serialization:
-      write-dates-as-timestamps: false
   jpa:
     open-in-view: false
     hibernate:


### PR DESCRIPTION
## Summary

- `application.yml` の `spring.jackson.serialization.write-dates-as-timestamps: false` を削除
- Jackson 3.x (`tools.jackson.databind.SerializationFeature`) では `WRITE_DATES_AS_TIMESTAMPS` が削除されており、Spring Boot 起動時に `No enum constant...write-dates-as-timestamps` で Fatal エラーになっていた
- Jackson 3.x では `JavaTimeModule` がデフォルトで ISO-8601 形式で日付をシリアライズするため、本設定は不要

## Test plan

- [ ] CI が通ること
- [ ] 所定の手順でデプロイ
- [ ] `Started TasksWebapiApplication` が確認できること
- [ ] `/actuator/health` が 200 を返すこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)