### PR TITLE
feat(auth): GET /api/auth/me 実装 — ログインユーザー情報 + 所属テナント一覧(MeResponse)

### DIFF
--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/security/adapter/web/MeController.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/security/adapter/web/MeController.java
@@ -1,0 +1,46 @@
+package xyz.dgz48.tasks.webapi.security.adapter.web;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.Nullable;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+import xyz.dgz48.tasks.webapi.security.adapter.web.dto.MeResponse;
+import xyz.dgz48.tasks.webapi.security.adapter.web.dto.TenantSummaryDto;
+import xyz.dgz48.tasks.webapi.security.adapter.web.dto.UserProfileDto;
+import xyz.dgz48.tasks.webapi.security.domain.TasksPrincipal;
+import xyz.dgz48.tasks.webapi.security.usecase.GetMeUseCase;
+
+/**
+ * GET /api/auth/me — ログインユーザー情報・所属テナント一覧。
+ *
+ * <p>TenantContextFilter の免除パス({@code /api/auth/**})に該当するため X-Tenant-Id ヘッダは不要。 activeTenantId は
+ * X-Tenant-Id 指定時にそれを返し、未指定時は null とする(自動解決 ADR-0016 は /me では行わない)。
+ */
+@RestController
+@RequiredArgsConstructor
+public class MeController {
+
+  private final GetMeUseCase getMeUseCase;
+
+  @GetMapping("/api/auth/me")
+  public MeResponse me(
+      @AuthenticationPrincipal TasksPrincipal principal,
+      @RequestHeader(name = "X-Tenant-Id", required = false) @Nullable Long activeTenantId) {
+
+    List<TenantSummaryDto> tenants =
+        getMeUseCase.findTenants(principal.getId()).stream().map(TenantSummaryDto::from).toList();
+
+    UserProfileDto userProfile =
+        new UserProfileDto(
+            principal.getId(),
+            principal.getEmail(),
+            principal.getFullName(),
+            principal.getFullNameKana(),
+            principal.getDepartmentName());
+
+    return new MeResponse(userProfile, tenants, activeTenantId);
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/security/adapter/web/dto/MeResponse.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/security/adapter/web/dto/MeResponse.java
@@ -1,0 +1,7 @@
+package xyz.dgz48.tasks.webapi.security.adapter.web.dto;
+
+import java.util.List;
+import org.jspecify.annotations.Nullable;
+
+public record MeResponse(
+    UserProfileDto user, List<TenantSummaryDto> tenants, @Nullable Long activeTenantId) {}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/security/adapter/web/dto/TenantSummaryDto.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/security/adapter/web/dto/TenantSummaryDto.java
@@ -1,0 +1,11 @@
+package xyz.dgz48.tasks.webapi.security.adapter.web.dto;
+
+import xyz.dgz48.tasks.webapi.tenant.domain.TenantRole;
+import xyz.dgz48.tasks.webapi.tenant.domain.TenantSummaryInfo;
+
+public record TenantSummaryDto(Long id, String code, String name, TenantRole role) {
+
+  public static TenantSummaryDto from(TenantSummaryInfo src) {
+    return new TenantSummaryDto(src.id(), src.code(), src.name(), src.role());
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/security/adapter/web/dto/UserProfileDto.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/security/adapter/web/dto/UserProfileDto.java
@@ -1,0 +1,6 @@
+package xyz.dgz48.tasks.webapi.security.adapter.web.dto;
+
+import org.jspecify.annotations.Nullable;
+
+public record UserProfileDto(
+    Long id, String email, String fullName, String fullNameKana, @Nullable String departmentName) {}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/security/usecase/GetMeUseCase.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/security/usecase/GetMeUseCase.java
@@ -1,0 +1,21 @@
+package xyz.dgz48.tasks.webapi.security.usecase;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import xyz.dgz48.tasks.webapi.tenant.domain.TenantSummaryInfo;
+import xyz.dgz48.tasks.webapi.tenant.usecase.TenantMembershipPort;
+
+/** ログインユーザーの所属テナント一覧を返すユースケース。 */
+@Service
+@RequiredArgsConstructor
+public class GetMeUseCase {
+
+  private final TenantMembershipPort tenantMembershipPort;
+
+  @Transactional(readOnly = true)
+  public List<TenantSummaryInfo> findTenants(Long userId) {
+    return tenantMembershipPort.findActiveMembershipDetails(userId);
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/adapter/persistence/UserTenantJpaRepository.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/adapter/persistence/UserTenantJpaRepository.java
@@ -3,6 +3,9 @@ package xyz.dgz48.tasks.webapi.tenant.adapter.persistence;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import xyz.dgz48.tasks.webapi.tenant.domain.TenantSummaryInfo;
 import xyz.dgz48.tasks.webapi.tenant.domain.UserTenantStatus;
 
 interface UserTenantJpaRepository extends JpaRepository<UserTenantJpaEntity, UserTenantId> {
@@ -14,4 +17,16 @@ interface UserTenantJpaRepository extends JpaRepository<UserTenantJpaEntity, Use
 
   List<UserTenantJpaEntity> findByIdUserIdAndStatusOrderByJoinedAtAsc(
       Long userId, UserTenantStatus status);
+
+  @Query(
+      """
+      SELECT new xyz.dgz48.tasks.webapi.tenant.domain.TenantSummaryInfo(
+          ut.id.tenantId, t.code, t.name, ut.role)
+      FROM UserTenantJpaEntity ut
+      JOIN TenantJpaEntity t ON t.id = ut.id.tenantId
+      WHERE ut.id.userId = :userId AND ut.status = :status
+      ORDER BY ut.joinedAt ASC
+      """)
+  List<TenantSummaryInfo> findActiveMembershipsWithTenantDetail(
+      @Param("userId") Long userId, @Param("status") UserTenantStatus status);
 }

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/adapter/persistence/UserTenantMembershipAdapter.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/adapter/persistence/UserTenantMembershipAdapter.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 import xyz.dgz48.tasks.webapi.tenant.domain.TenantMembership;
 import xyz.dgz48.tasks.webapi.tenant.domain.TenantRole;
+import xyz.dgz48.tasks.webapi.tenant.domain.TenantSummaryInfo;
 import xyz.dgz48.tasks.webapi.tenant.domain.UserTenantStatus;
 import xyz.dgz48.tasks.webapi.tenant.usecase.TenantMembershipPort;
 
@@ -32,5 +33,10 @@ class UserTenantMembershipAdapter implements TenantMembershipPort {
         .stream()
         .map(e -> new TenantMembership(e.getId().getTenantId(), e.getRole()))
         .toList();
+  }
+
+  @Override
+  public List<TenantSummaryInfo> findActiveMembershipDetails(Long userId) {
+    return repository.findActiveMembershipsWithTenantDetail(userId, UserTenantStatus.ACTIVE);
   }
 }

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/domain/TenantSummaryInfo.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/domain/TenantSummaryInfo.java
@@ -1,0 +1,4 @@
+package xyz.dgz48.tasks.webapi.tenant.domain;
+
+/** ユーザーの所属テナント要約情報。/api/auth/me 等での表示用。 */
+public record TenantSummaryInfo(Long id, String code, String name, TenantRole role) {}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/usecase/TenantMembershipPort.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/usecase/TenantMembershipPort.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Optional;
 import xyz.dgz48.tasks.webapi.tenant.domain.TenantMembership;
 import xyz.dgz48.tasks.webapi.tenant.domain.TenantRole;
+import xyz.dgz48.tasks.webapi.tenant.domain.TenantSummaryInfo;
 
 /** テナントメンバーシップ検証ポート。 */
 public interface TenantMembershipPort {
@@ -13,4 +14,7 @@ public interface TenantMembershipPort {
 
   /** 指定ユーザーの全 ACTIVE メンバーシップを joined_at ASC 順で返す。 */
   List<TenantMembership> findActiveMemberships(Long userId);
+
+  /** 指定ユーザーの全 ACTIVE メンバーシップをテナント詳細(code/name)付きで joined_at ASC 順で返す。 */
+  List<TenantSummaryInfo> findActiveMembershipDetails(Long userId);
 }

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/MeControllerWebMvcTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/MeControllerWebMvcTest.java
@@ -1,0 +1,94 @@
+package xyz.dgz48.tasks.webapi.security.adapter.web;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import xyz.dgz48.tasks.webapi.security.adapter.persistence.AppAdminUserRepository;
+import xyz.dgz48.tasks.webapi.security.usecase.GetMeUseCase;
+import xyz.dgz48.tasks.webapi.tenant.domain.TenantRole;
+import xyz.dgz48.tasks.webapi.tenant.domain.TenantSummaryInfo;
+import xyz.dgz48.tasks.webapi.tenant.usecase.TenantMembershipPort;
+import xyz.dgz48.tasks.webapi.tenant.usecase.UserTenantsResolverService;
+import xyz.dgz48.tasks.webapi.user.adapter.persistence.UserRepository;
+
+@WebMvcTest(MeController.class)
+@Import({
+  SecurityConfig.class,
+  TasksJwtAuthenticationConverter.class,
+  TasksAuthenticationEntryPoint.class,
+  TasksAccessDeniedHandler.class,
+})
+class MeControllerWebMvcTest {
+
+  @MockitoBean JwtDecoder jwtDecoder;
+  @MockitoBean UserRepository userRepository;
+  @MockitoBean AppAdminUserRepository appAdminUserRepository;
+  @MockitoBean TenantMembershipPort tenantMembershipPort;
+  @MockitoBean UserTenantsResolverService userTenantsResolverService;
+  @MockitoBean GetMeUseCase getMeUseCase;
+
+  @Autowired MockMvc mockMvc;
+
+  @Test
+  void unauthenticatedRequest_returnsUnauthorized() throws Exception {
+    mockMvc.perform(get("/api/auth/me")).andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  @WithMockJwt
+  void authenticatedRequest_returnsOkWithUserAndTenants() throws Exception {
+    when(getMeUseCase.findTenants(1L))
+        .thenReturn(List.of(new TenantSummaryInfo(100L, "acme", "Acme Corp", TenantRole.MEMBER)));
+
+    mockMvc
+        .perform(get("/api/auth/me"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.user.id").value(1))
+        .andExpect(jsonPath("$.user.email").value("test@example.com"))
+        .andExpect(jsonPath("$.user.fullName").value("テスト太郎"))
+        .andExpect(jsonPath("$.user.fullNameKana").value("テストタロウ"))
+        .andExpect(jsonPath("$.user.departmentName").isEmpty())
+        .andExpect(jsonPath("$.tenants").isArray())
+        .andExpect(jsonPath("$.tenants[0].id").value(100))
+        .andExpect(jsonPath("$.tenants[0].code").value("acme"))
+        .andExpect(jsonPath("$.tenants[0].name").value("Acme Corp"))
+        .andExpect(jsonPath("$.tenants[0].role").value("MEMBER"))
+        .andExpect(jsonPath("$.activeTenantId").isEmpty());
+  }
+
+  @Test
+  @WithMockJwt
+  void withXTenantIdHeader_returnsActiveTenantId() throws Exception {
+    // TenantContextFilter validates X-Tenant-Id membership before the controller runs
+    when(tenantMembershipPort.findActiveRole(1L, 42L)).thenReturn(Optional.of(TenantRole.MEMBER));
+    when(getMeUseCase.findTenants(1L)).thenReturn(List.of());
+
+    mockMvc
+        .perform(get("/api/auth/me").header("X-Tenant-Id", "42"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.activeTenantId").value(42));
+  }
+
+  @Test
+  @WithMockJwt
+  void withoutTenants_returnsEmptyArray() throws Exception {
+    when(getMeUseCase.findTenants(1L)).thenReturn(List.of());
+
+    mockMvc
+        .perform(get("/api/auth/me"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.tenants").isEmpty())
+        .andExpect(jsonPath("$.activeTenantId").isEmpty());
+  }
+}

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/MeIT.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/MeIT.java
@@ -1,0 +1,169 @@
+package xyz.dgz48.tasks.webapi.security.adapter.web;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import jakarta.persistence.EntityManager;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.support.TransactionTemplate;
+import xyz.dgz48.tasks.webapi.FixedClockConfiguration;
+import xyz.dgz48.tasks.webapi.MockJwtDecoderConfiguration;
+import xyz.dgz48.tasks.webapi.TestcontainersConfiguration;
+import xyz.dgz48.tasks.webapi.security.domain.TasksPrincipal;
+import xyz.dgz48.tasks.webapi.tenant.adapter.persistence.TenantJpaEntity;
+import xyz.dgz48.tasks.webapi.user.adapter.persistence.UserJpaEntity;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Import({
+  TestcontainersConfiguration.class,
+  MockJwtDecoderConfiguration.class,
+  FixedClockConfiguration.class
+})
+class MeIT {
+
+  @Autowired MockMvc mockMvc;
+  @Autowired EntityManager em;
+  @Autowired TransactionTemplate txTemplate;
+
+  private Long userId;
+  private Long tenantId1;
+  private Long tenantId2;
+  private TasksAuthenticationToken authToken;
+
+  @BeforeEach
+  void setUp() {
+    txTemplate.execute(
+        ignored -> {
+          var user =
+              new UserJpaEntity("sub-me-it", "me-it@example.com", "MeテストIT", "ミーテストIT", "開発部");
+          em.persist(user);
+          em.flush();
+          userId = user.getId();
+
+          var tenant1 = new TenantJpaEntity("me-t1", "MeテナントA");
+          var tenant2 = new TenantJpaEntity("me-t2", "MeテナントB");
+          em.persist(tenant1);
+          em.persist(tenant2);
+          em.flush();
+          tenantId1 = tenant1.getId();
+          tenantId2 = tenant2.getId();
+
+          return null;
+        });
+
+    var principal =
+        new TasksPrincipal(userId, "sub-me-it", "me-it@example.com", "MeテストIT", "ミーテストIT", "開発部");
+    authToken = new TasksAuthenticationToken(principal, List.of());
+  }
+
+  @AfterEach
+  void tearDown() {
+    SecurityContextHolder.clearContext();
+    if (userId == null) {
+      return;
+    }
+    txTemplate.execute(
+        ignored -> {
+          em.createNativeQuery("DELETE FROM user_tenants WHERE user_id = ?")
+              .setParameter(1, userId)
+              .executeUpdate();
+          em.createNativeQuery("DELETE FROM tenants WHERE id IN (?, ?)")
+              .setParameter(1, tenantId1)
+              .setParameter(2, tenantId2)
+              .executeUpdate();
+          em.createNativeQuery("DELETE FROM users WHERE id = ?")
+              .setParameter(1, userId)
+              .executeUpdate();
+          return null;
+        });
+  }
+
+  @Test
+  void unauthenticated_returns401() throws Exception {
+    mockMvc.perform(get("/api/auth/me")).andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  void noTenants_returnsEmptyArray() throws Exception {
+    mockMvc
+        .perform(get("/api/auth/me").with(authentication(authToken)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.user.id").value(userId))
+        .andExpect(jsonPath("$.user.email").value("me-it@example.com"))
+        .andExpect(jsonPath("$.user.fullName").value("MeテストIT"))
+        .andExpect(jsonPath("$.user.departmentName").value("開発部"))
+        .andExpect(jsonPath("$.tenants").isArray())
+        .andExpect(jsonPath("$.tenants").isEmpty())
+        .andExpect(jsonPath("$.activeTenantId").isEmpty());
+  }
+
+  @Test
+  void oneTenant_returnsSingleEntry() throws Exception {
+    insertUserTenant(userId, tenantId1, "MEMBER", LocalDateTime.of(2026, 1, 1, 0, 0));
+
+    mockMvc
+        .perform(get("/api/auth/me").with(authentication(authToken)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.tenants.length()").value(1))
+        .andExpect(jsonPath("$.tenants[0].id").value(tenantId1))
+        .andExpect(jsonPath("$.tenants[0].code").value("me-t1"))
+        .andExpect(jsonPath("$.tenants[0].name").value("MeテナントA"))
+        .andExpect(jsonPath("$.tenants[0].role").value("MEMBER"))
+        .andExpect(jsonPath("$.activeTenantId").isEmpty());
+  }
+
+  @Test
+  void multipleTenants_returnsAllInJoinedAtOrder() throws Exception {
+    insertUserTenant(userId, tenantId2, "TENANT_ADMIN", LocalDateTime.of(2026, 2, 1, 0, 0));
+    insertUserTenant(userId, tenantId1, "MEMBER", LocalDateTime.of(2026, 1, 1, 0, 0));
+
+    mockMvc
+        .perform(get("/api/auth/me").with(authentication(authToken)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.tenants.length()").value(2))
+        .andExpect(jsonPath("$.tenants[0].id").value(tenantId1))
+        .andExpect(jsonPath("$.tenants[0].role").value("MEMBER"))
+        .andExpect(jsonPath("$.tenants[1].id").value(tenantId2))
+        .andExpect(jsonPath("$.tenants[1].role").value("TENANT_ADMIN"));
+  }
+
+  @Test
+  void withXTenantIdHeader_returnsActiveTenantId() throws Exception {
+    insertUserTenant(userId, tenantId1, "MEMBER", LocalDateTime.of(2026, 1, 1, 0, 0));
+
+    mockMvc
+        .perform(
+            get("/api/auth/me").with(authentication(authToken)).header("X-Tenant-Id", tenantId1))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.activeTenantId").value(tenantId1));
+  }
+
+  private void insertUserTenant(Long uid, Long tid, String role, LocalDateTime joinedAt) {
+    txTemplate.execute(
+        ignored -> {
+          em.createNativeQuery(
+                  "INSERT INTO user_tenants (user_id, tenant_id, role, status, joined_at)"
+                      + " VALUES (?,?,?,?,?)")
+              .setParameter(1, uid)
+              .setParameter(2, tid)
+              .setParameter(3, role)
+              .setParameter(4, "ACTIVE")
+              .setParameter(5, joinedAt)
+              .executeUpdate();
+          return null;
+        });
+  }
+}

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/SecurityConfigTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/SecurityConfigTest.java
@@ -33,6 +33,7 @@ import org.springframework.security.oauth2.jwt.JwtValidationException;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import xyz.dgz48.tasks.webapi.security.adapter.persistence.AppAdminUserRepository;
+import xyz.dgz48.tasks.webapi.security.usecase.GetMeUseCase;
 import xyz.dgz48.tasks.webapi.security.usecase.LogoutUseCase;
 import xyz.dgz48.tasks.webapi.task.usecase.AddStakeholderUseCase;
 import xyz.dgz48.tasks.webapi.task.usecase.ChangeTaskStatusUseCase;
@@ -94,6 +95,7 @@ class SecurityConfigTest {
   @MockitoBean UpdateTenantUseCase updateTenantUseCase;
   @MockitoBean UpdateTenantStatusUseCase updateTenantStatusUseCase;
   @MockitoBean GetPlatformMetricsUseCase getPlatformMetricsUseCase;
+  @MockitoBean GetMeUseCase getMeUseCase;
 
   @Autowired MockMvc mockMvc;
 

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/TenantContextFilterTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/TenantContextFilterTest.java
@@ -22,6 +22,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 import xyz.dgz48.tasks.webapi.security.adapter.persistence.AppAdminUserRepository;
+import xyz.dgz48.tasks.webapi.security.usecase.GetMeUseCase;
 import xyz.dgz48.tasks.webapi.security.usecase.LogoutUseCase;
 import xyz.dgz48.tasks.webapi.shared.domain.TenantContext;
 import xyz.dgz48.tasks.webapi.task.usecase.AddStakeholderUseCase;
@@ -110,6 +111,7 @@ class TenantContextFilterTest {
   @MockitoBean UpdateTenantUseCase updateTenantUseCase;
   @MockitoBean UpdateTenantStatusUseCase updateTenantStatusUseCase;
   @MockitoBean GetPlatformMetricsUseCase getPlatformMetricsUseCase;
+  @MockitoBean GetMeUseCase getMeUseCase;
 
   @Autowired MockMvc mockMvc;
 


### PR DESCRIPTION
## Summary

- OpenAPI `operationId: getMe` が未実装で、SPA 初期描画(`Api.me()`)がエンドポイント不在で失敗していた問題を解消
- `TenantContextFilter` の免除パス(`/api/auth/**`)に該当するため X-Tenant-Id ヘッダ不要
- `activeTenantId` は X-Tenant-Id 指定時にその値を返し、未指定時は null(ADR-0016 の自動解決は `/me` では行わない)
- 所属 0 件 → `tenants: []`, `activeTenantId: null` を返す(401/403 は投げない)

## 変更内容

**tenant レイヤー**
- `TenantSummaryInfo` ドメインレコード追加(`id`, `code`, `name`, `role`)
- `TenantMembershipPort.findActiveMembershipDetails()` 追加
- `UserTenantJpaRepository` に `user_tenants JOIN tenants` JPQL コンストラクタ式クエリ追加(射影 interface 不要・GraalVM native 安全)
- `UserTenantMembershipAdapter` に実装追加(@Transactional は usecase 層に委譲)

**security レイヤー**
- `GetMeUseCase` — `@Transactional(readOnly=true)` トランザクション境界所有
- `MeController` — `GET /api/auth/me`
- `MeResponse` / `UserProfileDto` / `TenantSummaryDto`(static `from()` factory で adapter 層でのマッピング)

**テスト**
- `MeControllerWebMvcTest` — 200 / 401 / X-Tenant-Id ヘッダ境界
- `MeIT` — Testcontainers IT: 0件 / 1件 / 複数件 / `activeTenantId` ラウンドトリップ

## Test plan

- [ ] `./gradlew :webapi:check` グリーン(399 tests, 0 failed)
- [ ] CI `Native Build` ワークフロー グリーン(JPQL コンストラクタ式により射影 interface を排除、proxy-config.json 追記不要)
- [ ] `MeControllerWebMvcTest` — 4 ケース全通過
- [ ] `MeIT` — 5 ケース全通過(Testcontainers MySQL 8.4)
- [ ] `ModularityTests.verifyModularity()` パス(cross-module 依存は `@NamedInterface` 経由のみ)

Closes #659

🤖 Generated with [Claude Code](https://claude.com/claude-code)