### PR TITLE
fix(audit): LocalDate を audit_logs.detail に引用符なし出力して 500 になるバグを応急修正

### DIFF
--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/usecase/UpdateTaskUseCase.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/usecase/UpdateTaskUseCase.java
@@ -83,7 +83,8 @@ public class UpdateTaskUseCase {
       return "\"" + escapeJsonString(s) + "\"";
     }
     if (value instanceof Enum<?> e) return "\"" + escapeJsonString(e.name()) + "\"";
-    return String.valueOf(value);
+    if (value instanceof Number || value instanceof Boolean) return String.valueOf(value);
+    return "\"" + escapeJsonString(String.valueOf(value)) + "\"";
   }
 
   private static String escapeJsonString(String s) {

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/usecase/UpdateTaskUseCaseTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/usecase/UpdateTaskUseCaseTest.java
@@ -162,8 +162,7 @@ class UpdateTaskUseCaseTest {
   @Test
   void execute_audit_detail_quotesLocalDate() {
     Task task = buildTask();
-    List<FieldChange> changes =
-        List.of(new FieldChange("dueDate", null, LocalDate.of(2026, 8, 1)));
+    List<FieldChange> changes = List.of(new FieldChange("dueDate", null, LocalDate.of(2026, 8, 1)));
 
     when(taskRepository.findById(TASK_ID)).thenReturn(Optional.of(task));
     when(stakeholderRepository.findUserIdsByTaskId(TASK_ID, TENANT_ID)).thenReturn(List.of());
@@ -176,8 +175,7 @@ class UpdateTaskUseCaseTest {
 
     ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
     verify(auditLogPort)
-        .record(
-            eq(AuditEventType.TASK_UPDATED), eq(TENANT_ID), eq(OWNER_ID), captor.capture());
+        .record(eq(AuditEventType.TASK_UPDATED), eq(TENANT_ID), eq(OWNER_ID), captor.capture());
     // LocalDate は "2026-08-01" と引用符付きで出力されなければならない（修正前は引用符なしで 500 になった）
     assertThat(captor.getValue()).contains("\"2026-08-01\"");
   }

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/usecase/UpdateTaskUseCaseTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/usecase/UpdateTaskUseCaseTest.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -156,5 +157,28 @@ class UpdateTaskUseCaseTest {
     verify(taskRepository).save(task);
     verify(auditLogPort)
         .record(eq(AuditEventType.TASK_UPDATED), eq(TENANT_ID), eq(OWNER_ID), any(String.class));
+  }
+
+  @Test
+  void execute_audit_detail_quotesLocalDate() {
+    Task task = buildTask();
+    List<FieldChange> changes =
+        List.of(new FieldChange("dueDate", null, LocalDate.of(2026, 8, 1)));
+
+    when(taskRepository.findById(TASK_ID)).thenReturn(Optional.of(task));
+    when(stakeholderRepository.findUserIdsByTaskId(TASK_ID, TENANT_ID)).thenReturn(List.of());
+    when(taskAuthorizationDomainService.canBeViewedBy(task, OWNER_ID, List.of())).thenReturn(true);
+    when(taskAuthorizationDomainService.canBeEditedBy(task, OWNER_ID)).thenReturn(true);
+    when(taskAuditDiffDomainService.diff(any(), any())).thenReturn(changes);
+    when(taskRepository.save(any())).thenReturn(buildTask());
+
+    useCase.execute(TASK_ID, OWNER_ID, titleOnlyCmd(), VERSION);
+
+    ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+    verify(auditLogPort)
+        .record(
+            eq(AuditEventType.TASK_UPDATED), eq(TENANT_ID), eq(OWNER_ID), captor.capture());
+    // LocalDate は "2026-08-01" と引用符付きで出力されなければならない（修正前は引用符なしで 500 になった）
+    assertThat(captor.getValue()).contains("\"2026-08-01\"");
   }
 }


### PR DESCRIPTION
## Summary

- Issue #663 の代表フロー自動走査中に発見した `PATCH /api/tasks/{id}` の 500 バグを応急修正
- `UpdateTaskUseCase.toJsonValue()` が `LocalDate` を `String.valueOf()` で素通しし、`2026-08-01` が引用符なしで `audit_logs.detail` の JSON に埋め込まれていた
- MySQL の JSON 型バリデーションがこれを拒否して 500 を返していた
- `Number`/`Boolean` 以外の型をすべて文字列クォートするよう修正

## Root cause / 根本対応

手組み JSON 生成自体が問題。`ObjectMapper` への置き換えは #702 で別途実施。同じパターンが `UpdateTenantUseCase`・`ListTenantsUseCase` にもあり #702 で一括対応予定。

## Test plan

- [ ] CI グリーン
- [ ] `PATCH /api/tasks/{id}` で期限日を変更しても 200 が返り audit_logs に valid JSON が保存されることをローカル確認済み(Issue #663 走査)

## 未対応レビュー

| 指摘 | 内容 | 状態 |
|---|---|---|
| [LocalDate 回帰テストなし](https://github.com/win2cot/tasks-webapi/pull/703#pullrequestreview-2993131738) | ArgumentCaptor で audit detail の中身を検証するテスト追加 | ✅ 対応済み (bba9b66) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
