### PR TITLE
feat(e2e): 既存機能スモークテスト spec を backfill (ADR-0023 §6 Step 4 / #540)

### DIFF
--- a/e2e/fixtures/auth.ts
+++ b/e2e/fixtures/auth.ts
@@ -1,0 +1,21 @@
+import type { Page } from '@playwright/test';
+
+export const MEMBER1 = {
+  username: 'tenant1-member1@example.com',
+  password: 'password',
+} as const;
+
+/**
+ * Keycloak PKCE ログインを実行して tasks.html に到達するまで待機する。
+ * tenant1-member1 は tenant1 に 1 所属しているため index.html が自動でテナントを
+ * 選択し tasks.html にリダイレクトする。
+ */
+export async function loginAs(page: Page, username: string, password: string): Promise<void> {
+  await page.goto('/');
+  await page.waitForURL(/\/realms\/tasks\//);
+  await page.fill('#username', username);
+  await page.fill('#password', password);
+  await page.click('#kc-login');
+  // index.html が /api/auth/me を呼び、単一テナントを自動選択して tasks.html へ転送する。
+  await page.waitForURL(/\/tasks\.html/, { timeout: 15_000 });
+}

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -2,10 +2,10 @@ import { defineConfig, devices } from '@playwright/test';
 
 export default defineConfig({
   testDir: './tests',
-  fullyParallel: true,
+  fullyParallel: false,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 1 : undefined,
+  workers: 1,
   reporter: [['html', { open: 'never' }]],
   use: {
     baseURL: process.env.BASE_URL ?? 'http://localhost:5500',

--- a/e2e/tests/auth.spec.ts
+++ b/e2e/tests/auth.spec.ts
@@ -1,0 +1,14 @@
+import { expect, test } from '@playwright/test';
+import { loginAs, MEMBER1 } from '../fixtures/auth';
+
+// ADR-0023 §6 Step 4 — Keycloak ログイン往復
+// 認証情報を入力して Keycloak PKCE フローを完了し、
+// tasks.html(タスク一覧)へ戻ることを確認する。
+// ※ 未認証での Keycloak リダイレクトは top.spec.ts が担当する。
+
+test('Keycloak ログイン後にタスク一覧へ遷移して認証済み状態になる', async ({ page }) => {
+  await loginAs(page, MEMBER1.username, MEMBER1.password);
+  await expect(page.getByRole('heading', { name: 'タスク一覧' })).toBeVisible();
+  // ナビバーにユーザー名が表示される
+  await expect(page.locator('#nav-username')).not.toBeEmpty();
+});

--- a/e2e/tests/tasks.spec.ts
+++ b/e2e/tests/tasks.spec.ts
@@ -1,0 +1,65 @@
+import { expect, test } from '@playwright/test';
+import { loginAs, MEMBER1 } from '../fixtures/auth';
+
+// ADR-0023 §6 Step 4 — タスク一覧 + CRUD ハッピーパス
+
+test.describe('タスク一覧 + CRUD', () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAs(page, MEMBER1.username, MEMBER1.password);
+    // タスクパネルが表示されるまで待機
+    await expect(page.locator('#task-panel')).toBeVisible({ timeout: 15_000 });
+  });
+
+  test('タスク一覧パネルが表示される', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: 'タスク一覧' })).toBeVisible();
+    await expect(page.locator('table[aria-label="タスク一覧"]')).toBeVisible();
+  });
+
+  test('タスクを作成・詳細表示・ステータス変更・削除できる', async ({ page }) => {
+    const taskTitle = `E2E smoke ${Date.now()}`;
+
+    // ── Create ─────────────────────────────────────────────────────────────
+    await page.click('#btn-new-task');
+    // ドロワーが開くまで待機
+    const drawer = page.locator('app-task-drawer .offcanvas');
+    await expect(drawer).toBeVisible({ timeout: 5_000 });
+
+    await page.fill('#newTitle', taskTitle);
+    await page.fill('#newDue', '2099-12-31');
+    // 優先度はデフォルト MEDIUM、公開範囲はデフォルト TENANT のまま送信
+    await drawer.locator('button[type="submit"]').click();
+
+    // ドロワーが閉じてタスク一覧に反映されるのを待つ
+    await expect(drawer).not.toBeVisible({ timeout: 10_000 });
+    await expect(page.locator('#task-tbody')).toContainText(taskTitle, { timeout: 10_000 });
+
+    // ── Read (detail) ──────────────────────────────────────────────────────
+    // タスク行のオーナーセルをクリックして詳細ドロワーを開く
+    // (.cell-title-desc は editable タスクでは data-no-row-click が付くため .cell-owner を使う)
+    const taskRow = page.locator('app-task-row').filter({
+      has: page.locator('.task-title', { hasText: taskTitle }),
+    });
+    await taskRow.locator('td.cell-owner').click();
+
+    await expect(drawer).toBeVisible({ timeout: 5_000 });
+    await expect(drawer.locator('.offcanvas-title')).toContainText(taskTitle);
+
+    // ── Update (status change) ─────────────────────────────────────────────
+    const statusSel = drawer.locator('select.inline-sel');
+    await expect(statusSel).toBeVisible();
+    await statusSel.selectOption('IN_PROGRESS');
+    // 詳細ビューが再レンダリングされ、選択が反映される
+    await expect(drawer.locator('select.inline-sel')).toHaveValue('IN_PROGRESS', {
+      timeout: 5_000,
+    });
+
+    // ── Delete ─────────────────────────────────────────────────────────────
+    await drawer.locator('.btn-outline-danger').click();
+    // 削除確認ボタンが表示される
+    await drawer.locator('button.btn-danger').click();
+
+    // ドロワーが閉じてタスクが一覧から消えるのを確認
+    await expect(drawer).not.toBeVisible({ timeout: 5_000 });
+    await expect(page.locator('#task-tbody')).not.toContainText(taskTitle, { timeout: 10_000 });
+  });
+});

--- a/e2e/tests/tenant.spec.ts
+++ b/e2e/tests/tenant.spec.ts
@@ -1,0 +1,14 @@
+import { expect, test } from '@playwright/test';
+import { loginAs, MEMBER1 } from '../fixtures/auth';
+
+// ADR-0023 §6 Step 4 — テナント切替
+// ログイン後に単一テナントが自動選択され、ナビバーのテナントチップに
+// テナント名「テナント1」が表示されることを確認する。
+
+test('ログイン後にテナント名がナビバーに表示される', async ({ page }) => {
+  await loginAs(page, MEMBER1.username, MEMBER1.password);
+
+  const switcher = page.locator('app-tenant-switcher');
+  await expect(switcher).toBeVisible();
+  await expect(switcher).toContainText('テナント1');
+});


### PR DESCRIPTION
## Summary

- ADR-0023 §6 Step 4 の backfill: Keycloak ログイン往復 / テナント表示 / タスク CRUD のハッピーパス spec を `e2e/tests/` に追加
- `e2e/fixtures/auth.ts` に共通ログインヘルパー `loginAs()` と種データアカウント `MEMBER1` を切り出し
- `playwright.config.ts` を `workers: 1 / fullyParallel: false` に統一（start-dev Keycloak H2 の並行セッション競合を回避し、CI と同設定に揃える）

### 追加ファイル

| ファイル | 内容 |
|---|---|
| `e2e/fixtures/auth.ts` | Keycloak PKCE ログインヘルパー + `MEMBER1` 定数 |
| `e2e/tests/auth.spec.ts` | Keycloak ログイン往復 spec（認証後 tasks.html 到達・ユーザー名表示確認） |
| `e2e/tests/tenant.spec.ts` | テナント自動選択 spec（ナビバーに「テナント1」バッジ表示確認） |
| `e2e/tests/tasks.spec.ts` | タスク一覧 + CRUD smoke spec（作成→詳細→ステータス変更→削除） |

## Test plan

- [x] `npx playwright test --workers=1` で 5/5 全テスト通過を確認（ローカルフルスタック: MySQL + Keycloak + webapi + web）
- [ ] CI e2e-test.yml での通過確認（`CI=true` → `workers: 1` のため並行競合なし）

Closes #540

🤖 Generated with [Claude Code](https://claude.com/claude-code)