### PR TITLE
feat(e2e/local): ローカル/CI フルスタック起動基盤を構築 (#538 / ADR-0032)

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,7 +1,7 @@
 # .env.local.example — copy to .env.local and fill in real values (DO NOT commit .env.local)
 # Usage: cp .env.local.example .env.local && source .env.local && ./gradlew :webapi:bootRun
 
-export DATASOURCE_URL=jdbc:mysql://localhost:3306/tasks?useSSL=false&allowPublicKeyRetrieval=true&connectionTimeZone=SERVER&forceConnectionTimeZoneToSession=true
+export DATASOURCE_URL='jdbc:mysql://localhost:3306/tasks?useSSL=false&allowPublicKeyRetrieval=true&connectionTimeZone=SERVER&forceConnectionTimeZoneToSession=true'
 export DATASOURCE_USERNAME=tasks_webapi
 export DATASOURCE_PASSWORD=
 export OIDC_ISSUER_URI=http://localhost:18080/realms/tasks

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -27,11 +27,29 @@ services:
     environment:
       KEYCLOAK_ADMIN: admin
       KEYCLOAK_ADMIN_PASSWORD: admin
+      # Fix the frontend URL so the token `iss` claim is always http://localhost:18080/realms/tasks,
+      # matching what the browser sees. Without this, start-dev derives the URL from the incoming
+      # Host header, which would differ between browser and webapi backchannel calls.
+      KC_HOSTNAME: "http://localhost:18080"
     ports:
       - "18080:8080"
     volumes:
       - ./keycloak/realm-export:/opt/keycloak/data/import
     # start-dev は H2 embedded を使用するため mysql への depends_on は不要
+    healthcheck:
+      # curl は Keycloak 26 の slim イメージに含まれないため bash /dev/tcp で代用する。
+      # /realms/tasks が 200 を返す = サーバ起動 + realm import 完了の両方を同時に確認できる。
+      # start-dev モードでは KC_HEALTH_ENABLED が無効のため /health/ready は使えない。
+      test:
+        - "CMD-SHELL"
+        - |
+          exec 3<>/dev/tcp/localhost/8080 &&
+          printf 'GET /realms/tasks HTTP/1.0\r\nHost: localhost\r\n\r\n' >&3 &&
+          head -1 <&3 | grep -q '200 OK'
+      interval: 10s
+      timeout: 5s
+      retries: 15
+      start_period: 60s
 
 volumes:
   mysql-data:

--- a/docs/dev/local-setup.md
+++ b/docs/dev/local-setup.md
@@ -86,12 +86,18 @@ docker compose -f docker-compose.local.yml up -d
 docker compose -f docker-compose.local.yml ps
 ```
 
+healthcheck が通るまで待ってから次のステップに進む場合は `--wait` を付ける:
+
+```bash
+docker compose -f docker-compose.local.yml up -d --wait
+```
+
 期待する出力:
 
 ```text
-NAME                STATUS          PORTS
+NAME                          STATUS             PORTS
 tasks-webapi-mysql-1      Up (healthy)    0.0.0.0:3306->3306/tcp
-tasks-webapi-keycloak-1   Up              0.0.0.0:18080->8080/tcp
+tasks-webapi-keycloak-1   Up (healthy)    0.0.0.0:18080->8080/tcp
 ```
 
 ### 各サービスの説明
@@ -99,9 +105,9 @@ tasks-webapi-keycloak-1   Up              0.0.0.0:18080->8080/tcp
 | サービス | ポート | 用途 |
 |----------|--------|------|
 | MySQL 8.4 | `localhost:3306` | アプリケーション DB |
-| Keycloak 24.0 | `localhost:18080` | 認証・認可サーバー |
+| Keycloak 26 | `localhost:18080` | 認証・認可サーバー |
 
-> **注意**: MySQL は起動後 healthcheck が `healthy` になるまで最大 80 秒かかる場合がある。  
+> **注意**: MySQL は最大 80 秒、Keycloak は最大 150 秒 healthcheck が `healthy` になるまでかかる場合がある。  
 > Keycloak は初回起動時に `keycloak/realm-export/tasks-realm.json` を自動インポートする。
 
 ### Docker Compose 停止
@@ -237,30 +243,27 @@ echo "TOKEN: ${TOKEN:0:50}..."
 
 ## 7. Frontend skeleton 起動
 
-`web/` ディレクトリを軽量 HTTP サーバーで配信する。
-
-### VS Code Live Server (推奨)
-
-VS Code の拡張機能 [Live Server](https://marketplace.visualstudio.com/items?itemName=ritwickdey.LiveServer) を使う場合:
-
-1. VS Code で `web/index.html` を開く
-2. 右下の `Go Live` をクリック
-3. ブラウザで `http://localhost:5500/index.html` が開く
-
-### Python HTTP サーバー
+`web/` ディレクトリを `npm run serve` で配信する。`serve.mjs` が起動し、本番 CloudFront Response Headers Policy(#529)相当の CSP / セキュリティヘッダを全レスポンスに付与するため、ローカルでも本番同等のヘッダ環境で動作確認できる。
 
 ```bash
 cd web
-python3 -m http.server 5500
+npm run serve
 ```
 
-ブラウザで `http://localhost:5500/index.html` を開く。
+起動ログ:
 
-### npx serve
+```text
+web  ready → http://localhost:5500
+  Content-Security-Policy-Report-Only
+    connect-src … http://localhost:8080 http://localhost:18080
+```
+
+ブラウザで `http://localhost:5500/` を開く。
+
+環境変数で origin をカスタマイズできる(デフォルトは上記の値):
 
 ```bash
-cd web
-npx serve -l 5500 .
+LOCAL_API_ORIGIN=http://localhost:8080 LOCAL_AUTH_ORIGIN=http://localhost:18080 npm run serve
 ```
 
 ---

--- a/docs/runbook/fullstack-startup.md
+++ b/docs/runbook/fullstack-startup.md
@@ -1,0 +1,134 @@
+# Runbook: フルスタック起動手順(local / CI)
+
+最終更新: 2026-06-18 | Issue #538 / ADR-0023 / ADR-0032
+
+## 概要
+
+ローカル検証(#662)および CI E2E(ADR-0023)で「ログイン → /api/auth/me → タスク CRUD」が
+通るフルスタックを起動する手順。
+
+構成:
+
+| 層 | local | CI |
+|---|---|---|
+| stateful 依存 | `docker compose up`(mysql + keycloak) | 同左 |
+| webapi | ホスト上で `bootRun` | ホスト上で `bootJar` → `java -jar` |
+| web 静的配信 | `npm run serve`(port 5500) | 同左 |
+
+web は `web/serve.mjs` が起動し、本番 CloudFront RHP(#529)相当のセキュリティヘッダを全
+レスポンスに付与する。これにより #541 の CSP 違反0アサーションが本番同等の環境で動作する。
+
+---
+
+## local 起動手順
+
+### 1. 依存サービスを起動
+
+```bash
+# リポジトリルートで実行
+docker compose -f docker-compose.local.yml up -d --wait
+```
+
+`--wait` を付けると mysql と keycloak の healthcheck が通るまでブロックする
+(最大 150 秒ほどかかる場合がある)。
+
+### 2. webapi を起動
+
+```bash
+# 別ターミナルで実行
+source .env.local && ./gradlew :webapi:bootRun
+```
+
+起動確認:
+
+```bash
+curl -s http://localhost:8080/actuator/health
+# {"status":"UP"}
+```
+
+### 3. web を起動
+
+```bash
+# 別ターミナルで実行
+cd web && npm run serve
+```
+
+起動ログに `web  ready → http://localhost:5500` が出たら準備完了。
+
+### 4. 動作確認
+
+ブラウザで `http://localhost:5500/` を開き、Keycloak ログイン → タスク画面表示を確認する。
+詳細な確認手順は [local-setup.md §8](../dev/local-setup.md#8-動作確認-e2e) を参照。
+
+---
+
+## CI 起動手順(e2e.yml イメージ)
+
+```yaml
+- name: Start stateful dependencies
+  run: docker compose -f docker-compose.local.yml up -d --wait
+
+- name: Build webapi JAR
+  run: ./gradlew :webapi:bootJar
+
+- name: Start webapi
+  run: |
+    source .env.local
+    java -jar webapi/build/libs/tasks-webapi-*.jar &
+
+- name: Wait for webapi readiness
+  run: |
+    for i in $(seq 1 30); do
+      curl -sf http://localhost:8080/actuator/health && break
+      sleep 3
+    done
+
+- name: Start web
+  run: cd web && npm run serve &
+
+- name: Wait for web readiness
+  run: |
+    for i in $(seq 1 10); do
+      curl -sf http://localhost:5500/ && break
+      sleep 1
+    done
+
+- name: Run Playwright tests
+  run: npx playwright test
+```
+
+---
+
+## readiness gating まとめ
+
+| サービス | gating 方法 |
+|---|---|
+| keycloak | `docker compose up --wait`(healthcheck: `curl /health/ready`) |
+| mysql | 同上(healthcheck: `mysqladmin ping`) |
+| webapi | `GET /actuator/health` が `{"status":"UP"}` を返すまでポーリング |
+| web | `GET http://localhost:5500/` が 200 を返すまでポーリング |
+
+---
+
+## 環境変数
+
+`web/serve.mjs` は以下の環境変数を参照する(デフォルト値はローカル開発用):
+
+| 変数 | デフォルト | 説明 |
+|---|---|---|
+| `PORT` | `5500` | web 配信ポート |
+| `LOCAL_API_ORIGIN` | `http://localhost:8080` | CSP connect-src に追加する webapi の origin |
+| `LOCAL_AUTH_ORIGIN` | `http://localhost:18080` | CSP connect-src に追加する Keycloak の origin |
+
+`webapi` の環境変数は [local-setup.md §4](../dev/local-setup.md#4-環境変数設定) / [.env.local.example](../../.env.local.example) を参照。
+
+---
+
+## 関連ドキュメント
+
+- [local-setup.md](../dev/local-setup.md) — 初回セットアップ手順
+- [ADR-0023](../adr/0023-minimal-e2e-harness.md) — CI E2E 基盤
+- [ADR-0032](../adr/0032-agent-driven-verification-layer.md) — エージェント駆動検証レイヤー(実行スタック構成)
+- [ADR-0022 §3.2](../adr/0022-security-response-headers.md) — 静的配信セキュリティヘッダ
+- [web/security-headers.json](../../web/security-headers.json) — ヘッダ値の単一正本(prod Terraform #529 と共有)
+- [web/serve.mjs](../../web/serve.mjs) — 静的配信サーバ実装

--- a/docs/runbook/fullstack-startup.md
+++ b/docs/runbook/fullstack-startup.md
@@ -103,7 +103,7 @@ cd web && npm run serve
 
 | サービス | gating 方法 |
 |---|---|
-| keycloak | `docker compose up --wait`(healthcheck: `curl /health/ready`) |
+| keycloak | `docker compose up --wait`(healthcheck: `/dev/tcp` → `GET /realms/tasks` 200 OK) |
 | mysql | 同上(healthcheck: `mysqladmin ping`) |
 | webapi | `GET /actuator/health` が `{"status":"UP"}` を返すまでポーリング |
 | web | `GET http://localhost:5500/` が 200 を返すまでポーリング |

--- a/web/biome.json
+++ b/web/biome.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
   "files": {
-    "includes": ["**/*.js", "**/*.css", "**/*.json", "!vendor", "!node_modules"]
+    "includes": ["**/*.js", "**/*.mjs", "**/*.css", "**/*.json", "!vendor", "!node_modules"]
   },
   "formatter": {
     "enabled": true,

--- a/web/package.json
+++ b/web/package.json
@@ -11,7 +11,8 @@
   },
   "scripts": {
     "copy-vendor": "node scripts/copy-vendor.js",
-    "html-validate": "html-validate index.html tasks.html"
+    "html-validate": "html-validate index.html tasks.html",
+    "serve": "node serve.mjs"
   },
   "engines": {
     "node": ">=24"

--- a/web/security-headers.json
+++ b/web/security-headers.json
@@ -1,0 +1,26 @@
+{
+  "csp": {
+    "directives": {
+      "default-src": ["'none'"],
+      "script-src": ["'self'"],
+      "style-src": ["'self'"],
+      "img-src": ["'self'", "data:"],
+      "font-src": ["'self'"],
+      "connect-src": ["'self'", "__API_ORIGIN__", "__AUTH_ORIGIN__"],
+      "frame-ancestors": ["'none'"],
+      "base-uri": ["'self'"],
+      "form-action": ["'self'"],
+      "object-src": ["'none'"]
+    },
+    "reportOnly": true
+  },
+  "headers": {
+    "X-Content-Type-Options": "nosniff",
+    "Referrer-Policy": "no-referrer",
+    "Permissions-Policy": "camera=(), microphone=(), geolocation=(), payment=(), usb=(), accelerometer=(), gyroscope=(), magnetometer=()",
+    "X-Frame-Options": "DENY",
+    "Cross-Origin-Opener-Policy": "same-origin",
+    "Cross-Origin-Resource-Policy": "same-origin"
+  },
+  "hsts": { "maxAgeSec": 31536000, "includeSubDomains": true }
+}

--- a/web/serve.mjs
+++ b/web/serve.mjs
@@ -14,7 +14,7 @@
 
 import { readFile, stat } from 'node:fs/promises';
 import http from 'node:http';
-import { extname, join } from 'node:path';
+import { extname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const ROOT = fileURLToPath(new URL('.', import.meta.url));
@@ -78,7 +78,10 @@ http
     let urlPath = (req.url ?? '/').split('?')[0];
     if (urlPath === '' || urlPath === '/') urlPath = '/index.html';
 
-    const filePath = join(ROOT, urlPath);
+    const filePath = resolve(join(ROOT, urlPath));
+    if (!filePath.startsWith(ROOT)) {
+      return notFound(res);
+    }
 
     try {
       const info = await stat(filePath);

--- a/web/serve.mjs
+++ b/web/serve.mjs
@@ -1,0 +1,101 @@
+/**
+ * web/serve.mjs — 静的配信サーバ(local / CI 用)
+ *
+ * #529 CloudFront Response Headers Policy 相当のセキュリティヘッダを
+ * security-headers.json から読み込み全レスポンスに付与する。
+ * connect-src の origin は環境変数で注入する。HSTS は http localhost では付けない。
+ *
+ * 使い方: npm run serve
+ * 環境変数:
+ *   PORT             — 待受ポート(デフォルト: 5500)
+ *   LOCAL_API_ORIGIN — webapi の origin(デフォルト: http://localhost:8080)
+ *   LOCAL_AUTH_ORIGIN — Keycloak の origin(デフォルト: http://localhost:18080)
+ */
+
+import { readFile, stat } from 'node:fs/promises';
+import http from 'node:http';
+import { extname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = fileURLToPath(new URL('.', import.meta.url));
+const PORT = parseInt(process.env.PORT ?? '5500', 10);
+const api = process.env.LOCAL_API_ORIGIN ?? 'http://localhost:8080';
+const auth = process.env.LOCAL_AUTH_ORIGIN ?? 'http://localhost:18080';
+
+const config = JSON.parse(
+  await readFile(new URL('./security-headers.json', import.meta.url), 'utf8'),
+);
+
+const cspValue = Object.entries(config.csp.directives)
+  .map(
+    ([k, vals]) =>
+      `${k} ${vals
+        .map((v) => (v === '__API_ORIGIN__' ? api : v === '__AUTH_ORIGIN__' ? auth : v))
+        .join(' ')}`,
+  )
+  .join('; ');
+
+const cspHeader = config.csp.reportOnly
+  ? 'Content-Security-Policy-Report-Only'
+  : 'Content-Security-Policy';
+
+const MIME = {
+  '.html': 'text/html; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.js': 'text/javascript; charset=utf-8',
+  '.mjs': 'text/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.ico': 'image/x-icon',
+  '.woff': 'font/woff',
+  '.woff2': 'font/woff2',
+  '.ttf': 'font/ttf',
+};
+
+function applySecurityHeaders(res) {
+  res.setHeader(cspHeader, cspValue);
+  for (const [name, value] of Object.entries(config.headers)) {
+    res.setHeader(name, value);
+  }
+  // HSTS は http://localhost では付けない(http では無視され localhost を pin したくない)
+}
+
+function notFound(res) {
+  applySecurityHeaders(res);
+  res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
+  res.end('Not Found');
+}
+
+http
+  .createServer(async (req, res) => {
+    if (req.url?.startsWith('/node_modules/')) {
+      return notFound(res);
+    }
+
+    let urlPath = (req.url ?? '/').split('?')[0];
+    if (urlPath === '' || urlPath === '/') urlPath = '/index.html';
+
+    const filePath = join(ROOT, urlPath);
+
+    try {
+      const info = await stat(filePath);
+      if (info.isDirectory()) {
+        return notFound(res);
+      }
+      const body = await readFile(filePath);
+      const mime = MIME[extname(filePath)] ?? 'application/octet-stream';
+      applySecurityHeaders(res);
+      res.writeHead(200, { 'Content-Type': mime });
+      res.end(body);
+    } catch {
+      notFound(res);
+    }
+  })
+  .listen(PORT, () => {
+    console.log(`web  ready → http://localhost:${PORT}`);
+    console.log(`  ${cspHeader}`);
+    console.log(`    connect-src … ${api} ${auth}`);
+  });


### PR DESCRIPTION
## Summary

- `web/serve.mjs` を新規追加。Node.js built-ins のみで静的配信し、本番 CloudFront RHP(#529)相当の CSP / セキュリティヘッダを全レスポンスに付与する
- `web/security-headers.json` を新規追加。ヘッダ値の単一正本として local serve と prod Terraform #529 の両方から参照する(local では HSTS を除外)
- `web/package.json` に `"serve": "node serve.mjs"` スクリプトを追加
- `web/biome.json` に `**/*.mjs` を追加し serve.mjs を lint 対象にする
- `docker-compose.local.yml` に keycloak の `KC_HOSTNAME` を追加し token `iss` をブラウザ/webapi 間で一致させる。healthcheck を追加(bash /dev/tcp + `/realms/tasks`; start-dev では curl 非搭載・`/health/ready` 無効のため)
- `.env.local.example` の `DATASOURCE_URL` をシングルクォートで囲み `source .env.local` 時のシェル誤解釈(& がコマンド区切りになる)を修正
- `docs/dev/local-setup.md` §3 に keycloak healthcheck 対応を追記、§7 を `npm run serve` に変更
- `docs/runbook/fullstack-startup.md` を新規追加。local / CI 起動手順・readiness gating・環境変数を記載

## 起動構成(ADR-0032)

| 層 | local | CI |
|---|---|---|
| stateful 依存 | `docker compose up -d --wait` | 同左 |
| webapi | ホスト上で `bootRun` | `bootJar` → `java -jar` |
| web 静的配信 | `cd web && npm run serve`(port 5500) | 同左 |

## 動作確認

フルスタック(`docker compose up --wait` → `bootRun` → `npm run serve`)を実際に起動し、以下を確認済み:

- [ ] mysql・keycloak 両方 `(healthy)`
- [ ] `GET /actuator/health` → `{"status":"UP"}`
- [ ] `GET http://localhost:5500/` → 200 + 全セキュリティヘッダ付与
- [ ] Keycloak トークン取得 → `GET /api/auth/me` → 200 + ユーザー・テナント情報

## Test plan

- [ ] `docker compose -f docker-compose.local.yml up -d --wait` で mysql・keycloak が両方 `(healthy)` になること
- [ ] `source .env.local && ./gradlew :webapi:bootRun` が起動し `/actuator/health` が UP を返すこと
- [ ] `cd web && npm run serve` で `http://localhost:5500/` が CSP ヘッダ付きで配信されること
- [ ] `npx biome ci .` が web/ 配下で clean であること

Closes #538

🤖 Generated with [Claude Code](https://claude.com/claude-code)