### PR TITLE
refactor(audit): 監査 detail を Object 渡しに統一し JSON シリアライズを Adapter に集約

### DIFF
--- a/docs/specs/コーディング規約.md
+++ b/docs/specs/コーディング規約.md
@@ -419,6 +419,16 @@ public record TaskCreateRequest(
   - **リクエスト body / query 文字列の生ログ禁止**(検索キーワード等に PII が入り得る)。
   - **フレームワーク設定**: Hibernate のパラメータバインドログ(TRACE)等、値を吐く設定を prod 系環境で有効化しない。
 
+### 7.1 監査ログ detail — 手組み JSON 禁止
+
+`AuditLogPort.record` の `detail` 引数には **`Map` または小型 record 等の構造体をそのまま渡す**。usecase 層での JSON 文字列手組み(`StringBuilder` による `"{\"key\":...}"` 等)は禁止する。シリアライズは `AuditLogPersistenceAdapter` 内の `ObjectMapper` に一元化する(設計規約 §1.2.3 遵守)。
+
+- **diff 系**(`TASK_UPDATED` / `TENANT_UPDATED`): `List<AuditFieldChange>` に詰め替えて渡す。`AuditFieldChange` は `@JsonProperty("old")` / `@JsonProperty("new")` で JSON キー名を確定する。
+- **シンプル系**: `Map.of("taskId", id)` など。`Map.of` は `null` 値を弾くため、`null` 値を含む場合は `LinkedHashMap` を使う。
+- **空 detail**: `Map.of()` を渡す(または `null`、どちらも `"{}"` として格納される)。
+
+**理由**: 手組み JSON は `LocalDate` 等の非プリミティブ型を引用符なし出力する欠陥を起こしやすく(Issue #702 / PR #703)、`ObjectMapper` に集約することで型安全性・保守性・テスタビリティが向上する。
+
 ---
 
 ## 8. 命名規則

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/adapter/persistence/AuditLogPersistenceAdapter.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/adapter/persistence/AuditLogPersistenceAdapter.java
@@ -7,6 +7,8 @@ import java.time.Clock;
 import java.time.LocalDateTime;
 import org.jspecify.annotations.Nullable;
 import org.springframework.stereotype.Component;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.json.JsonMapper;
 import xyz.dgz48.tasks.webapi.audit.domain.AuditEventType;
 import xyz.dgz48.tasks.webapi.audit.usecase.AuditLogPort;
 
@@ -17,20 +19,36 @@ class AuditLogPersistenceAdapter implements AuditLogPort {
 
   private final AuditLogJpaRepository repository;
   private final Clock clock;
+  private final JsonMapper jsonMapper;
 
-  AuditLogPersistenceAdapter(AuditLogJpaRepository repository, Clock clock) {
+  AuditLogPersistenceAdapter(AuditLogJpaRepository repository, Clock clock, JsonMapper jsonMapper) {
     this.repository = repository;
     this.clock = clock;
+    this.jsonMapper = jsonMapper;
   }
 
   @Override
   public void record(
-      AuditEventType eventType, @Nullable Long tenantId, @Nullable Long userId, String detail) {
+      AuditEventType eventType,
+      @Nullable Long tenantId,
+      @Nullable Long userId,
+      @Nullable Object detail) {
     LocalDateTime createdAt = LocalDateTime.now(clock);
     String hashChain = computeChainHash(repository.findFirstByOrderByIdDesc().orElse(null));
+    String detailJson = serializeDetail(detail);
     var entity =
-        new AuditLogJpaEntity(tenantId, userId, eventType.name(), detail, createdAt, hashChain);
+        new AuditLogJpaEntity(tenantId, userId, eventType.name(), detailJson, createdAt, hashChain);
     repository.save(entity);
+  }
+
+  /** シリアライズ失敗は {@link JacksonException}(unchecked)をそのまま伝播させ fail-closed とする。 */
+  String serializeDetail(@Nullable Object detail) {
+    if (detail == null) return "{}";
+    try {
+      return jsonMapper.writeValueAsString(detail);
+    } catch (JacksonException e) {
+      throw new IllegalStateException("監査 detail のシリアライズに失敗しました", e);
+    }
   }
 
   static String computeChainHash(@Nullable AuditLogJpaEntity prev) {

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/usecase/AuditFieldChange.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/usecase/AuditFieldChange.java
@@ -1,0 +1,14 @@
+package xyz.dgz48.tasks.webapi.audit.usecase;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * 監査ログ detail の差分フィールド 1 件。JSON キー名は後方互換のため {@code "old"} / {@code "new"} で固定する。
+ *
+ * <p>domain 層の {@code FieldChange} は POJO のまま保持し、usecase 層でこの型に詰め替えてシリアライズ責務を分離する。
+ */
+public record AuditFieldChange(
+    String field,
+    @JsonProperty("old") @Nullable Object oldValue,
+    @JsonProperty("new") @Nullable Object newValue) {}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/usecase/AuditLogPort.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/usecase/AuditLogPort.java
@@ -12,8 +12,11 @@ public interface AuditLogPort {
    * @param eventType イベント種別
    * @param tenantId テナント ID(システム横断イベントの場合は {@code null})
    * @param userId 操作ユーザー ID(不明な場合は {@code null})
-   * @param detail JSON 形式の詳細情報
+   * @param detail 詳細情報({@code Map} / record 等の構造体。{@code null} の場合は {@code "{}"} を格納)
    */
   void record(
-      AuditEventType eventType, @Nullable Long tenantId, @Nullable Long userId, String detail);
+      AuditEventType eventType,
+      @Nullable Long tenantId,
+      @Nullable Long userId,
+      @Nullable Object detail);
 }

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/usecase/CrossTenantViolationAuditService.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/usecase/CrossTenantViolationAuditService.java
@@ -1,10 +1,10 @@
 package xyz.dgz48.tasks.webapi.audit.usecase;
 
+import java.util.Map;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
-import tools.jackson.databind.json.JsonMapper;
 import xyz.dgz48.tasks.webapi.audit.domain.AuditEventType;
 import xyz.dgz48.tasks.webapi.shared.domain.CrossTenantViolationDetectedEvent;
 
@@ -19,22 +19,15 @@ import xyz.dgz48.tasks.webapi.shared.domain.CrossTenantViolationDetectedEvent;
 class CrossTenantViolationAuditService {
 
   private final AuditLogPort auditLogPort;
-  private final JsonMapper jsonMapper;
 
-  CrossTenantViolationAuditService(AuditLogPort auditLogPort, JsonMapper jsonMapper) {
+  CrossTenantViolationAuditService(AuditLogPort auditLogPort) {
     this.auditLogPort = auditLogPort;
-    this.jsonMapper = jsonMapper;
   }
 
   @EventListener
   @Transactional(propagation = Propagation.REQUIRES_NEW)
   public void onViolationDetected(CrossTenantViolationDetectedEvent event) {
-    String detail =
-        jsonMapper
-            .createObjectNode()
-            .put("table", event.tableName())
-            .put("sqlType", event.sqlType())
-            .toString();
+    var detail = Map.of("table", event.tableName(), "sqlType", event.sqlType());
     auditLogPort.record(
         AuditEventType.CROSS_TENANT_VIOLATION_ATTEMPT, event.tenantId(), event.userId(), detail);
   }

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/usecase/AddStakeholderUseCase.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/usecase/AddStakeholderUseCase.java
@@ -3,6 +3,7 @@ package xyz.dgz48.tasks.webapi.task.usecase;
 import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -54,7 +55,7 @@ public class AddStakeholderUseCase {
         AuditEventType.STAKEHOLDER_ADDED,
         task.getTenantId(),
         operatorUserId,
-        "{\"taskId\":" + taskId + ",\"userId\":" + targetUserId + "}");
+        Map.of("taskId", taskId, "userId", targetUserId));
     return stakeholder;
   }
 }

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/usecase/ChangeVisibilityUseCase.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/usecase/ChangeVisibilityUseCase.java
@@ -3,6 +3,7 @@ package xyz.dgz48.tasks.webapi.task.usecase;
 import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.Nullable;
 import org.springframework.stereotype.Service;
@@ -68,7 +69,7 @@ public class ChangeVisibilityUseCase {
               AuditEventType.STAKEHOLDER_PURGED,
               task.getTenantId(),
               userId,
-              "{\"taskId\":" + taskId + ",\"purgedCount\":" + purgedCount + "}");
+              Map.of("taskId", taskId, "purgedCount", purgedCount));
         }
       }
       case TENANT -> {
@@ -80,13 +81,7 @@ public class ChangeVisibilityUseCase {
         AuditEventType.VISIBILITY_CHANGED,
         task.getTenantId(),
         userId,
-        "{\"taskId\":"
-            + taskId
-            + ",\"from\":\""
-            + oldVisibility
-            + "\",\"to\":\""
-            + newVisibility
-            + "\"}");
+        Map.of("taskId", taskId, "from", oldVisibility, "to", newVisibility));
 
     return saved;
   }

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/usecase/CreateTaskUseCase.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/usecase/CreateTaskUseCase.java
@@ -3,6 +3,7 @@ package xyz.dgz48.tasks.webapi.task.usecase;
 import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.Nullable;
 import org.springframework.stereotype.Service;
@@ -71,7 +72,7 @@ public class CreateTaskUseCase {
     }
 
     auditLogPort.record(
-        AuditEventType.TASK_CREATED, tenantId, ownerUserId, "{\"taskId\":" + task.getId() + "}");
+        AuditEventType.TASK_CREATED, tenantId, ownerUserId, Map.of("taskId", task.getId()));
 
     return task;
   }

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/usecase/DeleteTaskUseCase.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/usecase/DeleteTaskUseCase.java
@@ -3,6 +3,7 @@ package xyz.dgz48.tasks.webapi.task.usecase;
 import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -46,6 +47,6 @@ public class DeleteTaskUseCase {
     taskRepository.softDelete(task, LocalDateTime.now(clock));
 
     auditLogPort.record(
-        AuditEventType.TASK_DELETED, task.getTenantId(), userId, "{\"taskId\":" + taskId + "}");
+        AuditEventType.TASK_DELETED, task.getTenantId(), userId, Map.of("taskId", taskId));
   }
 }

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/usecase/RemoveStakeholderUseCase.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/usecase/RemoveStakeholderUseCase.java
@@ -1,6 +1,7 @@
 package xyz.dgz48.tasks.webapi.task.usecase;
 
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -42,6 +43,6 @@ public class RemoveStakeholderUseCase {
         AuditEventType.STAKEHOLDER_REMOVED,
         task.getTenantId(),
         operatorUserId,
-        "{\"taskId\":" + taskId + ",\"userId\":" + targetUserId + "}");
+        Map.of("taskId", taskId, "userId", targetUserId));
   }
 }

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/usecase/UpdateTaskUseCase.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/usecase/UpdateTaskUseCase.java
@@ -2,10 +2,10 @@ package xyz.dgz48.tasks.webapi.task.usecase;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.jspecify.annotations.Nullable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import xyz.dgz48.tasks.webapi.audit.domain.AuditEventType;
+import xyz.dgz48.tasks.webapi.audit.usecase.AuditFieldChange;
 import xyz.dgz48.tasks.webapi.audit.usecase.AuditLogPort;
 import xyz.dgz48.tasks.webapi.shared.exception.PreconditionFailedException;
 import xyz.dgz48.tasks.webapi.task.domain.FieldChange;
@@ -54,60 +54,12 @@ public class UpdateTaskUseCase {
     task.applyPatch(cmd);
     Task saved = taskRepository.save(task);
 
-    auditLogPort.record(
-        AuditEventType.TASK_UPDATED, task.getTenantId(), userId, buildAuditDetail(changes));
+    List<AuditFieldChange> auditChanges =
+        changes.stream()
+            .map(c -> new AuditFieldChange(c.field(), c.oldValue(), c.newValue()))
+            .toList();
+    auditLogPort.record(AuditEventType.TASK_UPDATED, task.getTenantId(), userId, auditChanges);
 
     return saved;
-  }
-
-  private static String buildAuditDetail(List<FieldChange> changes) {
-    StringBuilder sb = new StringBuilder("[");
-    for (int i = 0; i < changes.size(); i++) {
-      FieldChange c = changes.get(i);
-      if (i > 0) sb.append(",");
-      sb.append("{\"field\":\"")
-          .append(c.field())
-          .append("\",\"old\":")
-          .append(toJsonValue(c.oldValue()))
-          .append(",\"new\":")
-          .append(toJsonValue(c.newValue()))
-          .append("}");
-    }
-    sb.append("]");
-    return sb.toString();
-  }
-
-  private static String toJsonValue(@Nullable Object value) {
-    if (value == null) return "null";
-    if (value instanceof String s) {
-      return "\"" + escapeJsonString(s) + "\"";
-    }
-    if (value instanceof Enum<?> e) return "\"" + escapeJsonString(e.name()) + "\"";
-    if (value instanceof Number || value instanceof Boolean) return String.valueOf(value);
-    return "\"" + escapeJsonString(String.valueOf(value)) + "\"";
-  }
-
-  private static String escapeJsonString(String s) {
-    StringBuilder sb = new StringBuilder(s.length() + 16);
-    for (int i = 0; i < s.length(); i++) {
-      char c = s.charAt(i);
-      switch (c) {
-        case '"' -> sb.append("\\\"");
-        case '\\' -> sb.append("\\\\");
-        case '\n' -> sb.append("\\n");
-        case '\r' -> sb.append("\\r");
-        case '\t' -> sb.append("\\t");
-        case '\b' -> sb.append("\\b");
-        case '\f' -> sb.append("\\f");
-        default -> {
-          if (c < 0x20) {
-            sb.append(String.format("\\u%04X", (int) c));
-          } else {
-            sb.append(c);
-          }
-        }
-      }
-    }
-    return sb.toString();
   }
 }

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/usecase/GetPlatformMetricsUseCase.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/usecase/GetPlatformMetricsUseCase.java
@@ -1,5 +1,6 @@
 package xyz.dgz48.tasks.webapi.tenant.usecase;
 
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,7 +28,7 @@ public class GetPlatformMetricsUseCase {
     PlatformMetrics metrics =
         tenantFilterBypassService.runAsSaaSAdmin(platformMetricsPort::getMetrics);
 
-    auditLogPort.record(AuditEventType.PLATFORM_METRICS_VIEWED, null, userId, "{}");
+    auditLogPort.record(AuditEventType.PLATFORM_METRICS_VIEWED, null, userId, Map.of());
 
     return metrics;
   }

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/usecase/GetTenantUseCase.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/usecase/GetTenantUseCase.java
@@ -1,5 +1,6 @@
 package xyz.dgz48.tasks.webapi.tenant.usecase;
 
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -33,7 +34,7 @@ public class GetTenantUseCase {
             .orElseThrow(() -> new TenantNotFoundException(tenantId));
 
     auditLogPort.record(
-        AuditEventType.TENANT_VIEWED, tenantId, userId, "{\"tenantId\":" + tenantId + "}");
+        AuditEventType.TENANT_VIEWED, tenantId, userId, Map.of("tenantId", tenantId));
 
     return tenant;
   }

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/usecase/ListTenantsUseCase.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/usecase/ListTenantsUseCase.java
@@ -1,5 +1,7 @@
 package xyz.dgz48.tasks.webapi.tenant.usecase;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.Nullable;
 import org.springframework.data.domain.Page;
@@ -32,23 +34,12 @@ public class ListTenantsUseCase {
         tenantFilterBypassService.runAsSaaSAdmin(
             () -> adminTenantRepository.findAll(status, keyword, pageable));
 
-    String detail = buildListDetail(status, keyword, result.getTotalElements());
+    Map<String, Object> detail = new LinkedHashMap<>();
+    detail.put("totalElements", result.getTotalElements());
+    if (status != null) detail.put("statusFilter", status.name());
+    if (keyword != null && !keyword.isBlank()) detail.put("hasKeyword", true);
     auditLogPort.record(AuditEventType.TENANT_LIST_VIEWED, null, userId, detail);
 
     return result;
-  }
-
-  private static String buildListDetail(
-      @Nullable TenantStatus status, @Nullable String keyword, long totalElements) {
-    StringBuilder sb = new StringBuilder("{");
-    sb.append("\"totalElements\":").append(totalElements);
-    if (status != null) {
-      sb.append(",\"statusFilter\":\"").append(status.name()).append("\"");
-    }
-    if (keyword != null && !keyword.isBlank()) {
-      sb.append(",\"hasKeyword\":true");
-    }
-    sb.append("}");
-    return sb.toString();
   }
 }

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/usecase/UpdateTenantStatusUseCase.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/usecase/UpdateTenantStatusUseCase.java
@@ -1,5 +1,6 @@
 package xyz.dgz48.tasks.webapi.tenant.usecase;
 
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -54,13 +55,10 @@ public class UpdateTenantStatusUseCase {
         eventType,
         tenantId,
         userId,
-        "{\"tenantId\":"
-            + tenantId
-            + ",\"newStatus\":\""
-            + cmd.status().name()
-            + "\",\"previousStatus\":\""
-            + previous.getStatus().name()
-            + "\"}");
+        Map.of(
+            "tenantId", tenantId,
+            "newStatus", cmd.status().name(),
+            "previousStatus", previous.getStatus().name()));
 
     return updated;
   }

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/usecase/UpdateTenantUseCase.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/usecase/UpdateTenantUseCase.java
@@ -2,10 +2,10 @@ package xyz.dgz48.tasks.webapi.tenant.usecase;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.jspecify.annotations.Nullable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import xyz.dgz48.tasks.webapi.audit.domain.AuditEventType;
+import xyz.dgz48.tasks.webapi.audit.usecase.AuditFieldChange;
 import xyz.dgz48.tasks.webapi.audit.usecase.AuditLogPort;
 import xyz.dgz48.tasks.webapi.shared.usecase.TenantFilterBypassService;
 import xyz.dgz48.tasks.webapi.tenant.domain.FieldChange;
@@ -45,56 +45,12 @@ public class UpdateTenantUseCase {
         tenantFilterBypassService.runAsSaaSAdmin(
             () -> adminTenantRepository.updateName(tenantId, cmd.name()));
 
-    auditLogPort.record(AuditEventType.TENANT_UPDATED, tenantId, userId, buildDiffDetail(changes));
+    List<AuditFieldChange> auditChanges =
+        changes.stream()
+            .map(c -> new AuditFieldChange(c.field(), c.oldValue(), c.newValue()))
+            .toList();
+    auditLogPort.record(AuditEventType.TENANT_UPDATED, tenantId, userId, auditChanges);
 
     return updated;
-  }
-
-  static String buildDiffDetail(List<FieldChange> changes) {
-    StringBuilder sb = new StringBuilder("[");
-    for (int i = 0; i < changes.size(); i++) {
-      FieldChange c = changes.get(i);
-      if (i > 0) sb.append(",");
-      sb.append("{\"field\":\"")
-          .append(c.field())
-          .append("\",\"old\":")
-          .append(toJsonValue(c.oldValue()))
-          .append(",\"new\":")
-          .append(toJsonValue(c.newValue()))
-          .append("}");
-    }
-    sb.append("]");
-    return sb.toString();
-  }
-
-  private static String toJsonValue(@Nullable Object value) {
-    if (value == null) return "null";
-    if (value instanceof String s) return "\"" + escapeJsonString(s) + "\"";
-    if (value instanceof Enum<?> e) return "\"" + escapeJsonString(e.name()) + "\"";
-    return String.valueOf(value);
-  }
-
-  private static String escapeJsonString(String s) {
-    StringBuilder sb = new StringBuilder(s.length() + 16);
-    for (int i = 0; i < s.length(); i++) {
-      char c = s.charAt(i);
-      switch (c) {
-        case '"' -> sb.append("\\\"");
-        case '\\' -> sb.append("\\\\");
-        case '\n' -> sb.append("\\n");
-        case '\r' -> sb.append("\\r");
-        case '\t' -> sb.append("\\t");
-        case '\b' -> sb.append("\\b");
-        case '\f' -> sb.append("\\f");
-        default -> {
-          if (c < 0x20) {
-            sb.append(String.format("\\u%04X", (int) c));
-          } else {
-            sb.append(c);
-          }
-        }
-      }
-    }
-    return sb.toString();
   }
 }

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/audit/adapter/persistence/AuditLogPersistenceAdapterTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/audit/adapter/persistence/AuditLogPersistenceAdapterTest.java
@@ -5,11 +5,22 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.json.JsonMapper;
+import xyz.dgz48.tasks.webapi.audit.usecase.AuditFieldChange;
 
-/** {@link AuditLogPersistenceAdapter#computeChainHash} のユニットテスト。 */
+/** {@link AuditLogPersistenceAdapter} のユニットテスト。 */
 class AuditLogPersistenceAdapterTest {
+
+  private static JsonMapper defaultJsonMapper() {
+    // Jackson 3.x では DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS がデフォルト false のため
+    // LocalDate は設定なしで "2026-08-01" のような ISO 文字列にシリアライズされる
+    return JsonMapper.builder().build();
+  }
 
   @Test
   void computeChainHash_whenNoPreviousRecord_returnsGenesisHash() {
@@ -32,6 +43,50 @@ class AuditLogPersistenceAdapterTest {
     assertThat(hash).isEqualTo(sha256Hex(expectedInput));
     assertThat(hash).matches("[0-9a-f]{64}");
     assertThat(hash).isNotEqualTo("0".repeat(64));
+  }
+
+  @Test
+  void serializeDetail_null_returnsEmptyObject() {
+    var adapter = newAdapter();
+    assertThat(adapter.serializeDetail(null)).isEqualTo("{}");
+  }
+
+  @Test
+  void serializeDetail_emptyMap_returnsEmptyObject() {
+    var adapter = newAdapter();
+    assertThat(adapter.serializeDetail(Map.of())).isEqualTo("{}");
+  }
+
+  @Test
+  void serializeDetail_simpleMap_returnsValidJson() {
+    var adapter = newAdapter();
+    String json = adapter.serializeDetail(Map.of("taskId", 42L));
+    assertThat(json).isEqualTo("{\"taskId\":42}");
+  }
+
+  @Test
+  void serializeDetail_localDate_isQuotedAsIsoString() {
+    // LocalDate.of(2026, 8, 1) → "2026-08-01"(引用符あり)で出力される回帰テスト(PR #703 再発防止)
+    var adapter = newAdapter();
+    List<AuditFieldChange> changes =
+        List.of(new AuditFieldChange("dueDate", null, LocalDate.of(2026, 8, 1)));
+    String json = adapter.serializeDetail(changes);
+    assertThat(json).contains("\"2026-08-01\"");
+    assertThat(json).doesNotContain("2026-08-01\"\"");
+  }
+
+  @Test
+  void serializeDetail_auditFieldChange_usesOldNewKeys() {
+    var adapter = newAdapter();
+    List<AuditFieldChange> changes = List.of(new AuditFieldChange("title", "旧タイトル", "新タイトル"));
+    String json = adapter.serializeDetail(changes);
+    assertThat(json).contains("\"field\":\"title\"");
+    assertThat(json).contains("\"old\":\"旧タイトル\"");
+    assertThat(json).contains("\"new\":\"新タイトル\"");
+  }
+
+  private static AuditLogPersistenceAdapter newAdapter() {
+    return new AuditLogPersistenceAdapter(null, null, defaultJsonMapper());
   }
 
   private static String sha256Hex(String input) {

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/usecase/CreateTaskUseCaseTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/usecase/CreateTaskUseCaseTest.java
@@ -14,6 +14,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -97,7 +98,7 @@ class CreateTaskUseCaseTest {
     assertThat(result.getStatus()).isEqualTo(TaskStatus.NOT_STARTED);
     assertThat(result.getId()).isEqualTo(1L);
     verify(auditLogPort)
-        .record(eq(AuditEventType.TASK_CREATED), eq(TENANT_ID), eq(OWNER_ID), any(String.class));
+        .record(eq(AuditEventType.TASK_CREATED), eq(TENANT_ID), eq(OWNER_ID), any());
   }
 
   @Test
@@ -233,6 +234,7 @@ class CreateTaskUseCaseTest {
         null);
 
     verify(auditLogPort)
-        .record(eq(AuditEventType.TASK_CREATED), eq(TENANT_ID), eq(OWNER_ID), eq("{\"taskId\":1}"));
+        .record(
+            eq(AuditEventType.TASK_CREATED), eq(TENANT_ID), eq(OWNER_ID), eq(Map.of("taskId", 1L)));
   }
 }

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/usecase/UpdateTaskUseCaseTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/usecase/UpdateTaskUseCaseTest.java
@@ -20,6 +20,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.openapitools.jackson.nullable.JsonNullable;
 import xyz.dgz48.tasks.webapi.audit.domain.AuditEventType;
+import xyz.dgz48.tasks.webapi.audit.usecase.AuditFieldChange;
 import xyz.dgz48.tasks.webapi.audit.usecase.AuditLogPort;
 import xyz.dgz48.tasks.webapi.shared.exception.PreconditionFailedException;
 import xyz.dgz48.tasks.webapi.task.domain.FieldChange;
@@ -156,11 +157,14 @@ class UpdateTaskUseCaseTest {
     assertThat(result).isSameAs(saved);
     verify(taskRepository).save(task);
     verify(auditLogPort)
-        .record(eq(AuditEventType.TASK_UPDATED), eq(TENANT_ID), eq(OWNER_ID), any(String.class));
+        .record(eq(AuditEventType.TASK_UPDATED), eq(TENANT_ID), eq(OWNER_ID), any());
   }
 
   @Test
-  void execute_audit_detail_quotesLocalDate() {
+  @SuppressWarnings("unchecked")
+  void execute_audit_detail_localDateFieldPassedToPort() {
+    // LocalDate 値が AuditFieldChange に正しく詰め替えられて Port に渡されることを検証(PR #703 回帰)
+    // 実際の JSON シリアライズ("2026-08-01" 引用符あり)は AuditLogPersistenceAdapterTest で検証する
     Task task = buildTask();
     List<FieldChange> changes = List.of(new FieldChange("dueDate", null, LocalDate.of(2026, 8, 1)));
 
@@ -173,10 +177,12 @@ class UpdateTaskUseCaseTest {
 
     useCase.execute(TASK_ID, OWNER_ID, titleOnlyCmd(), VERSION);
 
-    ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
     verify(auditLogPort)
         .record(eq(AuditEventType.TASK_UPDATED), eq(TENANT_ID), eq(OWNER_ID), captor.capture());
-    // LocalDate は "2026-08-01" と引用符付きで出力されなければならない（修正前は引用符なしで 500 になった）
-    assertThat(captor.getValue()).contains("\"2026-08-01\"");
+    List<AuditFieldChange> detail = (List<AuditFieldChange>) captor.getValue();
+    assertThat(detail).hasSize(1);
+    assertThat(detail.get(0).field()).isEqualTo("dueDate");
+    assertThat(detail.get(0).newValue()).isEqualTo(LocalDate.of(2026, 8, 1));
   }
 }


### PR DESCRIPTION
closes #702

## Summary

- `AuditLogPort.record` の `detail` 引数を `String` → `@Nullable Object` に変更し、JSON 生成責務を UseCase から除去
- `AuditLogPersistenceAdapter` に Spring 自動設定の `JsonMapper` を注入し `serializeDetail()` で一元シリアライズ（`null` → `"{}"` / `LocalDate` 等は Jackson 3.x デフォルトの ISO 文字列）
- diff 用 `AuditFieldChange` レコードを新設（`@JsonProperty("old"/"new")` でキー名を固定）
- 12 ヶ所の UseCase で手組み JSON 構築メソッド（`buildAuditDetail` / `buildDiffDetail` / `buildListDetail` / `toJsonValue` / `escapeJsonString`）を全削除し `Map.of()` / `List<AuditFieldChange>` に置換
- PR #703 の `LocalDate` 応急修正を本実装に統合（応急パッチは自然消滅）
- `AuditLogPersistenceAdapterTest` に `serializeDetail` + `LocalDate` 引用符回帰テストを追加
- コーディング規約 §7.1「監査ログ detail — 手組み JSON 禁止」を追記

## Test plan

- [x] `./gradlew :webapi:check` — BUILD SUCCESSFUL（全テスト・Spotless・NullAway グリーン）
- [x] `serializeDetail_localDate_isQuotedAsIsoString` — `LocalDate` が `"2026-08-01"` 形式で出力されることを回帰テストで確認
- [x] `serializeDetail_auditFieldChange_usesOldNewKeys` — `"old"/"new"` キーが JSON に出力されることを確認
- [x] `execute_audit_detail_localDateFieldPassedToPort` — UseCase が `LocalDate` を `AuditFieldChange.newValue` に正しく詰めることを確認

## 未対応レビュー

| 指摘 | 内容 | 状態 |
|---|---|---|
| [jackson アノテーション namespace](https://github.com/win2cot/tasks-webapi/pull/704#pullrequestreview-8017462172) | `com.fasterxml.jackson.annotation.JsonProperty` → `tools.jackson.annotation.JsonProperty` への変更要求 | declined: 後述 |
