### PR TITLE
fix(task): GET/PATCH /api/tasks/{id} レスポンスに owner/assignee/editable/deletable を追加

### DIFF
--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/adapter/web/TaskController.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/adapter/web/TaskController.java
@@ -87,10 +87,11 @@ public class TaskController {
     if (tenantId == null) {
       throw new ResponseStatusException(HttpStatus.FORBIDDEN, "テナントが選択されていません");
     }
+    Long userId = token.getPrincipal().getId();
     Task task =
         createTaskUseCase.execute(
             tenantId,
-            token.getPrincipal().getId(),
+            userId,
             request.title(),
             request.description(),
             request.priority(),
@@ -103,7 +104,8 @@ public class TaskController {
             .path("/{id}")
             .buildAndExpand(task.getId())
             .toUri();
-    return ResponseEntity.created(location).body(TaskResponse.from(task));
+    return ResponseEntity.created(location)
+        .body(TaskResponse.from(task, userId, loadUserMap(task)));
   }
 
   /**
@@ -157,8 +159,9 @@ public class TaskController {
   @PreAuthorize("hasAnyRole('TENANT_ADMIN', 'MEMBER')")
   public ResponseEntity<TaskResponse> getTask(
       @PathVariable Long id, TasksAuthenticationToken token) {
-    Task task = getTaskUseCase.execute(id, token.getPrincipal().getId());
-    TaskResponse body = TaskResponse.from(task);
+    Long userId = token.getPrincipal().getId();
+    Task task = getTaskUseCase.execute(id, userId);
+    TaskResponse body = TaskResponse.from(task, userId, loadUserMap(task));
     return ResponseEntity.ok().header(HttpHeaders.ETAG, etagValue(task.getVersion())).body(body);
   }
 
@@ -177,8 +180,9 @@ public class TaskController {
             request.priority(),
             request.assigneeId(),
             request.dueDate());
-    Task task = updateTaskUseCase.execute(id, token.getPrincipal().getId(), cmd, ifMatchVersion);
-    TaskResponse body = TaskResponse.from(task);
+    Long userId = token.getPrincipal().getId();
+    Task task = updateTaskUseCase.execute(id, userId, cmd, ifMatchVersion);
+    TaskResponse body = TaskResponse.from(task, userId, loadUserMap(task));
     return ResponseEntity.ok().header(HttpHeaders.ETAG, etagValue(task.getVersion())).body(body);
   }
 
@@ -201,14 +205,11 @@ public class TaskController {
       @RequestBody @Valid ChangeVisibilityRequest request,
       TasksAuthenticationToken token) {
     Long ifMatchVersion = parseIfMatchVersion(ifMatch);
+    Long userId = token.getPrincipal().getId();
     Task task =
         changeVisibilityUseCase.execute(
-            id,
-            token.getPrincipal().getId(),
-            request.visibility(),
-            request.stakeholderUserIds(),
-            ifMatchVersion);
-    TaskResponse body = TaskResponse.from(task);
+            id, userId, request.visibility(), request.stakeholderUserIds(), ifMatchVersion);
+    TaskResponse body = TaskResponse.from(task, userId, loadUserMap(task));
     return ResponseEntity.ok().header(HttpHeaders.ETAG, etagValue(task.getVersion())).body(body);
   }
 
@@ -218,8 +219,9 @@ public class TaskController {
       @PathVariable Long id,
       @RequestBody @Valid ChangeTaskStatusRequest request,
       TasksAuthenticationToken token) {
-    Task task = changeTaskStatusUseCase.execute(id, token.getPrincipal().getId(), request.status());
-    return ResponseEntity.ok(TaskResponse.from(task));
+    Long userId = token.getPrincipal().getId();
+    Task task = changeTaskStatusUseCase.execute(id, userId, request.status());
+    return ResponseEntity.ok(TaskResponse.from(task, userId, loadUserMap(task)));
   }
 
   @GetMapping("/{id}/stakeholders")
@@ -249,6 +251,10 @@ public class TaskController {
       @PathVariable Long taskId, @PathVariable Long userId, TasksAuthenticationToken token) {
     removeStakeholderUseCase.execute(taskId, token.getPrincipal().getId(), userId);
     return ResponseEntity.noContent().build();
+  }
+
+  private Map<Long, UserJpaEntity> loadUserMap(Task task) {
+    return loadUserMap(List.of(task));
   }
 
   private Map<Long, UserJpaEntity> loadUserMap(List<Task> tasks) {

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/adapter/web/dto/TaskResponse.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/adapter/web/dto/TaskResponse.java
@@ -2,12 +2,14 @@ package xyz.dgz48.tasks.webapi.task.adapter.web.dto;
 
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
+import java.util.Map;
 import org.jspecify.annotations.Nullable;
 import xyz.dgz48.tasks.webapi.shared.infra.AppZones;
 import xyz.dgz48.tasks.webapi.task.domain.Priority;
 import xyz.dgz48.tasks.webapi.task.domain.Task;
 import xyz.dgz48.tasks.webapi.task.domain.TaskStatus;
 import xyz.dgz48.tasks.webapi.task.domain.Visibility;
+import xyz.dgz48.tasks.webapi.user.adapter.persistence.UserJpaEntity;
 
 public record TaskResponse(
     Long id,
@@ -17,14 +19,34 @@ public record TaskResponse(
     Priority priority,
     TaskStatus status,
     Visibility visibility,
-    @Nullable Long assigneeId,
+    UserSummaryResponse owner,
+    @Nullable UserSummaryResponse assignee,
     LocalDate dueDate,
     @Nullable OffsetDateTime completedAt,
     OffsetDateTime createdAt,
     OffsetDateTime updatedAt,
-    Long version) {
+    Long version,
+    boolean editable,
+    boolean deletable) {
 
-  public static TaskResponse from(Task task) {
+  public static TaskResponse from(Task task, Long currentUserId, Map<Long, UserJpaEntity> userMap) {
+    UserJpaEntity ownerEntity = userMap.get(task.getOwnerId());
+    UserSummaryResponse owner =
+        ownerEntity != null
+            ? new UserSummaryResponse(ownerEntity.getId(), ownerEntity.getFullName())
+            : new UserSummaryResponse(task.getOwnerId(), "");
+
+    @Nullable UserSummaryResponse assignee = null;
+    if (task.getAssigneeId() != null) {
+      UserJpaEntity assigneeEntity = userMap.get(task.getAssigneeId());
+      assignee =
+          assigneeEntity != null
+              ? new UserSummaryResponse(assigneeEntity.getId(), assigneeEntity.getFullName())
+              : new UserSummaryResponse(task.getAssigneeId(), "");
+    }
+
+    boolean isOwner = task.getOwnerId().equals(currentUserId);
+
     return new TaskResponse(
         task.getId(),
         task.getTenantId(),
@@ -33,13 +55,16 @@ public record TaskResponse(
         task.getPriority(),
         task.getStatus(),
         task.getVisibility(),
-        task.getAssigneeId(),
+        owner,
+        assignee,
         task.getDueDate(),
         task.getCompletedAt() != null
             ? task.getCompletedAt().atZone(AppZones.JST).toOffsetDateTime()
             : null,
         task.getCreatedAt().atZone(AppZones.JST).toOffsetDateTime(),
         task.getUpdatedAt().atZone(AppZones.JST).toOffsetDateTime(),
-        task.getVersion());
+        task.getVersion(),
+        isOwner,
+        isOwner);
   }
 }

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/adapter/web/CreateTaskIT.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/adapter/web/CreateTaskIT.java
@@ -233,7 +233,7 @@ class CreateTaskIT {
 
       String body = result.getResponse().getContentAsString();
       // task ID を取り出してステークホルダーが登録されたか確認
-      String taskIdStr = body.replaceAll(".*\"id\":(\\d+).*", "$1");
+      String taskIdStr = body.replaceAll("\\{\"id\":(\\d+),.*", "$1");
       Long taskId = Long.parseLong(taskIdStr);
 
       txTemplate.execute(
@@ -272,7 +272,7 @@ class CreateTaskIT {
                   .with(authentication(authToken)))
           .andExpect(status().isCreated())
           .andExpect(jsonPath("$.visibility").value("PRIVATE"))
-          .andExpect(jsonPath("$.assigneeId").value(otherUserId));
+          .andExpect(jsonPath("$.assignee.id").value(otherUserId));
     }
   }
 
@@ -482,7 +482,7 @@ class CreateTaskIT {
               .andReturn();
 
       String body = result.getResponse().getContentAsString();
-      String taskIdStr = body.replaceAll(".*\"id\":(\\d+).*", "$1");
+      String taskIdStr = body.replaceAll("\\{\"id\":(\\d+),.*", "$1");
       Long taskId = Long.parseLong(taskIdStr);
 
       txTemplate.execute(

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/adapter/web/PatchTaskIT.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/adapter/web/PatchTaskIT.java
@@ -220,7 +220,11 @@ class PatchTaskIT {
         .andExpect(jsonPath("$.title").value("Updated title"))
         .andExpect(jsonPath("$.description").value("Original description"))
         .andExpect(jsonPath("$.version").value(1))
-        .andExpect(header().string(HttpHeaders.ETAG, "W/\"1\""));
+        .andExpect(header().string(HttpHeaders.ETAG, "W/\"1\""))
+        .andExpect(jsonPath("$.owner.id").value(userId))
+        .andExpect(jsonPath("$.owner.fullName").value("PATCH 太郎"))
+        .andExpect(jsonPath("$.editable").value(true))
+        .andExpect(jsonPath("$.deletable").value(true));
   }
 
   @Test

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/adapter/web/TaskControllerWebMvcTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/adapter/web/TaskControllerWebMvcTest.java
@@ -138,6 +138,8 @@ class TaskControllerWebMvcTest {
   void get_returns200WithTaskJson() throws Exception {
     Task task = buildTask(TaskStatus.NOT_STARTED);
     when(getTaskUseCase.execute(1L, USER_ID)).thenReturn(task);
+    BDDMockito.given(userRepository.findAllById(ArgumentMatchers.anyCollection()))
+        .willReturn(List.of());
 
     mockMvc
         .perform(get("/api/tasks/1"))
@@ -147,7 +149,44 @@ class TaskControllerWebMvcTest {
         .andExpect(jsonPath("$.status").value("NOT_STARTED"))
         .andExpect(jsonPath("$.priority").value("MEDIUM"))
         .andExpect(jsonPath("$.visibility").value("TENANT"))
-        .andExpect(jsonPath("$.completedAt").doesNotExist());
+        .andExpect(jsonPath("$.completedAt").doesNotExist())
+        .andExpect(jsonPath("$.owner.id").value(USER_ID))
+        .andExpect(jsonPath("$.assignee").doesNotExist())
+        .andExpect(jsonPath("$.editable").value(true))
+        .andExpect(jsonPath("$.deletable").value(true));
+  }
+
+  @Test
+  @WithMockMember
+  void get_returns200_withEditableFalse_whenNonOwner() throws Exception {
+    long otherOwnerId = 999L;
+    Task task =
+        new Task(
+            1L,
+            100L,
+            "Test task",
+            null,
+            TaskStatus.NOT_STARTED,
+            Priority.MEDIUM,
+            Visibility.TENANT,
+            otherOwnerId,
+            null,
+            LocalDate.of(2026, 6, 1),
+            null,
+            null,
+            LocalDateTime.of(2026, 5, 31, 9, 0),
+            LocalDateTime.of(2026, 5, 31, 9, 0),
+            VERSION);
+    when(getTaskUseCase.execute(1L, USER_ID)).thenReturn(task);
+    BDDMockito.given(userRepository.findAllById(ArgumentMatchers.anyCollection()))
+        .willReturn(List.of());
+
+    mockMvc
+        .perform(get("/api/tasks/1"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.owner.id").value(otherOwnerId))
+        .andExpect(jsonPath("$.editable").value(false))
+        .andExpect(jsonPath("$.deletable").value(false));
   }
 
   @Test
@@ -177,6 +216,8 @@ class TaskControllerWebMvcTest {
   void changeStatus_returns200WithCompletedAt_whenDone() throws Exception {
     Task done = buildDoneTask();
     when(changeTaskStatusUseCase.execute(1L, USER_ID, TaskStatus.DONE)).thenReturn(done);
+    BDDMockito.given(userRepository.findAllById(ArgumentMatchers.anyCollection()))
+        .willReturn(List.of());
 
     mockMvc
         .perform(
@@ -265,6 +306,8 @@ class TaskControllerWebMvcTest {
   void get_returns200_whenTenantAdmin() throws Exception {
     Task task = buildTask(TaskStatus.NOT_STARTED);
     when(getTaskUseCase.execute(1L, USER_ID)).thenReturn(task);
+    BDDMockito.given(userRepository.findAllById(ArgumentMatchers.anyCollection()))
+        .willReturn(List.of());
 
     mockMvc
         .perform(get("/api/tasks/1"))
@@ -277,6 +320,8 @@ class TaskControllerWebMvcTest {
   void changeStatus_returns200_whenTenantAdmin() throws Exception {
     Task done = buildDoneTask();
     when(changeTaskStatusUseCase.execute(1L, USER_ID, TaskStatus.DONE)).thenReturn(done);
+    BDDMockito.given(userRepository.findAllById(ArgumentMatchers.anyCollection()))
+        .willReturn(List.of());
 
     mockMvc
         .perform(
@@ -374,6 +419,8 @@ class TaskControllerWebMvcTest {
                 ArgumentMatchers.any(),
                 ArgumentMatchers.any()))
         .willReturn(created);
+    BDDMockito.given(userRepository.findAllById(ArgumentMatchers.anyCollection()))
+        .willReturn(List.of());
 
     mockMvc
         .perform(
@@ -468,6 +515,8 @@ class TaskControllerWebMvcTest {
                 ArgumentMatchers.any(),
                 ArgumentMatchers.any()))
         .willReturn(created);
+    BDDMockito.given(userRepository.findAllById(ArgumentMatchers.anyCollection()))
+        .willReturn(List.of());
 
     mockMvc
         .perform(


### PR DESCRIPTION
## 概要

Issue #678 の修正。`TaskResponse` から `assigneeId` を削除し、OpenAPI `TaskDetail` スキーマが required としている 4 フィールドを追加する。

- `owner`: `UserSummary` — タスク所有者のユーザー情報
- `assignee`: `UserSummary | null` — 担当者のユーザー情報（旧 `assigneeId` を置換）
- `editable`: `boolean` — 所有者のみ `true`（ADR-0005）
- `deletable`: `boolean` — 所有者のみ `true`（ADR-0005）

影響エンドポイント: `POST /api/tasks`、`GET /api/tasks/{id}`、`PATCH /api/tasks/{id}`、`PATCH /api/tasks/{id}/visibility`、`PATCH /api/tasks/{id}/status`

## 実装方針

`TaskListItemResponse` と同じパターンを採用。`user.adapter.persistence` は `@NamedInterface` で公開済みのため、モジュール境界違反なし。`TaskController` に `loadUserMap(Task)` オーバーロードを追加し、単一タスクのユーザー解決を既存の `loadUserMap(List<Task>)` に委譲する。

## テスト

- `TaskControllerWebMvcTest`: 所有者ケースで `owner.id / editable: true / deletable: true` のアサーション追加、非所有者ケースで `editable: false / deletable: false` の新規テスト追加
- `PatchTaskIT`: `patchTask_updatesTitle_andReturnsNewEtag` で `owner.id / owner.fullName / editable: true` のアサーション追加（DB からの実ユーザー名解決を検証）
- `CreateTaskIT`: `$.assigneeId` → `$.assignee.id` に更新、タスク ID 抽出正規表現を `owner.id` との衝突を避けるよう修正

## Test plan

- [x] `./gradlew :webapi:check` 全 397 テスト通過
- [x] spotless フォーマットチェック通過
- [x] `ModularityTests.verifyModularity()` 通過（`user.adapter.persistence` は @NamedInterface）

Closes #678

🤖 Generated with [Claude Code](https://claude.com/claude-code)