### PR TITLE
feat(db/keycloak): dev シードデータ追加 — テストユーザー・テナント初期登録

### DIFF
--- a/keycloak/realm-export/tasks-realm.json
+++ b/keycloak/realm-export/tasks-realm.json
@@ -84,6 +84,7 @@
   ],
   "users": [
     {
+      "id": "69649e2f-63a3-4b75-ae2e-2916ee22e1b5",
       "username": "admin@example.com",
       "email": "admin@example.com",
       "firstName": "Admin",
@@ -102,6 +103,7 @@
       ]
     },
     {
+      "id": "0090cd3a-7ac2-4409-b086-23a285c196ea",
       "username": "tenant1-admin@example.com",
       "email": "tenant1-admin@example.com",
       "firstName": "Tenant1",
@@ -120,6 +122,7 @@
       ]
     },
     {
+      "id": "c490c707-819c-4ac7-860f-6e05426a6708",
       "username": "tenant1-member1@example.com",
       "email": "tenant1-member1@example.com",
       "firstName": "Tenant1",
@@ -138,6 +141,7 @@
       ]
     },
     {
+      "id": "11873fb0-285d-4188-bd3b-cf223c257ecf",
       "username": "tenant1-member2@example.com",
       "email": "tenant1-member2@example.com",
       "firstName": "Tenant1",

--- a/webapi/src/main/resources/db/migration/V1.0.0_02__seed_dev_data.sql
+++ b/webapi/src/main/resources/db/migration/V1.0.0_02__seed_dev_data.sql
@@ -1,0 +1,20 @@
+-- Dev seed data: test tenant and users corresponding to tasks-realm.json accounts.
+-- oidc_sub values match the fixed UUIDs declared in keycloak/realm-export/tasks-realm.json.
+-- Remove before first production deployment.
+
+INSERT INTO tenants (id, code, name, plan, status, created_at, updated_at) VALUES
+  (1, 'tenant1', 'テナント1', 'STANDARD', 'ACTIVE', NOW(), NOW());
+
+INSERT INTO users (id, oidc_sub, email, full_name, full_name_kana, status, version) VALUES
+  (1, '69649e2f-63a3-4b75-ae2e-2916ee22e1b5', 'admin@example.com',          'Admin User',     'アドミン ユーザー',        'ACTIVE', 0),
+  (2, '0090cd3a-7ac2-4409-b086-23a285c196ea', 'tenant1-admin@example.com',   'Tenant1 Admin',  'テナントイチ アドミン',    'ACTIVE', 0),
+  (3, 'c490c707-819c-4ac7-860f-6e05426a6708', 'tenant1-member1@example.com', 'Tenant1 Member1','テナントイチ メンバーイチ', 'ACTIVE', 0),
+  (4, '11873fb0-285d-4188-bd3b-cf223c257ecf', 'tenant1-member2@example.com', 'Tenant1 Member2','テナントイチ メンバーニ',   'ACTIVE', 0);
+
+INSERT INTO user_tenants (user_id, tenant_id, role, status, joined_at) VALUES
+  (2, 1, 'TENANT_ADMIN', 'ACTIVE', NOW()),
+  (3, 1, 'MEMBER',       'ACTIVE', NOW()),
+  (4, 1, 'MEMBER',       'ACTIVE', NOW());
+
+INSERT INTO app_admin_users (oidc_sub, created_at) VALUES
+  ('69649e2f-63a3-4b75-ae2e-2916ee22e1b5', NOW());


### PR DESCRIPTION
## Summary

- **Flyway V1.0.0_02**: `users` / `tenants` / `user_tenants` / `app_admin_users` にテストアカウント 4 名 + テナント1 を INSERT
  - `tenant1-admin@example.com` → TENANT_ADMIN
  - `tenant1-member1@example.com` / `tenant1-member2@example.com` → MEMBER
  - `admin@example.com` → app_admin_users (SaaS Admin)
- **keycloak/realm-export/tasks-realm.json**: 各ユーザーに `id` (UUID) を明示し、Keycloak 再インポート時に `oidc_sub` が変わらないよう固定化

## 背景

webapi v0.1.18 起動成功後、`/api/auth/me` が 401 を返す問題を調査した結果、「JWT 自体は有効だが `users` テーブルに対応レコードが存在しない」ことが原因と判明（`USER_NOT_REGISTERED` ログ）。Flyway マイグレーションには CREATE TABLE のみで INSERT がなかったため、本 PR でシードデータを追加する。

## Test plan

- [ ] PR マージ後、`v0.1.x` タグを打って Release Build → Deploy を実行
- [ ] webapi 起動ログで `Successfully applied 1 migration (V1.0.0_02)` を確認
- [ ] `tenant1-admin@example.com` / `password` でログイン → `/api/auth/me` が 200 を返すことを確認
- [ ] `https://tasks-dev.dgz48.xyz` でテナント選択 → タスク一覧画面に遷移することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)