### PR TITLE
impl(security): /api/auth/me から activeTenantId を削除しフロント遷移ゲートを client 解決に置換 (ADR-0034) (#691)

### DIFF
--- a/web/js/api.js
+++ b/web/js/api.js
@@ -87,7 +87,6 @@
 /**
  * @typedef {object} MeResponse
  * @property {{ id: number, fullName: string }} user
- * @property {number|null} activeTenantId
  * @property {TenantRef[]} tenants
  */
 
@@ -111,6 +110,27 @@ const Api = (() => {
     } else {
       sessionStorage.removeItem('tenantId');
     }
+  }
+
+  /**
+   * /me のテナント一覧からアクティブテナント ID を解決する(ADR-0034 §5)。
+   * 1. sessionStorage の tenantId が一覧に含まれる → 採用
+   * 2. 0 件 → null(テナント未所属)
+   * 3. 1 件 → 先頭を自動採用し sessionStorage に保存
+   * 4. 複数かつ有効な保存値なし → null(テナント選択 UI を表示)
+   * @param {Array<{id: number}>} tenants
+   * @returns {number|null}
+   */
+  function resolveActiveTenant(tenants) {
+    if (_tenantId !== null) {
+      const id = Number(_tenantId);
+      if (tenants.some((t) => t.id === id)) return id;
+    }
+    if (tenants.length === 1) {
+      setTenantId(String(tenants[0].id));
+      return tenants[0].id;
+    }
+    return null;
   }
 
   /**
@@ -377,6 +397,7 @@ const Api = (() => {
 
   return {
     setTenantId,
+    resolveActiveTenant,
     request,
     requestRaw,
     getMe,

--- a/web/js/components/app-tenant-switcher.js
+++ b/web/js/components/app-tenant-switcher.js
@@ -1,5 +1,5 @@
 // <app-tenant-switcher> — dropdown or chip for switching tenants.
-// Method: setData(tenants, activeTenantId)
+// Method: setData(tenants, activeTenantId) where activeTenantId is resolved by the caller (ADR-0034)
 // Depends on: Api (Api.selectTenant, Api.setTenantId), Bootstrap 5
 
 const _tsBadgeTpl = document.createElement('template');
@@ -80,10 +80,6 @@ class AppTenantSwitcher extends HTMLElement {
     this.classList.remove('d-none');
 
     if (tenants.length === 1) {
-      if (activeTenantId === null) {
-        _switchTenant(tenants[0].id);
-        return;
-      }
       const chip = /** @type {HTMLElement} */ (
         /** @type {DocumentFragment} */ (_tsBadgeTpl.content.cloneNode(true)).firstElementChild
       );

--- a/web/js/index.js
+++ b/web/js/index.js
@@ -19,9 +19,9 @@ async function main() {
 
   try {
     const me = await Api.getMe();
+    const activeTenantId = Api.resolveActiveTenant(me.tenants);
 
-    if (me.activeTenantId !== null) {
-      Api.setTenantId(String(me.activeTenantId));
+    if (activeTenantId !== null) {
       window.location.replace('tasks.html');
       return;
     }
@@ -32,7 +32,7 @@ async function main() {
 
     /** @type {AppTenantSwitcherElement} */ (mustQuery(document, '#tenant-switcher')).setData(
       me.tenants,
-      me.activeTenantId,
+      null,
     );
   } catch (err) {
     /** @type {HTMLElement} */ (mustQuery(document, '#user-info')).textContent =

--- a/web/js/tasks.js
+++ b/web/js/tasks.js
@@ -337,19 +337,20 @@ async function main() {
   /** @type {HTMLElement} */ (mustQuery(document, '#user-avatar')).textContent =
     displayName.slice(0, 1) || '?';
 
-  if (!me.activeTenantId) {
+  const activeTenantId = Api.resolveActiveTenant(me.tenants);
+
+  if (activeTenantId === null) {
     window.location.replace('index.html');
     return;
   }
-  Api.setTenantId(String(me.activeTenantId));
 
   /** @type {AppTenantSwitcherElement} */ (mustQuery(document, '#tenant-switcher')).setData(
     me.tenants,
-    me.activeTenantId,
+    activeTenantId,
   );
 
   // Reflect Tenant Admin role in sidebar
-  const activeTenant = me.tenants?.find((t) => t.id === me.activeTenantId);
+  const activeTenant = me.tenants?.find((t) => t.id === activeTenantId);
   if (activeTenant?.role === 'TENANT_ADMIN') {
     document.body.classList.add('role-admin');
   }

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/security/adapter/web/MeController.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/security/adapter/web/MeController.java
@@ -2,10 +2,8 @@ package xyz.dgz48.tasks.webapi.security.adapter.web;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.jspecify.annotations.Nullable;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 import xyz.dgz48.tasks.webapi.security.adapter.web.dto.MeResponse;
 import xyz.dgz48.tasks.webapi.security.adapter.web.dto.TenantSummaryDto;
@@ -14,10 +12,10 @@ import xyz.dgz48.tasks.webapi.security.domain.TasksPrincipal;
 import xyz.dgz48.tasks.webapi.security.usecase.GetMeUseCase;
 
 /**
- * GET /api/auth/me — ログインユーザー情報・所属テナント一覧。
+ * GET /api/auth/me — ログインユーザー情報・所属テナント一覧({@code joined_at} 昇順)。
  *
- * <p>TenantContextFilter の免除パス({@code /api/auth/**})に該当するため X-Tenant-Id ヘッダは不要。 activeTenantId は
- * X-Tenant-Id 指定時にそれを返し、未指定時は null とする(自動解決 ADR-0016 は /me では行わない)。
+ * <p>TenantContextFilter の免除パス({@code /api/auth/**})に該当するため X-Tenant-Id ヘッダは不要。アクティブテナントの SSOT
+ * はクライアント({@code sessionStorage})であり、サーバは状態を保持しない(ADR-0034)。
  */
 @RestController
 @RequiredArgsConstructor
@@ -26,9 +24,7 @@ public class MeController {
   private final GetMeUseCase getMeUseCase;
 
   @GetMapping("/api/auth/me")
-  public MeResponse me(
-      @AuthenticationPrincipal TasksPrincipal principal,
-      @RequestHeader(name = "X-Tenant-Id", required = false) @Nullable Long activeTenantId) {
+  public MeResponse me(@AuthenticationPrincipal TasksPrincipal principal) {
 
     List<TenantSummaryDto> tenants =
         getMeUseCase.findTenants(principal.getId()).stream().map(TenantSummaryDto::from).toList();
@@ -41,6 +37,6 @@ public class MeController {
             principal.getFullNameKana(),
             principal.getDepartmentName());
 
-    return new MeResponse(userProfile, tenants, activeTenantId);
+    return new MeResponse(userProfile, tenants);
   }
 }

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/security/adapter/web/dto/MeResponse.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/security/adapter/web/dto/MeResponse.java
@@ -1,7 +1,5 @@
 package xyz.dgz48.tasks.webapi.security.adapter.web.dto;
 
 import java.util.List;
-import org.jspecify.annotations.Nullable;
 
-public record MeResponse(
-    UserProfileDto user, List<TenantSummaryDto> tenants, @Nullable Long activeTenantId) {}
+public record MeResponse(UserProfileDto user, List<TenantSummaryDto> tenants) {}

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/MeControllerWebMvcTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/MeControllerWebMvcTest.java
@@ -6,7 +6,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.util.List;
-import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
@@ -64,20 +63,24 @@ class MeControllerWebMvcTest {
         .andExpect(jsonPath("$.tenants[0].code").value("acme"))
         .andExpect(jsonPath("$.tenants[0].name").value("Acme Corp"))
         .andExpect(jsonPath("$.tenants[0].role").value("MEMBER"))
-        .andExpect(jsonPath("$.activeTenantId").isEmpty());
+        .andExpect(jsonPath("$.activeTenantId").doesNotExist());
   }
 
   @Test
   @WithMockJwt
-  void withXTenantIdHeader_returnsActiveTenantId() throws Exception {
-    // TenantContextFilter validates X-Tenant-Id membership before the controller runs
-    when(tenantMembershipPort.findActiveRole(1L, 42L)).thenReturn(Optional.of(TenantRole.MEMBER));
-    when(getMeUseCase.findTenants(1L)).thenReturn(List.of());
+  void multipleTenants_returnedInUseCaseOrder() throws Exception {
+    when(getMeUseCase.findTenants(1L))
+        .thenReturn(
+            List.of(
+                new TenantSummaryInfo(10L, "alpha", "Alpha", TenantRole.MEMBER),
+                new TenantSummaryInfo(20L, "beta", "Beta", TenantRole.TENANT_ADMIN)));
 
     mockMvc
-        .perform(get("/api/auth/me").header("X-Tenant-Id", "42"))
+        .perform(get("/api/auth/me"))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.activeTenantId").value(42));
+        .andExpect(jsonPath("$.tenants.length()").value(2))
+        .andExpect(jsonPath("$.tenants[0].id").value(10))
+        .andExpect(jsonPath("$.tenants[1].id").value(20));
   }
 
   @Test
@@ -89,6 +92,6 @@ class MeControllerWebMvcTest {
         .perform(get("/api/auth/me"))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.tenants").isEmpty())
-        .andExpect(jsonPath("$.activeTenantId").isEmpty());
+        .andExpect(jsonPath("$.activeTenantId").doesNotExist());
   }
 }

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/MeIT.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/MeIT.java
@@ -107,7 +107,7 @@ class MeIT {
         .andExpect(jsonPath("$.user.departmentName").value("開発部"))
         .andExpect(jsonPath("$.tenants").isArray())
         .andExpect(jsonPath("$.tenants").isEmpty())
-        .andExpect(jsonPath("$.activeTenantId").isEmpty());
+        .andExpect(jsonPath("$.activeTenantId").doesNotExist());
   }
 
   @Test
@@ -122,7 +122,7 @@ class MeIT {
         .andExpect(jsonPath("$.tenants[0].code").value("me-t1"))
         .andExpect(jsonPath("$.tenants[0].name").value("MeテナントA"))
         .andExpect(jsonPath("$.tenants[0].role").value("MEMBER"))
-        .andExpect(jsonPath("$.activeTenantId").isEmpty());
+        .andExpect(jsonPath("$.activeTenantId").doesNotExist());
   }
 
   @Test
@@ -138,17 +138,6 @@ class MeIT {
         .andExpect(jsonPath("$.tenants[0].role").value("MEMBER"))
         .andExpect(jsonPath("$.tenants[1].id").value(tenantId2))
         .andExpect(jsonPath("$.tenants[1].role").value("TENANT_ADMIN"));
-  }
-
-  @Test
-  void withXTenantIdHeader_returnsActiveTenantId() throws Exception {
-    insertUserTenant(userId, tenantId1, "MEMBER", LocalDateTime.of(2026, 1, 1, 0, 0));
-
-    mockMvc
-        .perform(
-            get("/api/auth/me").with(authentication(authToken)).header("X-Tenant-Id", tenantId1))
-        .andExpect(status().isOk())
-        .andExpect(jsonPath("$.activeTenantId").value(tenantId1));
   }
 
   private void insertUserTenant(Long uid, Long tid, String role, LocalDateTime joinedAt) {


### PR DESCRIPTION
## Summary

- `MeResponse` から `activeTenantId` フィールドを削除(OpenAPI は #690 で更新済み)
- `MeController` から `X-Tenant-Id` echo 引数を撤去、Javadoc を ADR-0034 準拠に更新
- `api.js` に `Api.resolveActiveTenant(tenants)` を追加(ADR-0034 §5 の 4 ステップ解決: 保存値検証 → 0件未所属 → 1件自動採用 → 複数+保存なし→セレクタ表示)
- `index.js` / `tasks.js` の `me.activeTenantId` 依存を `resolveActiveTenant()` 呼び出しに置換
- `app-tenant-switcher.js` の `activeTenantId === null` 自動切替分岐(呼び出し元で解決済みのため dead code)を削除

## Test plan

- [x] `MeControllerWebMvcTest`: `activeTenantId` アサーションを `doesNotExist()` に修正、X-Tenant-Id echo テスト削除、`multipleTenants_returnedInUseCaseOrder` 追加
- [x] `MeIT`: `activeTenantId` アサーション修正、`withXTenantIdHeader_returnsActiveTenantId` 削除(`joined_at` 順序は既存の `multipleTenants_returnsAllInJoinedAtOrder` が担保)
- [x] `./gradlew :webapi:check` green(Spotless / NullAway / ErrorProne / JaCoCo 80%+ / tests)
- [x] `npx biome ci .` / `html-validate` / `tsc --noEmit` green

## 関連

Closes #691 / ADR-0034 / PR #690(OpenAPI 更新)

🤖 Generated with [Claude Code](https://claude.com/claude-code)