### PR TITLE
fix(webapi): Hibernate Validator Messages_$bundle をネイティブイメージに追加

### DIFF
--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/shared/infra/NativeImageHintsConfig.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/shared/infra/NativeImageHintsConfig.java
@@ -15,14 +15,16 @@ class NativeImageHintsConfig {
 
     @Override
     public void registerHints(RuntimeHints hints, @Nullable ClassLoader classLoader) {
-      // JBoss Logging annotation-generated impl; not reached by Spring Boot AOT hints
-      try {
-        hints
-            .reflection()
-            .registerType(
-                Class.forName("org.hibernate.validator.internal.util.logging.Log_$logger"),
-                MemberCategory.values());
-      } catch (ClassNotFoundException ignored) {
+      // JBoss Logging annotation-generated impls; not reached by Spring Boot AOT hints
+      for (String cls :
+          new String[] {
+            "org.hibernate.validator.internal.util.logging.Log_$logger",
+            "org.hibernate.validator.internal.util.logging.Messages_$bundle",
+          }) {
+        try {
+          hints.reflection().registerType(Class.forName(cls), MemberCategory.values());
+        } catch (ClassNotFoundException ignored) {
+        }
       }
       // Flyway classpath scanner cannot enumerate directories under the native-image resource:
       // protocol


### PR DESCRIPTION
## Summary

- `NativeImageHintsConfig` に `Messages_$bundle` のリフレクション登録を追加
- `Log_$logger`（前 PR で修正済み）に加え、`Messages_$bundle` も JBoss Logging アノテーション生成クラスであり GraalVM native image でリフレクション未登録だった
- これにより `Invalid bundle interface org.hibernate.validator.internal.util.logging.Messages (implementation not found)` → JPA EntityManagerFactory 初期化失敗が修正される

hibernate-validator 9.1.0.Final に含まれる JBoss Logging 生成クラスはこの 2 つのみ。

## Test plan

- [ ] CI が通ること
- [ ] 所定の手順でデプロイ
- [ ] `Started TasksWebapiApplication` が確認できること
- [ ] `/actuator/health` が 200 を返すこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)