### PR TITLE
fix(task): /api/tasks/{id}/status を楽観ロック対象外にする(If-Match 撤去) + ADR-0012 amendment

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -725,7 +725,11 @@ paths:
     patch:
       tags: [Task]
       summary: ステータス変更
-      description: "認可: 所有者または担当者(Tenant Admin の特別権限なし、ADR-0005)"
+      description: |-
+        認可: 所有者または担当者(Tenant Admin の特別権限なし、ADR-0005)。
+
+        **楽観ロック対象外(ADR-0012 amendment)**: `If-Match` ヘッダ不要。単一フィールドの絶対値 SET であり
+        多フィールド同時上書きによる lost update が構造的に発生しない。同時変更は last-write-wins で受容する。
       operationId: changeStatus
       parameters:
         - { name: id, in: path, required: true, description: "タスクID", schema: { type: integer, format: int64 } }

--- a/docs/adr/0012-optimistic-locking-etag-if-match.md
+++ b/docs/adr/0012-optimistic-locking-etag-if-match.md
@@ -132,3 +132,39 @@ Issue #150 派生 5(Sprint 0 UX 原則)で `tasks.completed_at` 追加の Flyway
 - Issue #150(Sprint 0 UX 原則、`tasks.completed_at` DDL)
 - ADR-0011(独自 record ErrorResponse)
 - RFC 7232(HTTP Conditional Requests)
+
+---
+
+## Amendment 1: 楽観ロック適用基準の追記(2026-06-19, Issue #680)
+
+### 経緯
+
+`PATCH /api/tasks/{id}/status` が If-Match required で実装されていたが、OpenAPI 未定義・フロント未送出のため常に 400 になることが判明。事故分析の結果、本 endpoint は楽観ロック対象外と確定した。
+
+### 適用基準(§scope)
+
+楽観ロック(If-Match)は **「呼び出し側が観測していない変更を上書きしうる write」にのみ適用する**。
+
+判定マトリクス:
+
+| 観点 | 対象とする | 対象外とする |
+|---|---|---|
+| フィールド範囲 | 多フィールドを束ねる PATCH / PUT | 単一フィールドの絶対値 SET |
+| 上書き実害 | 他人の未編集列を巻き込む lost update が起きる | 同フィールドのみ最後勝ちで自然 |
+| 頻度 / UX | 低頻度 or 412 再試行コストが許容範囲 | 高頻度で 412 が誤検知摩擦のみを生む |
+
+決定マトリクス(現行 endpoint):
+
+| Endpoint | 適用 | 理由 |
+|---|---|---|
+| `PATCH /api/tasks/{id}` | ✅ 対象 | 多フィールド read-modify-write; lost update リスク高 |
+| `DELETE /api/tasks/{id}` | ✅ 対象 | 論理削除; 低頻度・高実害 |
+| `PATCH /api/tasks/{id}/status` | ❌ 対象外 | 単一フィールド SET; last-write-wins で自然 |
+| `PATCH /api/tasks/{id}/visibility` | ✅ 対象 | stakeholders 同時置換を含む; 低頻度・高実害 |
+
+### 実装変更(Issue #680)
+
+- `ChangeTaskStatusUseCase.execute` から `ifMatchVersion` 引数と version 一致チェックを撤去
+- `TaskController.changeStatus` から `@RequestHeader(IF_MATCH)` を撤去
+- バイパス実装: `TaskRepository.saveStatus` を JPQL UPDATE(`version` 列非更新)で実装し、JPA `@Version` チェックをバイパスして last-write-wins を実現
+- `updatedAt` はアプリ層で `LocalDateTime.now(clock)` を渡してアップデート

--- a/web/js/tasks.js
+++ b/web/js/tasks.js
@@ -83,10 +83,7 @@ async function onStatusChange(taskId, status, selectEl) {
     rerenderRow(taskId);
   } catch (err) {
     rerenderRow(taskId); // revert
-    // PATCH /api/tasks/{id}/status は ADR-0012 の If-Match 対象外のため 412 は理論上返らない
-    if (/** @type {any} */ (err).status === 412) conflictBanner.show();
-    else
-      errorBanner.show(`ステータスの更新に失敗しました: ${/** @type {any} */ (err).message || ''}`);
+    errorBanner.show(`ステータスの更新に失敗しました: ${/** @type {any} */ (err).message || ''}`);
   }
 }
 

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/adapter/persistence/TaskJpaRepository.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/adapter/persistence/TaskJpaRepository.java
@@ -1,9 +1,14 @@
 package xyz.dgz48.tasks.webapi.task.adapter.persistence;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
+import org.jspecify.annotations.Nullable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
+import xyz.dgz48.tasks.webapi.task.domain.TaskStatus;
 
 interface TaskJpaRepository extends JpaRepository<TaskJpaEntity, Long> {
 
@@ -14,4 +19,20 @@ interface TaskJpaRepository extends JpaRepository<TaskJpaEntity, Long> {
   @Override
   @Query("SELECT t FROM TaskJpaEntity t WHERE t.id = :id")
   Optional<TaskJpaEntity> findById(@Param("id") Long id);
+
+  /**
+   * ステータスのみを楽観ロックなしで更新する(last-write-wins、ADR-0012 amendment)。
+   *
+   * <p>{@code version} 列を変更しないため {@code @Version} チェックをバイパスし、同時更新が競合しない。 {@code clearAutomatically
+   * = true} で永続化コンテキストをクリアし、後続 findById が最新 DB 値を返す。
+   */
+  @Modifying(clearAutomatically = true)
+  @Transactional
+  @Query(
+      "UPDATE TaskJpaEntity t SET t.status = :status, t.completedAt = :completedAt, t.updatedAt = :updatedAt WHERE t.id = :id")
+  void updateStatusById(
+      @Param("id") Long id,
+      @Param("status") TaskStatus status,
+      @Param("completedAt") @Nullable LocalDateTime completedAt,
+      @Param("updatedAt") LocalDateTime updatedAt);
 }

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/adapter/persistence/TaskJpaRepositoryAdapter.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/adapter/persistence/TaskJpaRepositoryAdapter.java
@@ -248,6 +248,17 @@ class TaskJpaRepositoryAdapter implements TaskRepository {
   }
 
   @Override
+  public Task saveStatus(
+      Long taskId, TaskStatus newStatus, @Nullable LocalDateTime completedAt, LocalDateTime now) {
+    jpaRepository.updateStatusById(taskId, newStatus, completedAt, now);
+    return toDomain(
+        jpaRepository
+            .findById(taskId)
+            .orElseThrow(
+                () -> new IllegalStateException("Task not found after status update: " + taskId)));
+  }
+
+  @Override
   public void softDelete(Task task, LocalDateTime deletedAt) {
     TaskJpaEntity entity =
         jpaRepository

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/adapter/web/TaskController.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/adapter/web/TaskController.java
@@ -209,15 +209,10 @@ public class TaskController {
   @PreAuthorize("hasAnyRole('TENANT_ADMIN', 'MEMBER')")
   public ResponseEntity<TaskResponse> changeStatus(
       @PathVariable Long id,
-      @RequestHeader(name = HttpHeaders.IF_MATCH) String ifMatch,
       @RequestBody @Valid ChangeTaskStatusRequest request,
       TasksAuthenticationToken token) {
-    Long ifMatchVersion = parseIfMatchVersion(ifMatch);
-    Task task =
-        changeTaskStatusUseCase.execute(
-            id, token.getPrincipal().getId(), request.status(), ifMatchVersion);
-    TaskResponse body = TaskResponse.from(task);
-    return ResponseEntity.ok().header(HttpHeaders.ETAG, etagValue(task.getVersion())).body(body);
+    Task task = changeTaskStatusUseCase.execute(id, token.getPrincipal().getId(), request.status());
+    return ResponseEntity.ok(TaskResponse.from(task));
   }
 
   @GetMapping("/{id}/stakeholders")

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/usecase/ChangeTaskStatusUseCase.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/usecase/ChangeTaskStatusUseCase.java
@@ -6,7 +6,6 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import xyz.dgz48.tasks.webapi.shared.exception.PreconditionFailedException;
 import xyz.dgz48.tasks.webapi.task.domain.Task;
 import xyz.dgz48.tasks.webapi.task.domain.TaskAuthorizationDomainService;
 import xyz.dgz48.tasks.webapi.task.domain.TaskNotFoundException;
@@ -24,7 +23,7 @@ public class ChangeTaskStatusUseCase {
   private final Clock clock;
 
   @Transactional
-  public Task execute(Long taskId, Long userId, TaskStatus newStatus, Long ifMatchVersion) {
+  public Task execute(Long taskId, Long userId, TaskStatus newStatus) {
     Task task =
         taskRepository.findById(taskId).orElseThrow(() -> new TaskNotFoundException(taskId));
     List<Long> stakeholderUserIds =
@@ -35,10 +34,8 @@ public class ChangeTaskStatusUseCase {
     if (!taskAuthorizationDomainService.canChangeStatusBy(task, userId)) {
       throw new TaskOwnershipException(taskId);
     }
-    if (!task.getVersion().equals(ifMatchVersion)) {
-      throw new PreconditionFailedException("バージョンが競合しています: task=" + taskId);
-    }
-    task.changeStatus(newStatus, LocalDateTime.now(clock));
-    return taskRepository.save(task);
+    LocalDateTime now = LocalDateTime.now(clock);
+    task.changeStatus(newStatus, now);
+    return taskRepository.saveStatus(taskId, task.getStatus(), task.getCompletedAt(), now);
   }
 }

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/usecase/TaskRepository.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/usecase/TaskRepository.java
@@ -51,4 +51,12 @@ public interface TaskRepository {
 
   /** タスクを論理削除する(deleted_at セット)。楽観ロック競合時は PreconditionFailedException を投げる。 */
   void softDelete(Task task, LocalDateTime deletedAt);
+
+  /**
+   * ステータスと completedAt のみを更新する(last-write-wins、ADR-0012 amendment)。
+   *
+   * <p>楽観ロック({@code @Version})をバイパスするため同時変更が競合しない。{@code now} は {@code updated_at} に反映される。
+   */
+  Task saveStatus(
+      Long taskId, TaskStatus newStatus, @Nullable LocalDateTime completedAt, LocalDateTime now);
 }

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/adapter/web/ChangeTaskStatusIT.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/adapter/web/ChangeTaskStatusIT.java
@@ -3,7 +3,6 @@ package xyz.dgz48.tasks.webapi.task.adapter.web;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -22,7 +21,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.context.annotation.Import;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -41,9 +39,10 @@ import xyz.dgz48.tasks.webapi.tenant.adapter.persistence.TenantJpaEntity;
 import xyz.dgz48.tasks.webapi.user.adapter.persistence.UserJpaEntity;
 
 /**
- * PATCH /api/tasks/{id}/status の楽観ロック(ETag / If-Match)統合 IT。
+ * PATCH /api/tasks/{id}/status の統合 IT。
  *
- * <p>ADR-0012 §3 に従い、If-Match 一致→200、不一致→412、なし→400、同時実行片方→412 を検証する。
+ * <p>楽観ロック(If-Match)対象外(ADR-0012 amendment)。If-Match 不要で 200 を返し、同時変更は last-write-wins で両方 200
+ * を返すことを検証する。
  */
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -142,50 +141,20 @@ class ChangeTaskStatusIT {
   }
 
   @Test
-  void changeStatus_returns400_whenIfMatchHeaderMissing() throws Exception {
+  void changeStatus_returns200_withoutIfMatch() throws Exception {
     mockMvc
         .perform(
             patch("/api/tasks/" + taskId + "/status")
                 .header("X-Tenant-Id", String.valueOf(tenantId))
-                .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"status\":\"IN_PROGRESS\"}")
-                .with(authentication(authToken)))
-        .andExpect(status().isBadRequest())
-        .andExpect(jsonPath("$.code").value("E_VALIDATION"));
-  }
-
-  @Test
-  void changeStatus_returns412_whenIfMatchVersionStale() throws Exception {
-    mockMvc
-        .perform(
-            patch("/api/tasks/" + taskId + "/status")
-                .header("X-Tenant-Id", String.valueOf(tenantId))
-                .header(HttpHeaders.IF_MATCH, "W/\"99\"")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"status\":\"IN_PROGRESS\"}")
-                .with(authentication(authToken)))
-        .andExpect(status().isPreconditionFailed())
-        .andExpect(jsonPath("$.code").value("E_PRECONDITION_FAILED"));
-  }
-
-  @Test
-  void changeStatus_returns200_whenIfMatchVersionMatches() throws Exception {
-    mockMvc
-        .perform(
-            patch("/api/tasks/" + taskId + "/status")
-                .header("X-Tenant-Id", String.valueOf(tenantId))
-                .header(HttpHeaders.IF_MATCH, "W/\"0\"")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"status\":\"IN_PROGRESS\"}")
                 .with(authentication(authToken)))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.status").value("IN_PROGRESS"))
-        .andExpect(jsonPath("$.version").value(1))
-        .andExpect(header().string(HttpHeaders.ETAG, "W/\"1\""));
+        .andExpect(jsonPath("$.status").value("IN_PROGRESS"));
   }
 
   @Test
-  void changeStatus_concurrentRequests_oneGets412() throws Exception {
+  void changeStatus_concurrentRequests_bothReturn200_lastWriteWins() throws Exception {
     ExecutorService executor = Executors.newFixedThreadPool(2);
 
     Callable<MvcResult> patchRequest =
@@ -194,7 +163,6 @@ class ChangeTaskStatusIT {
                 .perform(
                     patch("/api/tasks/" + taskId + "/status")
                         .header("X-Tenant-Id", String.valueOf(tenantId))
-                        .header(HttpHeaders.IF_MATCH, "W/\"0\"")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"status\":\"IN_PROGRESS\"}")
                         .with(authentication(authToken)))
@@ -207,11 +175,11 @@ class ChangeTaskStatusIT {
     MockHttpServletResponse response2 = future2.get().getResponse();
     executor.shutdown();
 
-    int status1 = response1.getStatus();
-    int status2 = response2.getStatus();
-
-    assertThat(List.of(status1, status2))
-        .as("一方が 200、もう一方が 412 であること")
-        .containsExactlyInAnyOrder(200, 412);
+    assertThat(response1.getStatus())
+        .as("同時ステータス変更: リクエスト1 が 200 を返すこと(last-write-wins)")
+        .isEqualTo(200);
+    assertThat(response2.getStatus())
+        .as("同時ステータス変更: リクエスト2 が 200 を返すこと(last-write-wins)")
+        .isEqualTo(200);
   }
 }

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/adapter/web/TaskControllerWebMvcTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/adapter/web/TaskControllerWebMvcTest.java
@@ -33,7 +33,6 @@ import xyz.dgz48.tasks.webapi.security.adapter.web.TasksJwtAuthenticationConvert
 import xyz.dgz48.tasks.webapi.security.adapter.web.WithMockMember;
 import xyz.dgz48.tasks.webapi.security.adapter.web.WithMockSaasAdmin;
 import xyz.dgz48.tasks.webapi.security.adapter.web.WithMockTenantAdmin;
-import xyz.dgz48.tasks.webapi.shared.exception.PreconditionFailedException;
 import xyz.dgz48.tasks.webapi.task.domain.Priority;
 import xyz.dgz48.tasks.webapi.task.domain.Task;
 import xyz.dgz48.tasks.webapi.task.domain.TaskNotFoundException;
@@ -95,7 +94,6 @@ class TaskControllerWebMvcTest {
   }
 
   private static final long VERSION = 0L;
-  private static final String IF_MATCH = "W/\"" + VERSION + "\"";
 
   private Task buildTask(TaskStatus status) {
     return new Task(
@@ -178,12 +176,11 @@ class TaskControllerWebMvcTest {
   @WithMockMember
   void changeStatus_returns200WithCompletedAt_whenDone() throws Exception {
     Task done = buildDoneTask();
-    when(changeTaskStatusUseCase.execute(1L, USER_ID, TaskStatus.DONE, VERSION)).thenReturn(done);
+    when(changeTaskStatusUseCase.execute(1L, USER_ID, TaskStatus.DONE)).thenReturn(done);
 
     mockMvc
         .perform(
             patch("/api/tasks/1/status")
-                .header("If-Match", IF_MATCH)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"status\":\"DONE\"}"))
         .andExpect(status().isOk())
@@ -193,39 +190,13 @@ class TaskControllerWebMvcTest {
 
   @Test
   @WithMockMember
-  void changeStatus_returns400_whenIfMatchHeaderMissing() throws Exception {
-    mockMvc
-        .perform(
-            patch("/api/tasks/1/status")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"status\":\"DONE\"}"))
-        .andExpect(status().isBadRequest())
-        .andExpect(jsonPath("$.code").value("E_VALIDATION"));
-  }
-
-  @Test
-  @WithMockMember
-  void changeStatus_returns400_whenIfMatchInvalidFormat() throws Exception {
-    mockMvc
-        .perform(
-            patch("/api/tasks/1/status")
-                .header("If-Match", "not-a-version")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"status\":\"DONE\"}"))
-        .andExpect(status().isBadRequest())
-        .andExpect(jsonPath("$.code").value("E_VALIDATION"));
-  }
-
-  @Test
-  @WithMockMember
   void changeStatus_returns404_whenTaskNotViewable() throws Exception {
-    when(changeTaskStatusUseCase.execute(2L, USER_ID, TaskStatus.DONE, VERSION))
+    when(changeTaskStatusUseCase.execute(2L, USER_ID, TaskStatus.DONE))
         .thenThrow(new TaskNotViewableException(2L));
 
     mockMvc
         .perform(
             patch("/api/tasks/2/status")
-                .header("If-Match", IF_MATCH)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"status\":\"DONE\"}"))
         .andExpect(status().isNotFound())
@@ -235,34 +206,16 @@ class TaskControllerWebMvcTest {
   @Test
   @WithMockMember
   void changeStatus_returns403_whenOwnershipException() throws Exception {
-    when(changeTaskStatusUseCase.execute(3L, USER_ID, TaskStatus.DONE, VERSION))
+    when(changeTaskStatusUseCase.execute(3L, USER_ID, TaskStatus.DONE))
         .thenThrow(new TaskOwnershipException(3L));
 
     mockMvc
         .perform(
             patch("/api/tasks/3/status")
-                .header("If-Match", IF_MATCH)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"status\":\"DONE\"}"))
         .andExpect(status().isForbidden())
         .andExpect(jsonPath("$.code").value("E_FORBIDDEN"));
-  }
-
-  @Test
-  @WithMockMember
-  void changeStatus_returns412_whenOptimisticLockingFailure() throws Exception {
-    when(changeTaskStatusUseCase.execute(5L, USER_ID, TaskStatus.DONE, VERSION))
-        .thenThrow(new PreconditionFailedException("バージョンが競合しています: task=5"));
-
-    mockMvc
-        .perform(
-            patch("/api/tasks/5/status")
-                .header("If-Match", IF_MATCH)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"status\":\"DONE\"}"))
-        .andExpect(status().isPreconditionFailed())
-        .andExpect(jsonPath("$.code").value("E_PRECONDITION_FAILED"))
-        .andExpect(jsonPath("$.status").value(412));
   }
 
   // --- 認可マトリクス: 未認証 (401) ---
@@ -277,7 +230,6 @@ class TaskControllerWebMvcTest {
     mockMvc
         .perform(
             patch("/api/tasks/1/status")
-                .header("If-Match", IF_MATCH)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"status\":\"DONE\"}"))
         .andExpect(status().isUnauthorized());
@@ -301,7 +253,6 @@ class TaskControllerWebMvcTest {
     mockMvc
         .perform(
             patch("/api/tasks/1/status")
-                .header("If-Match", IF_MATCH)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"status\":\"DONE\"}"))
         .andExpect(status().isForbidden());
@@ -325,12 +276,11 @@ class TaskControllerWebMvcTest {
   @WithMockTenantAdmin
   void changeStatus_returns200_whenTenantAdmin() throws Exception {
     Task done = buildDoneTask();
-    when(changeTaskStatusUseCase.execute(1L, USER_ID, TaskStatus.DONE, VERSION)).thenReturn(done);
+    when(changeTaskStatusUseCase.execute(1L, USER_ID, TaskStatus.DONE)).thenReturn(done);
 
     mockMvc
         .perform(
             patch("/api/tasks/1/status")
-                .header("If-Match", IF_MATCH)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"status\":\"DONE\"}"))
         .andExpect(status().isOk())

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/usecase/ChangeTaskStatusUseCaseTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/usecase/ChangeTaskStatusUseCaseTest.java
@@ -3,6 +3,8 @@ package xyz.dgz48.tasks.webapi.task.usecase;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.when;
 
 import java.time.Clock;
@@ -16,7 +18,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import xyz.dgz48.tasks.webapi.shared.exception.PreconditionFailedException;
 import xyz.dgz48.tasks.webapi.shared.infra.AppZones;
 import xyz.dgz48.tasks.webapi.task.domain.Priority;
 import xyz.dgz48.tasks.webapi.task.domain.Task;
@@ -76,7 +77,7 @@ class ChangeTaskStatusUseCaseTest {
   void execute_throwsTaskNotFoundException_whenTaskNotFound() {
     when(taskRepository.findById(TASK_ID)).thenReturn(Optional.empty());
 
-    assertThatThrownBy(() -> useCase.execute(TASK_ID, OWNER_ID, TaskStatus.DONE, VERSION))
+    assertThatThrownBy(() -> useCase.execute(TASK_ID, OWNER_ID, TaskStatus.DONE))
         .isInstanceOf(TaskNotFoundException.class);
   }
 
@@ -87,7 +88,7 @@ class ChangeTaskStatusUseCaseTest {
     when(taskAuthorizationDomainService.canBeViewedBy(task, OTHER_USER_ID, List.of()))
         .thenReturn(false);
 
-    assertThatThrownBy(() -> useCase.execute(TASK_ID, OTHER_USER_ID, TaskStatus.DONE, VERSION))
+    assertThatThrownBy(() -> useCase.execute(TASK_ID, OTHER_USER_ID, TaskStatus.DONE))
         .isInstanceOf(TaskNotViewableException.class);
   }
 
@@ -99,19 +100,8 @@ class ChangeTaskStatusUseCaseTest {
         .thenReturn(true);
     when(taskAuthorizationDomainService.canChangeStatusBy(task, OTHER_USER_ID)).thenReturn(false);
 
-    assertThatThrownBy(() -> useCase.execute(TASK_ID, OTHER_USER_ID, TaskStatus.DONE, VERSION))
+    assertThatThrownBy(() -> useCase.execute(TASK_ID, OTHER_USER_ID, TaskStatus.DONE))
         .isInstanceOf(TaskOwnershipException.class);
-  }
-
-  @Test
-  void execute_throwsPreconditionFailedException_whenVersionMismatch() {
-    Task task = buildTask(TaskStatus.IN_PROGRESS);
-    when(taskRepository.findById(TASK_ID)).thenReturn(Optional.of(task));
-    when(taskAuthorizationDomainService.canBeViewedBy(task, OWNER_ID, List.of())).thenReturn(true);
-    when(taskAuthorizationDomainService.canChangeStatusBy(task, OWNER_ID)).thenReturn(true);
-
-    assertThatThrownBy(() -> useCase.execute(TASK_ID, OWNER_ID, TaskStatus.DONE, VERSION + 1))
-        .isInstanceOf(PreconditionFailedException.class);
   }
 
   @Test
@@ -121,9 +111,27 @@ class ChangeTaskStatusUseCaseTest {
     when(taskAuthorizationDomainService.canBeViewedBy(task, OWNER_ID, List.of())).thenReturn(true);
     when(taskAuthorizationDomainService.canChangeStatusBy(task, OWNER_ID)).thenReturn(true);
     setupClock();
-    when(taskRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+    Task expected =
+        new Task(
+            TASK_ID,
+            TENANT_ID,
+            "Test task",
+            null,
+            TaskStatus.DONE,
+            Priority.MEDIUM,
+            Visibility.TENANT,
+            OWNER_ID,
+            ASSIGNEE_ID,
+            LocalDate.of(2026, 6, 1),
+            FIXED_LDT,
+            null,
+            LocalDateTime.of(2026, 5, 31, 0, 0),
+            FIXED_LDT,
+            VERSION);
+    when(taskRepository.saveStatus(eq(TASK_ID), eq(TaskStatus.DONE), eq(FIXED_LDT), any()))
+        .thenReturn(expected);
 
-    Task result = useCase.execute(TASK_ID, OWNER_ID, TaskStatus.DONE, VERSION);
+    Task result = useCase.execute(TASK_ID, OWNER_ID, TaskStatus.DONE);
 
     assertThat(result.getStatus()).isEqualTo(TaskStatus.DONE);
     assertThat(result.getCompletedAt()).isEqualTo(FIXED_LDT);
@@ -153,9 +161,27 @@ class ChangeTaskStatusUseCaseTest {
         .thenReturn(true);
     when(taskAuthorizationDomainService.canChangeStatusBy(task, ASSIGNEE_ID)).thenReturn(true);
     setupClock();
-    when(taskRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+    Task expected =
+        new Task(
+            TASK_ID,
+            TENANT_ID,
+            "Test task",
+            null,
+            TaskStatus.IN_PROGRESS,
+            Priority.MEDIUM,
+            Visibility.TENANT,
+            OWNER_ID,
+            ASSIGNEE_ID,
+            LocalDate.of(2026, 6, 1),
+            null,
+            null,
+            LocalDateTime.of(2026, 5, 31, 0, 0),
+            FIXED_LDT,
+            VERSION);
+    when(taskRepository.saveStatus(eq(TASK_ID), eq(TaskStatus.IN_PROGRESS), isNull(), any()))
+        .thenReturn(expected);
 
-    Task result = useCase.execute(TASK_ID, ASSIGNEE_ID, TaskStatus.IN_PROGRESS, VERSION);
+    Task result = useCase.execute(TASK_ID, ASSIGNEE_ID, TaskStatus.IN_PROGRESS);
 
     assertThat(result.getStatus()).isEqualTo(TaskStatus.IN_PROGRESS);
     assertThat(result.getCompletedAt()).isNull();


### PR DESCRIPTION
Closes #680

## Summary

- `PATCH /api/tasks/{id}/status` から `If-Match` ヘッダ要求を撤去し、常に 400 になっていたバグを修正
- `@Version` バイパス用 JPQL UPDATE (`TaskRepository.saveStatus`) を導入し **last-write-wins** を実装 — 同時変更は両方 200 を返す
- ADR-0012 に **Amendment 1** として楽観ロック適用基準(判定マトリクス・決定マトリクス)を追記

## 変更ファイル

| 種別 | ファイル | 内容 |
|---|---|---|
| main | `TaskJpaRepository` | `@Modifying(clearAutomatically=true)` JPQL UPDATE `updateStatusById` 追加 |
| main | `TaskRepository` | `saveStatus(...)` ポートメソッド追加 |
| main | `TaskJpaRepositoryAdapter` | `saveStatus` 実装 — UPDATE 後 re-fetch で最新 DB 値を返す |
| main | `ChangeTaskStatusUseCase` | `ifMatchVersion` 引数と version チェック撤去、`saveStatus` 呼び出しへ変更 |
| main | `TaskController` | `changeStatus` から `@RequestHeader(IF_MATCH)` と ETag レスポンスヘッダを撤去 |
| test | `ChangeTaskStatusUseCaseTest` | `PreconditionFailedException` テスト削除、mock を新シグネチャに更新 |
| test | `TaskControllerWebMvcTest` | If-Match/412 テスト 3 本削除、残テストから If-Match ヘッダ除去 |
| test | `ChangeTaskStatusIT` | last-write-wins 統合 IT に全面書き換え(no-If-Match→200 / 同時→両方 200) |
| frontend | `web/js/tasks.js` | `onStatusChange` の 412 デッドブランチ削除 |
| openapi | `api/openapi.yaml` | `/status` description に「楽観ロック対象外」明記 |
| docs | `ADR-0012` | Amendment 1: 適用基準(判定マトリクス・決定マトリクス)追記 |

## Test plan

- [x] `./gradlew :webapi:check` — BUILD SUCCESSFUL(compile + spotless + NullAway + tests + JaCoCo)
- [x] `npx biome ci .`(web/) — No fixes applied
- [x] `ChangeTaskStatusIT.changeStatus_returns200_withoutIfMatch` — If-Match なし→200 確認
- [x] `ChangeTaskStatusIT.changeStatus_concurrentRequests_bothReturn200_lastWriteWins` — 同時変更→両方 200 確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)