### PR TITLE
feat(e2e): Playwright 基盤を e2e/ に scaffold (ADR-0023 §6 Step 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,9 @@ web/vendor/
 
 # Playwright MCP snapshot artifacts
 .playwright-mcp/
+
+# e2e/ Playwright artifacts (generated)
+e2e/node_modules/
+e2e/test-results/
+e2e/playwright-report/
+e2e/.cache/

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -1,0 +1,99 @@
+{
+  "name": "tasks-e2e",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "tasks-e2e",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@playwright/test": "^1.54.0",
+        "@types/node": "^24.0.0"
+      },
+      "engines": {
+        "node": ">=24"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.0.tgz",
+      "integrity": "sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.13.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
+      "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
+      "integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
+      "integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -8,8 +8,8 @@
       "name": "tasks-e2e",
       "version": "1.0.0",
       "devDependencies": {
-        "@playwright/test": "^1.54.0",
-        "@types/node": "^24.0.0"
+        "@playwright/test": "^1.61.0",
+        "@types/node": "^24.13.2"
       },
       "engines": {
         "node": ">=24"

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "tasks-e2e",
+  "private": true,
+  "version": "1.0.0",
+  "description": "Tasks SaaS E2E テスト (Playwright / TypeScript)",
+  "scripts": {
+    "test": "playwright test",
+    "test:headed": "playwright test --headed",
+    "report": "playwright show-report"
+  },
+  "engines": {
+    "node": ">=24"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.61.0",
+    "@types/node": "^24.13.2"
+  }
+}

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: [['html', { open: 'never' }]],
+  use: {
+    baseURL: process.env.BASE_URL ?? 'http://localhost:5500',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});

--- a/e2e/tests/top.spec.ts
+++ b/e2e/tests/top.spec.ts
@@ -1,0 +1,9 @@
+import { expect, test } from '@playwright/test';
+
+// 未認証ユーザーがトップ(/)を開くと Keycloak ログインページへリダイレクトされる。
+// これが full-stack の「トップ表示」の正常系。
+test('トップページが表示される', async ({ page }) => {
+  await page.goto('/');
+  await page.waitForURL(/\/realms\/tasks\//);
+  await expect(page.getByRole('heading', { name: 'Sign in to your account' })).toBeVisible();
+});

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/renovate.json
+++ b/renovate.json
@@ -65,6 +65,10 @@
       "addLabels": ["area/web", "renovate"]
     },
     {
+      "matchFileNames": ["e2e/**"],
+      "addLabels": ["area/e2e", "renovate"]
+    },
+    {
       "matchFileNames": [".github/**"],
       "addLabels": ["area/ci", "renovate"]
     },


### PR DESCRIPTION
## Summary

- `e2e/` を新設し `@playwright/test@^1.61.0` + TypeScript 設定を配置
- 最小 1 spec(`tests/top.spec.ts`): `/` → Keycloak ログインページへのリダイレクトを確認(full-stack 時の「トップ表示」正常系)
- `e2e/node_modules/` 等を `.gitignore` に追加
- `renovate.json` に `e2e/**` → `area/e2e` ラベルルールを追加し Renovate npm 管理対象に組み込み

ADR-0023 §6 の Step 1(scaffold)に対応。Step 2(compose 拡張)以降は後続 issue で実施。

Closes #537

## Test plan

- [x] `cd e2e && npx playwright test` — 1 passed (1.5s) (Keycloak + web server 起動済み環境で確認)
- [x] `@playwright/test@1.61.0` / `@types/node@24.13.2` — `npm outdated` でギャップなし(24 系最新)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 未対応レビュー

| 指摘 | 内容 | ステータス |
|---|---|---|
| (なし) | — | — |
