### PR TITLE
feat(task): /api/tasks/{id}/visibility に楽観ロック(If-Match)を付与する (#683)

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -776,9 +776,17 @@ paths:
         不要なリスト情報の残留を避けるため削除し、件数を `STAKEHOLDER_PURGED` の `detail` に記録して監査追跡を確保する。
 
         シーケンス図: `docs/diagrams/sequence-06-visibility-change.mmd`
+
+        楽観ロック(ADR-0012): `If-Match` ヘッダに `GET /api/tasks/{id}` レスポンスの ETag 値を必須指定。
+        不一致時は 412 Precondition Failed(`E_PRECONDITION_FAILED`)を返す。
       operationId: changeVisibility
       parameters:
         - { name: id, in: path, required: true, description: "タスクID", schema: { type: integer, format: int64 } }
+        - name: If-Match
+          in: header
+          required: true
+          description: "楽観ロック用 ETag (`GET /api/tasks/{id}` レスポンスの ETag 値、ADR-0012)"
+          schema: { type: string }
       requestBody:
         required: true
         content:
@@ -795,6 +803,10 @@ paths:
       responses:
         "200":
           description: OK
+          headers:
+            ETag:
+              description: "更新後バージョンタグ (W/\"<version>\")。次回リクエスト時の If-Match に使用"
+              schema: { type: string }
           content:
             application/json:
               schema: { $ref: "#/components/schemas/Task" }
@@ -806,6 +818,7 @@ paths:
           description: |-
             タスクが存在しないか、当該ユーザーが**参照権限**を持たない(可視性チェック不通過によりリソース存在を秘匿、HTTP Status Policy / NIST AC-4)。
             なお**公開範囲変更権限**(所有者のみ、ADR-0005)不足の場合は 403 を返す(基本設計書 §6.2.1)。
+        "412": { $ref: "#/components/responses/PreconditionFailed" }
 
   # --- 関係者 ---
   /api/tasks/{id}/stakeholders:

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -325,17 +325,22 @@ const Api = (() => {
   }
 
   /**
-   * PATCH /api/tasks/{id}/visibility — 公開範囲変更(A-17)。
+   * PATCH /api/tasks/{id}/visibility — 公開範囲変更(A-17)。If-Match 必須(ADR-0012)。
    * @param {number} id
+   * @param {string} etag — W/"<version>" 形式の If-Match 値
    * @param {string} visibility — Visibility 値
    * @param {number[]} [stakeholderUserIds] visibility=STAKEHOLDERS のとき指定
    * @returns {Promise<Task>}
    */
-  function changeVisibility(id, visibility, stakeholderUserIds) {
+  function changeVisibility(id, etag, visibility, stakeholderUserIds) {
     /** @type {{visibility: string, stakeholderUserIds?: number[]}} */
     const body = { visibility };
     if (stakeholderUserIds) body.stakeholderUserIds = stakeholderUserIds;
-    return request(`/api/tasks/${id}/visibility`, { method: 'PATCH', body: JSON.stringify(body) });
+    return request(`/api/tasks/${id}/visibility`, {
+      method: 'PATCH',
+      headers: { 'If-Match': etag },
+      body: JSON.stringify(body),
+    });
   }
 
   /**

--- a/web/js/components/app-task-drawer.js
+++ b/web/js/components/app-task-drawer.js
@@ -825,7 +825,9 @@ class AppTaskDrawer extends HTMLElement {
       saveBtn.disabled = true;
       saveBtn.textContent = '保存中...';
       try {
-        await Api.changeVisibility(task.id, newVis, shIds);
+        const etag = this.#etag;
+        if (!etag) return;
+        await Api.changeVisibility(task.id, etag, newVis, shIds);
         // Reload task + stakeholders and re-render
         await this.#loadAndRenderDetail(task.id);
         this.dispatchEvent(
@@ -835,9 +837,15 @@ class AppTaskDrawer extends HTMLElement {
           }),
         );
       } catch (err) {
-        this.#showDetailError(
-          `公開範囲の変更に失敗しました: ${/** @type {any} */ (err).message || ''}`,
-        );
+        if (/** @type {any} */ (err).status === 412) {
+          this.#showDetailError(
+            '他のユーザーがこのタスクを編集しました。一旦閉じてから再度開いてください。',
+          );
+        } else {
+          this.#showDetailError(
+            `公開範囲の変更に失敗しました: ${/** @type {any} */ (err).message || ''}`,
+          );
+        }
         this.#renderDetail();
       }
     });

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/adapter/web/TaskController.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/adapter/web/TaskController.java
@@ -197,12 +197,19 @@ public class TaskController {
   @PreAuthorize("hasAnyRole('TENANT_ADMIN', 'MEMBER')")
   public ResponseEntity<TaskResponse> changeVisibility(
       @PathVariable Long id,
+      @RequestHeader(name = HttpHeaders.IF_MATCH) String ifMatch,
       @RequestBody @Valid ChangeVisibilityRequest request,
       TasksAuthenticationToken token) {
+    Long ifMatchVersion = parseIfMatchVersion(ifMatch);
     Task task =
         changeVisibilityUseCase.execute(
-            id, token.getPrincipal().getId(), request.visibility(), request.stakeholderUserIds());
-    return ResponseEntity.ok(TaskResponse.from(task));
+            id,
+            token.getPrincipal().getId(),
+            request.visibility(),
+            request.stakeholderUserIds(),
+            ifMatchVersion);
+    TaskResponse body = TaskResponse.from(task);
+    return ResponseEntity.ok().header(HttpHeaders.ETAG, etagValue(task.getVersion())).body(body);
   }
 
   @PatchMapping("/{id}/status")

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/usecase/ChangeVisibilityUseCase.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/usecase/ChangeVisibilityUseCase.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import xyz.dgz48.tasks.webapi.audit.domain.AuditEventType;
 import xyz.dgz48.tasks.webapi.audit.usecase.AuditLogPort;
+import xyz.dgz48.tasks.webapi.shared.exception.PreconditionFailedException;
 import xyz.dgz48.tasks.webapi.task.domain.Task;
 import xyz.dgz48.tasks.webapi.task.domain.TaskAuthorizationDomainService;
 import xyz.dgz48.tasks.webapi.task.domain.TaskNotFoundException;
@@ -29,7 +30,11 @@ public class ChangeVisibilityUseCase {
 
   @Transactional
   public Task execute(
-      Long taskId, Long userId, Visibility newVisibility, @Nullable List<Long> stakeholderUserIds) {
+      Long taskId,
+      Long userId,
+      Visibility newVisibility,
+      @Nullable List<Long> stakeholderUserIds,
+      Long ifMatchVersion) {
 
     Task task =
         taskRepository.findById(taskId).orElseThrow(() -> new TaskNotFoundException(taskId));
@@ -41,6 +46,9 @@ public class ChangeVisibilityUseCase {
     }
     if (!taskAuthorizationDomainService.canChangeVisibilityBy(task, userId)) {
       throw new TaskOwnershipException(taskId);
+    }
+    if (!task.getVersion().equals(ifMatchVersion)) {
+      throw new PreconditionFailedException("バージョンが競合しています: task=" + taskId);
     }
 
     Visibility oldVisibility = task.getVisibility();

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/adapter/web/ChangeVisibilityIT.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/adapter/web/ChangeVisibilityIT.java
@@ -17,6 +17,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.web.servlet.MockMvc;
@@ -161,6 +162,7 @@ class ChangeVisibilityIT {
         .perform(
             patch("/api/tasks/" + taskId + "/visibility")
                 .header("X-Tenant-Id", String.valueOf(tenantId))
+                .header(HttpHeaders.IF_MATCH, "W/\"0\"")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"visibility\":\"PRIVATE\"}")
                 .with(authentication(ownerToken)))
@@ -169,11 +171,39 @@ class ChangeVisibilityIT {
   }
 
   @Test
+  void changeVisibility_returns400_whenIfMatchHeaderMissing() throws Exception {
+    mockMvc
+        .perform(
+            patch("/api/tasks/" + taskId + "/visibility")
+                .header("X-Tenant-Id", String.valueOf(tenantId))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"visibility\":\"PRIVATE\"}")
+                .with(authentication(ownerToken)))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("E_VALIDATION"));
+  }
+
+  @Test
+  void changeVisibility_returns412_whenIfMatchVersionStale() throws Exception {
+    mockMvc
+        .perform(
+            patch("/api/tasks/" + taskId + "/visibility")
+                .header("X-Tenant-Id", String.valueOf(tenantId))
+                .header(HttpHeaders.IF_MATCH, "W/\"99\"")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"visibility\":\"PRIVATE\"}")
+                .with(authentication(ownerToken)))
+        .andExpect(status().isPreconditionFailed())
+        .andExpect(jsonPath("$.code").value("E_PRECONDITION_FAILED"));
+  }
+
+  @Test
   void changeVisibility_returns403_whenNotOwner() throws Exception {
     mockMvc
         .perform(
             patch("/api/tasks/" + taskId + "/visibility")
                 .header("X-Tenant-Id", String.valueOf(tenantId))
+                .header(HttpHeaders.IF_MATCH, "W/\"0\"")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"visibility\":\"PRIVATE\"}")
                 .with(authentication(memberToken)))
@@ -187,6 +217,7 @@ class ChangeVisibilityIT {
         .perform(
             patch("/api/tasks/" + taskId + "/visibility")
                 .header("X-Tenant-Id", String.valueOf(tenantId))
+                .header(HttpHeaders.IF_MATCH, "W/\"0\"")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"visibility\":\"PRIVATE\"}")
                 .with(authentication(ownerToken)))
@@ -206,6 +237,7 @@ class ChangeVisibilityIT {
         .perform(
             patch("/api/tasks/" + taskId + "/visibility")
                 .header("X-Tenant-Id", String.valueOf(tenantId))
+                .header(HttpHeaders.IF_MATCH, "W/\"0\"")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(
                     "{\"visibility\":\"STAKEHOLDERS\",\"stakeholderUserIds\":[" + memberId + "]}")
@@ -228,6 +260,7 @@ class ChangeVisibilityIT {
         .perform(
             patch("/api/tasks/" + taskId + "/visibility")
                 .header("X-Tenant-Id", String.valueOf(tenantId))
+                .header(HttpHeaders.IF_MATCH, "W/\"0\"")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{}")
                 .with(authentication(ownerToken)))
@@ -241,6 +274,7 @@ class ChangeVisibilityIT {
         .perform(
             patch("/api/tasks/99999999/visibility")
                 .header("X-Tenant-Id", String.valueOf(tenantId))
+                .header(HttpHeaders.IF_MATCH, "W/\"0\"")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"visibility\":\"PRIVATE\"}")
                 .with(authentication(ownerToken)))
@@ -254,6 +288,7 @@ class ChangeVisibilityIT {
         .perform(
             patch("/api/tasks/" + taskId + "/visibility")
                 .header("X-Tenant-Id", String.valueOf(tenantId))
+                .header(HttpHeaders.IF_MATCH, "W/\"0\"")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(
                     "{\"visibility\":\"STAKEHOLDERS\",\"stakeholderUserIds\":[" + memberId + "]}")
@@ -265,6 +300,7 @@ class ChangeVisibilityIT {
         .perform(
             patch("/api/tasks/" + taskId + "/visibility")
                 .header("X-Tenant-Id", String.valueOf(tenantId))
+                .header(HttpHeaders.IF_MATCH, "W/\"1\"")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"visibility\":\"TENANT\"}")
                 .with(authentication(ownerToken)))

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/adapter/web/ChangeVisibilityIT.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/adapter/web/ChangeVisibilityIT.java
@@ -3,6 +3,7 @@ package xyz.dgz48.tasks.webapi.task.adapter.web;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -167,7 +168,9 @@ class ChangeVisibilityIT {
                 .content("{\"visibility\":\"PRIVATE\"}")
                 .with(authentication(ownerToken)))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.visibility").value("PRIVATE"));
+        .andExpect(jsonPath("$.visibility").value("PRIVATE"))
+        .andExpect(jsonPath("$.version").value(1))
+        .andExpect(header().string(HttpHeaders.ETAG, "W/\"1\""));
   }
 
   @Test

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/usecase/ChangeVisibilityUseCaseTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/usecase/ChangeVisibilityUseCaseTest.java
@@ -21,6 +21,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import xyz.dgz48.tasks.webapi.audit.domain.AuditEventType;
 import xyz.dgz48.tasks.webapi.audit.usecase.AuditLogPort;
+import xyz.dgz48.tasks.webapi.shared.exception.PreconditionFailedException;
 import xyz.dgz48.tasks.webapi.shared.infra.AppZones;
 import xyz.dgz48.tasks.webapi.task.domain.Priority;
 import xyz.dgz48.tasks.webapi.task.domain.Task;
@@ -77,7 +78,7 @@ class ChangeVisibilityUseCaseTest {
   void execute_throwsTaskNotFoundException_whenTaskNotFound() {
     when(taskRepository.findById(TASK_ID)).thenReturn(Optional.empty());
 
-    assertThatThrownBy(() -> useCase.execute(TASK_ID, OWNER_ID, Visibility.PRIVATE, null))
+    assertThatThrownBy(() -> useCase.execute(TASK_ID, OWNER_ID, Visibility.PRIVATE, null, VERSION))
         .isInstanceOf(TaskNotFoundException.class);
   }
 
@@ -89,7 +90,8 @@ class ChangeVisibilityUseCaseTest {
     when(taskAuthorizationDomainService.canBeViewedBy(task, OTHER_USER_ID, List.of()))
         .thenReturn(false);
 
-    assertThatThrownBy(() -> useCase.execute(TASK_ID, OTHER_USER_ID, Visibility.PRIVATE, null))
+    assertThatThrownBy(
+            () -> useCase.execute(TASK_ID, OTHER_USER_ID, Visibility.PRIVATE, null, VERSION))
         .isInstanceOf(TaskNotViewableException.class);
   }
 
@@ -103,8 +105,22 @@ class ChangeVisibilityUseCaseTest {
     when(taskAuthorizationDomainService.canChangeVisibilityBy(task, OTHER_USER_ID))
         .thenReturn(false);
 
-    assertThatThrownBy(() -> useCase.execute(TASK_ID, OTHER_USER_ID, Visibility.PRIVATE, null))
+    assertThatThrownBy(
+            () -> useCase.execute(TASK_ID, OTHER_USER_ID, Visibility.PRIVATE, null, VERSION))
         .isInstanceOf(TaskOwnershipException.class);
+  }
+
+  @Test
+  void execute_throwsPreconditionFailedException_whenVersionMismatch() {
+    Task task = buildTask(Visibility.TENANT);
+    when(taskRepository.findById(TASK_ID)).thenReturn(Optional.of(task));
+    when(stakeholderRepository.findUserIdsByTaskId(TASK_ID, TENANT_ID)).thenReturn(List.of());
+    when(taskAuthorizationDomainService.canBeViewedBy(task, OWNER_ID, List.of())).thenReturn(true);
+    when(taskAuthorizationDomainService.canChangeVisibilityBy(task, OWNER_ID)).thenReturn(true);
+
+    assertThatThrownBy(
+            () -> useCase.execute(TASK_ID, OWNER_ID, Visibility.PRIVATE, null, VERSION + 1))
+        .isInstanceOf(PreconditionFailedException.class);
   }
 
   @Test
@@ -119,7 +135,7 @@ class ChangeVisibilityUseCaseTest {
     when(taskRepository.save(task)).thenReturn(task);
     setupClock();
 
-    Task result = useCase.execute(TASK_ID, OWNER_ID, Visibility.PRIVATE, null);
+    Task result = useCase.execute(TASK_ID, OWNER_ID, Visibility.PRIVATE, null, VERSION);
 
     assertThat(result.getVisibility()).isEqualTo(Visibility.PRIVATE);
     verify(stakeholderRepository).deleteAllByTaskId(TASK_ID, TENANT_ID);
@@ -140,7 +156,7 @@ class ChangeVisibilityUseCaseTest {
     when(taskRepository.save(task)).thenReturn(task);
     setupClock();
 
-    useCase.execute(TASK_ID, OWNER_ID, Visibility.STAKEHOLDERS, newIds);
+    useCase.execute(TASK_ID, OWNER_ID, Visibility.STAKEHOLDERS, newIds, VERSION);
 
     verify(stakeholderRepository)
         .replaceAll(eq(TASK_ID), eq(TENANT_ID), eq(newIds), eq(OWNER_ID), any(LocalDateTime.class));
@@ -161,7 +177,7 @@ class ChangeVisibilityUseCaseTest {
     when(taskRepository.save(task)).thenReturn(task);
     setupClock();
 
-    useCase.execute(TASK_ID, OWNER_ID, Visibility.TENANT, null);
+    useCase.execute(TASK_ID, OWNER_ID, Visibility.TENANT, null, VERSION);
 
     verify(stakeholderRepository, never()).deleteAllByTaskId(any(), any());
     verify(stakeholderRepository, never()).replaceAll(any(), any(), any(), any(), any());
@@ -180,7 +196,7 @@ class ChangeVisibilityUseCaseTest {
     when(taskRepository.save(task)).thenReturn(task);
     setupClock();
 
-    useCase.execute(TASK_ID, OWNER_ID, Visibility.PRIVATE, null);
+    useCase.execute(TASK_ID, OWNER_ID, Visibility.PRIVATE, null, VERSION);
 
     verify(auditLogPort, never())
         .record(eq(AuditEventType.STAKEHOLDER_PURGED), any(), any(), any());


### PR DESCRIPTION
## Summary

- `PATCH /api/tasks/{id}/visibility` に `If-Match` ヘッダ必須の楽観ロックを付与(ADR-0012 適用基準 / #680 amendment に基づく)
- visibility 変更はアクセス制御変更を伴う高リスク操作のため、silent 後勝ち上書きによる「見えるべき人が見えない / 見えてはいけない人が見える」状態を防止する
- `/status` 同様に低頻度変更のため誤検知 412 コストはほぼゼロ

## Changes

### Backend
- `ChangeVisibilityUseCase.execute()` に `ifMatchVersion` 引数追加 + version 不一致時 `PreconditionFailedException`(→ 412)
- `TaskController.changeVisibility()` に `@RequestHeader(IF_MATCH)` 追加・パース・usecase へ渡す。レスポンスに `ETag` ヘッダを付与

### OpenAPI
- `/api/tasks/{id}/visibility` PATCH: `If-Match` ヘッダ必須パラメータ追加、`412` レスポンス追加、200 に `ETag` ヘッダ追加、楽観ロック説明追記

### Frontend
- `Api.changeVisibility(id, etag, visibility, stakeholderUserIds)` にシグネチャ変更(etag 追加)・`If-Match` ヘッダ送出
- `app-task-drawer.js`: `this.#etag` を渡す + 412 時に「他のユーザーが編集しました」メッセージ表示(delete / patchTask と同じパターン)

### Tests
- `ChangeVisibilityUseCaseTest`: 全 `execute()` 呼び出しにバージョン引数追加、`execute_throwsPreconditionFailedException_whenVersionMismatch` 追加
- `ChangeVisibilityIT`: 全 PATCH に `If-Match: W/"0"` 追加、多段テストは `W/"1"` 対応、`returns400_whenIfMatchHeaderMissing` / `returns412_whenIfMatchVersionStale` 追加
- `ChangeVisibilityIT`: `changeVisibility_returns200_andUpdatesVisibility` に `$.version=1` / `ETag: W/"1"` アサーション追加(ADR-0012 §6 受入基準パターン統一)

## Test plan

- [x] `./gradlew :webapi:check` 通過確認(本 PR 作成前に実施済み — BUILD SUCCESSFUL)
- [x] `npx biome ci .` / `npx tsc --noEmit` / `npm run html-validate` 通過確認(実施済み)
- [x] 古い version で 412、一致版で 200 + ETag 返却を IT で確認済み(`ChangeVisibilityIT`)

## 未対応レビュー

| 指摘 | 内容 | 対応状況 |
|---|---|---|
| (なし) | — | — |

Closes #683

🤖 Generated with [Claude Code](https://claude.com/claude-code)
