### PR TITLE
refactor(security/infra): RDS IAM DataSource を DB_HOST 単一注入に整理 — URL パース/withSsl 廃止

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,7 +1,8 @@
 # .env.local.example — copy to .env.local and fill in real values (DO NOT commit .env.local)
 # Usage: cp .env.local.example .env.local && source .env.local && ./gradlew :webapi:bootRun
 
-export DATASOURCE_URL='jdbc:mysql://localhost:3306/tasks?useSSL=false&allowPublicKeyRetrieval=true&connectionTimeZone=SERVER&forceConnectionTimeZoneToSession=true'
+export DB_HOST=localhost
+# export DB_PORT=3306  # optional, defaults to 3306
 export DATASOURCE_USERNAME=tasks_webapi
 export DATASOURCE_PASSWORD=
 export OIDC_ISSUER_URI=http://localhost:18080/realms/tasks

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -247,7 +247,7 @@ jobs:
             -e AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE \
             -e AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY \
             -e AWS_DEFAULT_REGION=ap-northeast-1 \
-            -e SPRING_DATASOURCE_URL="jdbc:mysql://smoke-mysql:3306/tasks?sslMode=REQUIRED&connectionTimeZone=SERVER&forceConnectionTimeZoneToSession=true" \
+            -e DB_HOST=smoke-mysql \
             -e SPRING_DATASOURCE_USERNAME=tasks_webapi \
             -e OIDC_ISSUER_URI=http://localhost:18080/realms/tasks \
             "${ECR_REGISTRY}/tasks-webapi:${VERSION}")

--- a/.github/workflows/webapi-native-build.yml
+++ b/.github/workflows/webapi-native-build.yml
@@ -71,7 +71,7 @@ jobs:
     env:
       # processAot starts the production Spring context (Flyway + Hibernate validate).
       # These env vars are picked up by the aotEnv() fallback in webapi/build.gradle.
-      DATASOURCE_URL: "jdbc:mysql://localhost:3306/tasks?useSSL=false&allowPublicKeyRetrieval=true&connectionTimeZone=SERVER&forceConnectionTimeZoneToSession=true"
+      DB_HOST: "localhost"
       DATASOURCE_USERNAME: tasks_webapi
       DATASOURCE_PASSWORD: tasks_webapi
       # Spring Security JwtDecoder is lazy (no network call at context startup).

--- a/docs/dev/local-setup.md
+++ b/docs/dev/local-setup.md
@@ -137,7 +137,7 @@ cp .env.local.example .env.local
 ```bash
 # リポジトリルートで実行
 cat > .env.local << 'EOF'
-export DATASOURCE_URL=jdbc:mysql://localhost:3306/tasks?useSSL=false&allowPublicKeyRetrieval=true&connectionTimeZone=SERVER&forceConnectionTimeZoneToSession=true
+export DB_HOST=localhost
 export DATASOURCE_USERNAME=tasks_webapi
 export DATASOURCE_PASSWORD=tasks_webapi
 export OIDC_ISSUER_URI=http://localhost:18080/realms/tasks
@@ -148,7 +148,7 @@ EOF
 
 | 変数名 | ローカル開発値 | 説明 |
 |--------|----------------|------|
-| `DATASOURCE_URL` | `jdbc:mysql://localhost:3306/tasks?useSSL=false&allowPublicKeyRetrieval=true&connectionTimeZone=SERVER&forceConnectionTimeZoneToSession=true` | MySQL JDBC URL |
+| `DB_HOST` | `localhost` | DB ホスト名。JDBC URL テンプレートは `application.yml` にハードコード済み |
 | `DATASOURCE_USERNAME` | `tasks_webapi` | DB ユーザー名 |
 | `DATASOURCE_PASSWORD` | `tasks_webapi` | DB パスワード |
 | `OIDC_ISSUER_URI` | `http://localhost:18080/realms/tasks` | Keycloak realm の issuer URI |
@@ -350,7 +350,7 @@ docker compose -f docker-compose.local.yml stop
 
 ```bash
 docker run --rm \
-  -e DATASOURCE_URL="jdbc:mysql://host.docker.internal:3306/tasks?useSSL=false&allowPublicKeyRetrieval=true&connectionTimeZone=SERVER&forceConnectionTimeZoneToSession=true" \
+  -e DB_HOST=host.docker.internal \
   -e DATASOURCE_USERNAME=tasks_webapi \
   -e DATASOURCE_PASSWORD=tasks_webapi \
   -e OIDC_ISSUER_URI=http://host.docker.internal:18080/realms/tasks \
@@ -410,8 +410,8 @@ sudo systemctl stop mysql
 # または docker-compose.local.yml の ports を変更
 # ports:
 #   - "3307:3306"  # 3307 に変更
-# その場合 .env.local の DATASOURCE_URL も更新すること
-# DATASOURCE_URL=jdbc:mysql://localhost:3307/tasks?...
+# その場合 .env.local の DB_PORT も更新すること
+# DB_PORT=3307
 ```
 
 ---
@@ -450,8 +450,8 @@ ls keycloak/realm-export/tasks-realm.json
 |------|----------|------|
 | MySQL が起動していない | `docker compose ps` | `docker compose -f docker-compose.local.yml up -d` |
 | MySQL がまだ healthy でない | `docker compose ps` の STATUS | healthy になるまで最大 80 秒待つ |
-| `.env.local` が読み込まれていない | `echo $DATASOURCE_URL`(空なら未読込) | `source .env.local && ./gradlew :webapi:bootRun` で再起動(`.env.local` に `export` があることを確認) |
-| DATASOURCE_URL の値が間違い | `.env.local` を確認 | [セクション 4](#4-環境変数設定) の値を再確認 |
+| `.env.local` が読み込まれていない | `echo $DB_HOST`(空なら未読込) | `source .env.local && ./gradlew :webapi:bootRun` で再起動(`.env.local` に `export` があることを確認) |
+| `DB_HOST` の値が間違い | `.env.local` を確認 | [セクション 4](#4-環境変数設定) の値を再確認 |
 
 ```bash
 # MySQL への接続テスト

--- a/docs/specs/コーディング規約.md
+++ b/docs/specs/コーディング規約.md
@@ -858,8 +858,8 @@ bootBuildImage {
 
 ```groovy
 tasks.named('processAot') {
-    environment 'OIDC_ISSUER_URI',     aotEnv('OIDC_ISSUER_URI',    'http://localhost:18080/realms/tasks')
-    environment 'DATASOURCE_URL',      aotEnv('DATASOURCE_URL',     'jdbc:mysql://localhost:3306/tasks?...')
+    environment 'OIDC_ISSUER_URI',     aotEnv('OIDC_ISSUER_URI',     'http://localhost:18080/realms/tasks')
+    environment 'DB_HOST',             aotEnv('DB_HOST',             'localhost')
     environment 'DATASOURCE_USERNAME', aotEnv('DATASOURCE_USERNAME', 'tasks_webapi')
     environment 'DATASOURCE_PASSWORD', aotEnv('DATASOURCE_PASSWORD', 'tasks_webapi')
 }

--- a/docs/specs/設計規約.md
+++ b/docs/specs/設計規約.md
@@ -501,7 +501,7 @@ Content-Security-Policy:
 - HTTPS 必須(TLS 1.3 を優先、最低 1.2)、HSTS 有効。**HSTS の SSOT は TLS 終端層**(API 経路 = ALB、静的配信経路 = CloudFront)。Spring の HSTS writer は二重送出を防ぐため `disable()` する(§5.4.2)。
 - DB 接続は SSL/TLS を有効化。RDS は KMS で保存時暗号化。
 - 機密情報の管理方針は [infrastructure-plan §3.4 / §3.5](../architecture/infrastructure-plan.md) に従う:
-  - **tasks-webapi の RDS 接続**: IAM 認証(K-A 案、infrastructure-plan §3.5)。DB password は使用せず、`application.yml` の `password` は空文字注入(`${DATASOURCE_PASSWORD:}`)。
+  - **tasks-webapi の RDS 接続**: IAM 認証(K-A 案、infrastructure-plan §3.5)。DB password は使用せず、`application.yml` の `password` は空文字注入(`${DATASOURCE_PASSWORD:}`)。実装方式は AWS SDK v2 `RdsUtilities.generateAuthenticationToken()` によるトークン生成 + カスタム DataSource(`RdsIamDataSourceConfig` / `RdsIamDriverDataSource`)。接続先ホストは `DB_HOST`(port は任意 `DB_PORT`、デフォルト 3306)のみを env で注入し、JDBC URL テンプレートは `application.yml` にハードコード。local/CI=password 認証(`RDS_IAM_AUTH_ENABLED` 未設定)、stg/prd=IAM 認証(`RDS_IAM_AUTH_ENABLED=true`)の切替は env 変数のみで行い Spring Profile は使用しない。詳細は [ADR-0033](../adr/0033-rds-iam-auth-datasource.md) 参照。
   - **Keycloak の SMTP password 等、IAM 認証で代替できない機密情報**: AWS Systems Manager **Parameter Store SecureString** で管理(infrastructure-plan §3.4、S0Infra-7、ADR-0006 派生)。
   - **AWS Secrets Manager は本プロジェクトでは未採用**(Parameter Store SecureString で同等のセキュリティを実現 + 運用コスト圧縮、2026-05-23 議論確定事項 #9、#250)。
   - いずれも `application.yml` への直書きは禁止。ECS Task Definition の `environment` / `secrets` で注入。

--- a/docs/specs/開発計画書.md
+++ b/docs/specs/開発計画書.md
@@ -419,7 +419,7 @@ GitHub Flow を採用する。
 #### 環境階層の方針(v1.3 で追記)
 
 - **コンテナイメージは全環境共通**(環境別ファイル同梱せず、Native Image 移行を見据え Spring プロファイルは不使用)
-- **環境差は環境変数注入で吸収**(ECS Task Definition / Docker Compose で `DATASOURCE_URL` `OIDC_ISSUER_URI` 等)
+- **環境差は環境変数注入で吸収**(ECS Task Definition / Docker Compose で `DB_HOST` `OIDC_ISSUER_URI` 等)
 - **シークレットは Parameter Store SecureString** で管理(`/tasks/<env>/...` パス階層、Secrets Manager は不採用 - コスト面)
 - **ドメイン体系**: `tasks.dgz48.xyz` 系(`tasks-dev` / `api-dev.tasks` / `auth-dev.tasks`、stg/prd は環境 suffix 変更)
 - **RDS 認証(v1.3)**: tasks-webapi は **IAM 認証**(AWSAuthenticationPlugin、パスワード不使用)/ Keycloak は **パスワード認証**(Parameter Store)/ master は DBA 業務用(Parameter Store、アプリ非使用)

--- a/infra/environments/dev/ecs_service.tf
+++ b/infra/environments/dev/ecs_service.tf
@@ -98,8 +98,8 @@ resource "aws_ecs_task_definition" "webapi" {
     environment = [
       { name = "SERVER_PORT", value = "8080" },
       { name = "TZ", value = "Asia/Tokyo" },
-      # sslMode=REQUIRED is mandatory for RDS IAM auth; connectionTimeZone keeps timestamps consistent
-      { name = "SPRING_DATASOURCE_URL", value = "jdbc:mysql://${module.rds.db_instance_address}:3306/tasks?sslMode=REQUIRED&connectionTimeZone=SERVER&forceConnectionTimeZoneToSession=true" },
+      { name = "DB_HOST", value = module.rds.db_instance_address },
+      { name = "DB_PORT", value = tostring(module.rds.db_instance_port) },
       { name = "SPRING_DATASOURCE_USERNAME", value = "tasks_webapi" },
       { name = "RDS_IAM_AUTH_ENABLED", value = "true" },
       { name = "CORS_ALLOWED_ORIGINS", value = "https://tasks-dev.dgz48.xyz" },

--- a/infra/modules/rds/outputs.tf
+++ b/infra/modules/rds/outputs.tf
@@ -3,6 +3,11 @@ output "db_instance_address" {
   value       = aws_db_instance.main.address
 }
 
+output "db_instance_port" {
+  description = "RDS instance port"
+  value       = aws_db_instance.main.port
+}
+
 output "db_instance_identifier" {
   description = "RDS instance identifier"
   value       = aws_db_instance.main.identifier

--- a/webapi/build.gradle
+++ b/webapi/build.gradle
@@ -185,7 +185,7 @@ graalvmNative {
 }
 
 // AOT processing runs a trimmed Spring context at build time and requires
-// the same env vars as the runtime application (OIDC_ISSUER_URI, DATASOURCE_*).
+// the same env vars as the runtime application (OIDC_ISSUER_URI, DB_HOST, DATASOURCE_*).
 // Fall back to local-dev defaults so 'bootBuildImage' and 'nativeCompile' work
 // when the caller has already started Docker Compose but hasn't sourced .env.local.
 def aotEnv = { String key, String fallback ->
@@ -194,8 +194,8 @@ def aotEnv = { String key, String fallback ->
 }
 
 tasks.named('processAot') {
-    environment 'OIDC_ISSUER_URI',    aotEnv('OIDC_ISSUER_URI',    'http://localhost:18080/realms/tasks')
-    environment 'DATASOURCE_URL',     aotEnv('DATASOURCE_URL',     'jdbc:mysql://localhost:3306/tasks?useSSL=false&allowPublicKeyRetrieval=true&connectionTimeZone=SERVER&forceConnectionTimeZoneToSession=true')
+    environment 'OIDC_ISSUER_URI',     aotEnv('OIDC_ISSUER_URI',     'http://localhost:18080/realms/tasks')
+    environment 'DB_HOST',             aotEnv('DB_HOST',             'localhost')
     environment 'DATASOURCE_USERNAME', aotEnv('DATASOURCE_USERNAME', 'tasks_webapi')
     environment 'DATASOURCE_PASSWORD', aotEnv('DATASOURCE_PASSWORD', 'tasks_webapi')
     // Force RDS IAM auth branch into the native image so @ConditionalOnProperty resolves to 'true'
@@ -205,8 +205,8 @@ tasks.named('processAot') {
 }
 
 tasks.named('processTestAot') {
-    environment 'OIDC_ISSUER_URI',    aotEnv('OIDC_ISSUER_URI',    'http://localhost:18080/realms/tasks')
-    environment 'DATASOURCE_URL',     aotEnv('DATASOURCE_URL',     'jdbc:mysql://localhost:3306/tasks?useSSL=false&allowPublicKeyRetrieval=true&connectionTimeZone=SERVER&forceConnectionTimeZoneToSession=true')
+    environment 'OIDC_ISSUER_URI',     aotEnv('OIDC_ISSUER_URI',     'http://localhost:18080/realms/tasks')
+    environment 'DB_HOST',             aotEnv('DB_HOST',             'localhost')
     environment 'DATASOURCE_USERNAME', aotEnv('DATASOURCE_USERNAME', 'tasks_webapi')
     environment 'DATASOURCE_PASSWORD', aotEnv('DATASOURCE_PASSWORD', 'tasks_webapi')
 }

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/shared/infra/RdsIamDataSourceConfig.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/shared/infra/RdsIamDataSourceConfig.java
@@ -27,8 +27,11 @@ import software.amazon.awssdk.services.rds.RdsUtilities;
 @ConditionalOnProperty(name = "rds.iam-auth.enabled", havingValue = "true")
 class RdsIamDataSourceConfig {
 
-  @Value("${spring.datasource.url}")
-  private String jdbcUrl;
+  @Value("${DB_HOST}")
+  private String dbHost;
+
+  @Value("${DB_PORT:3306}")
+  private int dbPort;
 
   @Value("${spring.datasource.username}")
   private String username;
@@ -50,52 +53,17 @@ class RdsIamDataSourceConfig {
   }
 
   HikariConfig buildHikariConfig(RdsUtilities rdsUtilities) {
-    String sslJdbcUrl = withSsl(jdbcUrl);
-    String host = extractHost(jdbcUrl);
-    int port = extractPort(jdbcUrl);
+    String jdbcUrl =
+        "jdbc:mysql://"
+            + dbHost
+            + ":"
+            + dbPort
+            + "/tasks?sslMode=REQUIRED&connectionTimeZone=SERVER&forceConnectionTimeZoneToSession=true";
 
     HikariConfig config = new HikariConfig();
     config.setDataSource(
-        new RdsIamDriverDataSource(sslJdbcUrl, username, host, port, rdsUtilities));
+        new RdsIamDriverDataSource(jdbcUrl, username, dbHost, dbPort, rdsUtilities));
     config.setMaxLifetime(840_000L);
     return config;
-  }
-
-  private static String withSsl(String url) {
-    if (url.contains("sslMode")) {
-      return url;
-    }
-    return url.contains("?") ? url + "&sslMode=REQUIRED" : url + "?sslMode=REQUIRED";
-  }
-
-  private static String extractHost(String url) {
-    // jdbc:mysql://host:port/db?params  →  host
-    int start = url.indexOf("://") + 3;
-    String rest = url.substring(start);
-    int colon = rest.indexOf(':');
-    int slash = rest.indexOf('/');
-    int end = colon >= 0 ? colon : (slash >= 0 ? slash : rest.length());
-    return rest.substring(0, end);
-  }
-
-  private static int extractPort(String url) {
-    // jdbc:mysql://host:port/db?params  →  port (default 3306)
-    int start = url.indexOf("://") + 3;
-    String rest = url.substring(start);
-    int colon = rest.indexOf(':');
-    if (colon < 0) {
-      return 3306;
-    }
-    String afterColon = rest.substring(colon + 1);
-    int slash = afterColon.indexOf('/');
-    int query = afterColon.indexOf('?');
-    int end = afterColon.length();
-    if (slash >= 0) end = Math.min(end, slash);
-    if (query >= 0) end = Math.min(end, query);
-    try {
-      return Integer.parseInt(afterColon.substring(0, end));
-    } catch (NumberFormatException e) {
-      return 3306;
-    }
   }
 }

--- a/webapi/src/main/resources/application.yml
+++ b/webapi/src/main/resources/application.yml
@@ -1,5 +1,6 @@
 # env vars (required at startup):
-#   DATASOURCE_URL       - JDBC URL e.g. jdbc:mysql://localhost:3306/tasks?useSSL=false&allowPublicKeyRetrieval=true&connectionTimeZone=SERVER&forceConnectionTimeZoneToSession=true
+#   DB_HOST              - DB hostname e.g. localhost
+#   DB_PORT              - DB port (optional, default 3306)
 #   DATASOURCE_USERNAME  - DB user e.g. tasks_webapi
 #   DATASOURCE_PASSWORD  - DB password (unused when RDS_IAM_AUTH_ENABLED=true)
 #   OIDC_ISSUER_URI      - Keycloak realm issuer e.g. http://localhost:8080/realms/tasks
@@ -11,7 +12,7 @@ spring:
   application:
     name: tasks-webapi
   datasource:
-    url: ${DATASOURCE_URL}
+    url: "jdbc:mysql://${DB_HOST}:${DB_PORT:3306}/tasks?useSSL=false&allowPublicKeyRetrieval=true&connectionTimeZone=SERVER&forceConnectionTimeZoneToSession=true"
     username: ${DATASOURCE_USERNAME}
     password: ${DATASOURCE_PASSWORD:}
     driver-class-name: com.mysql.cj.jdbc.Driver

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/RdsIamAuthIntegrationTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/RdsIamAuthIntegrationTest.java
@@ -60,12 +60,11 @@ class RdsIamAuthIntegrationTest {
 
   @DynamicPropertySource
   static void datasourceProps(DynamicPropertyRegistry registry) {
-    // Prepend sslMode=DISABLED so RdsIamDataSourceConfig.withSsl() leaves the URL unchanged.
-    // Local Testcontainer MySQL uses self-signed certs; adding sslMode=REQUIRED causes cert-verify
-    // failures that are irrelevant to what this test validates.
-    String baseUrl = mysql.getJdbcUrl();
-    String separator = baseUrl.contains("?") ? "&" : "?";
-    registry.add("spring.datasource.url", () -> baseUrl + separator + "sslMode=DISABLED");
+    // RdsIamDataSourceConfig reads DB_HOST / DB_PORT directly and builds the IAM JDBC URL
+    // (sslMode=REQUIRED) internally. MySQL 8.4 in Docker supports TLS by default, so
+    // sslMode=REQUIRED works without additional certificate configuration.
+    registry.add("DB_HOST", mysql::getHost);
+    registry.add("DB_PORT", () -> mysql.getMappedPort(3306));
     registry.add("spring.datasource.username", mysql::getUsername);
     // spring.datasource.password is intentionally omitted — RdsIamDataSourceConfig does not read
     // it. The mock RdsUtilities returns the password directly as the IAM token.

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/shared/infra/RdsIamDataSourceConfigTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/shared/infra/RdsIamDataSourceConfigTest.java
@@ -16,8 +16,8 @@ import software.amazon.awssdk.services.rds.model.GenerateAuthenticationTokenRequ
 
 class RdsIamDataSourceConfigTest {
 
-  private static final String JDBC_URL =
-      "jdbc:mysql://db.tasks.internal:3306/tasks?sslMode=REQUIRED";
+  private static final String DB_HOST = "db.tasks.internal";
+  private static final int DB_PORT = 3306;
   private static final String USERNAME = "tasks_webapi";
   private static final String REGION = "ap-northeast-1";
 
@@ -25,7 +25,8 @@ class RdsIamDataSourceConfigTest {
   void buildHikariConfig_maxLifetimeIsLessThan15Minutes() {
     RdsUtilities mockUtils = mock(RdsUtilities.class);
 
-    HikariConfig config = buildConfig(JDBC_URL, USERNAME, REGION).buildHikariConfig(mockUtils);
+    HikariConfig config =
+        buildConfig(DB_HOST, DB_PORT, USERNAME, REGION).buildHikariConfig(mockUtils);
 
     // IAM tokens expire in 15 min; maxLifetime must be below 900000 ms to ensure reconnects
     assertThat(config.getMaxLifetime()).isLessThan(900_000L);
@@ -35,29 +36,47 @@ class RdsIamDataSourceConfigTest {
   void buildHikariConfig_hasUnderlyingDataSource() {
     RdsUtilities mockUtils = mock(RdsUtilities.class);
 
-    HikariConfig config = buildConfig(JDBC_URL, USERNAME, REGION).buildHikariConfig(mockUtils);
+    HikariConfig config =
+        buildConfig(DB_HOST, DB_PORT, USERNAME, REGION).buildHikariConfig(mockUtils);
 
     assertThat(config.getDataSource()).isInstanceOf(RdsIamDriverDataSource.class);
   }
 
   @Test
-  void buildHikariConfig_extractsHostAndPortFromJdbcUrl() throws Exception {
+  void buildHikariConfig_usesDbHostAndPortForTokenGeneration() throws Exception {
     RdsUtilities mockUtils = mock(RdsUtilities.class);
     when(mockUtils.generateAuthenticationToken(any(GenerateAuthenticationTokenRequest.class)))
         .thenReturn("mock-iam-token");
 
     var ds =
         (RdsIamDriverDataSource)
-            buildConfig(JDBC_URL, USERNAME, REGION).buildHikariConfig(mockUtils).getDataSource();
+            buildConfig(DB_HOST, DB_PORT, USERNAME, REGION)
+                .buildHikariConfig(mockUtils)
+                .getDataSource();
 
     // Trigger token generation by attempting a connection (will fail at TCP level)
     assertThatThrownBy(ds::getConnection).isInstanceOf(SQLException.class);
 
     var captor = ArgumentCaptor.forClass(GenerateAuthenticationTokenRequest.class);
     verify(mockUtils).generateAuthenticationToken(captor.capture());
-    assertThat(captor.getValue().hostname()).isEqualTo("db.tasks.internal");
-    assertThat(captor.getValue().port()).isEqualTo(3306);
+    assertThat(captor.getValue().hostname()).isEqualTo(DB_HOST);
+    assertThat(captor.getValue().port()).isEqualTo(DB_PORT);
     assertThat(captor.getValue().username()).isEqualTo(USERNAME);
+  }
+
+  @Test
+  void buildHikariConfig_jdbcUrlContainsSslRequired() throws Exception {
+    RdsUtilities mockUtils = mock(RdsUtilities.class);
+
+    var ds =
+        (RdsIamDriverDataSource)
+            buildConfig(DB_HOST, DB_PORT, USERNAME, REGION)
+                .buildHikariConfig(mockUtils)
+                .getDataSource();
+
+    var field = RdsIamDriverDataSource.class.getDeclaredField("jdbcUrl");
+    field.setAccessible(true);
+    assertThat((String) field.get(ds)).contains("sslMode=REQUIRED");
   }
 
   @Test
@@ -79,42 +98,14 @@ class RdsIamDataSourceConfigTest {
     verify(mockUtils).generateAuthenticationToken(any(GenerateAuthenticationTokenRequest.class));
   }
 
-  @Test
-  void buildHikariConfig_appendsSslModeWhenAbsent() throws Exception {
-    RdsUtilities mockUtils = mock(RdsUtilities.class);
-
-    var ds =
-        (RdsIamDriverDataSource)
-            buildConfig("jdbc:mysql://db.tasks.internal:3306/db", USERNAME, REGION)
-                .buildHikariConfig(mockUtils)
-                .getDataSource();
-
-    var field = RdsIamDriverDataSource.class.getDeclaredField("jdbcUrl");
-    field.setAccessible(true);
-    assertThat((String) field.get(ds)).contains("sslMode=REQUIRED");
-  }
-
-  @Test
-  void buildHikariConfig_doesNotDuplicateSslMode() throws Exception {
-    RdsUtilities mockUtils = mock(RdsUtilities.class);
-
-    var ds =
-        (RdsIamDriverDataSource)
-            buildConfig(JDBC_URL, USERNAME, REGION).buildHikariConfig(mockUtils).getDataSource();
-
-    var field = RdsIamDriverDataSource.class.getDeclaredField("jdbcUrl");
-    field.setAccessible(true);
-    String url = (String) field.get(ds);
-    assertThat(url.indexOf("sslMode")).isEqualTo(url.lastIndexOf("sslMode"));
-  }
-
   // ── helpers ─────────────────────────────────────────────────────────────────
 
   private static RdsIamDataSourceConfig buildConfig(
-      String jdbcUrl, String username, String region) {
+      String dbHost, int dbPort, String username, String region) {
     try {
       var config = new RdsIamDataSourceConfig();
-      setField(config, "jdbcUrl", jdbcUrl);
+      setField(config, "dbHost", dbHost);
+      setField(config, "dbPort", dbPort);
       setField(config, "username", username);
       setField(config, "region", region);
       return config;
@@ -123,7 +114,7 @@ class RdsIamDataSourceConfigTest {
     }
   }
 
-  private static void setField(Object target, String name, String value)
+  private static void setField(Object target, String name, Object value)
       throws ReflectiveOperationException {
     var field = target.getClass().getDeclaredField(name);
     field.setAccessible(true);

--- a/webapi/src/test/resources/application.yml
+++ b/webapi/src/test/resources/application.yml
@@ -1,7 +1,7 @@
 # Test-only property values for placeholders defined in src/main/resources/application.yml.
 # @ServiceConnection (Testcontainers) overrides the actual datasource connection at runtime;
 # these values only exist to satisfy placeholder resolution before the context starts.
-DATASOURCE_URL: jdbc:mysql://localhost:3306/tasks_test
+DB_HOST: localhost
 DATASOURCE_USERNAME: test
 OIDC_ISSUER_URI: http://localhost:8080/realms/tasks
 


### PR DESCRIPTION
## Summary

Closes #686. ADR-0033 が定める目標形へ整理。

- **`RdsIamDataSourceConfig`**: `jdbcUrl` フィールド(フル URL 注入)を `dbHost` / `dbPort` に置換し、`extractHost` / `extractPort` / `withSsl` を全廃。URL は `sslMode=REQUIRED` テンプレートでクラス内組み立て
- **`application.yml`**: `${DATASOURCE_URL}` → `jdbc:mysql://${DB_HOST}:${DB_PORT:3306}/tasks?…` テンプレートにハードコード
- **`infra/ecs_service.tf`**: `SPRING_DATASOURCE_URL`(フル URL) → `DB_HOST` + `DB_PORT`(明示)に変更。`infra/modules/rds/outputs.tf` に `db_instance_port` 出力を追加
- **CI/CD**: `release-build.yml` smoke test・`webapi-native-build.yml`・`build.gradle` processAot を `DB_HOST` 方式へ追従
- **テスト**: `RdsIamDataSourceConfigTest` を新フィールド構成に書き直し(URL パース系テスト → `jdbcUrlContainsSslRequired` / `usesDbHostAndPortForTokenGeneration` に置換)。`RdsIamAuthIntegrationTest` の `@DynamicPropertySource` を `DB_HOST`/`DB_PORT` に変更
- **設計規約 §5.5**: RDS IAM 実装方式(SDK v2 `RdsUtilities` + `DB_HOST` 注入)を追記し ADR-0033 を参照

## Test plan

- [x] `./gradlew :webapi:spotlessApply` — フォーマット適用
- [x] `./gradlew :webapi:check` — コンパイル + spotlessCheck + 全テスト green (BUILD SUCCESSFUL)
- [ ] native smoke test は release ビルド CI で確認(GraalVM 環境必要)

🤖 Generated with [Claude Code](https://claude.com/claude-code)