### PR TITLE
feat(e2e): CSP 違反0 の共通フィクスチャ (ADR-0023 §6 Step 5 / ADR-0022 (b) / #541)

### DIFF
--- a/e2e/fixtures/test.ts
+++ b/e2e/fixtures/test.ts
@@ -1,0 +1,50 @@
+import { test as base, expect } from '@playwright/test';
+
+// ADR-0023 §6 Step 5 / ADR-0022 (b) — CSP 違反 0 の共通フィクスチャ
+// すべてのテストに auto で適用し、securitypolicyviolation イベントが 0 件であることを assert する。
+
+type CspViolation = {
+  blockedURI: string;
+  violatedDirective: string;
+  documentURI: string;
+};
+
+declare global {
+  interface Window {
+    __pwCspViolation: (v: CspViolation) => void;
+  }
+}
+
+export const test = base.extend<{ _csp: void }>({
+  _csp: [
+    async ({ page }, use) => {
+      const violations: CspViolation[] = [];
+
+      // Node.js 側のコールバックをブラウザ全ナビゲーションで永続的に公開する
+      await page.exposeFunction('__pwCspViolation', (v: CspViolation) => {
+        violations.push(v);
+      });
+
+      // ページロード前に securitypolicyviolation リスナーを全ナビゲーションへ注入する
+      await page.addInitScript(() => {
+        document.addEventListener('securitypolicyviolation', (e) => {
+          window.__pwCspViolation({
+            blockedURI: e.blockedURI,
+            violatedDirective: e.violatedDirective,
+            documentURI: e.documentURI,
+          });
+        });
+      });
+
+      await use();
+
+      expect(
+        violations,
+        `CSP violations detected:\n${JSON.stringify(violations, null, 2)}`,
+      ).toHaveLength(0);
+    },
+    { auto: true },
+  ],
+});
+
+export { expect } from '@playwright/test';

--- a/e2e/tests/auth.spec.ts
+++ b/e2e/tests/auth.spec.ts
@@ -1,5 +1,5 @@
-import { expect, test } from '@playwright/test';
 import { loginAs, MEMBER1 } from '../fixtures/auth';
+import { expect, test } from '../fixtures/test';
 
 // ADR-0023 §6 Step 4 — Keycloak ログイン往復
 // 認証情報を入力して Keycloak PKCE フローを完了し、

--- a/e2e/tests/tasks.spec.ts
+++ b/e2e/tests/tasks.spec.ts
@@ -1,5 +1,5 @@
-import { expect, test } from '@playwright/test';
 import { loginAs, MEMBER1 } from '../fixtures/auth';
+import { expect, test } from '../fixtures/test';
 
 // ADR-0023 §6 Step 4 — タスク一覧 + CRUD ハッピーパス
 

--- a/e2e/tests/tenant.spec.ts
+++ b/e2e/tests/tenant.spec.ts
@@ -1,5 +1,5 @@
-import { expect, test } from '@playwright/test';
 import { loginAs, MEMBER1 } from '../fixtures/auth';
+import { expect, test } from '../fixtures/test';
 
 // ADR-0023 §6 Step 4 — テナント切替
 // ログイン後に単一テナントが自動選択され、ナビバーのテナントチップに

--- a/e2e/tests/top.spec.ts
+++ b/e2e/tests/top.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from '../fixtures/test';
 
 // 未認証ユーザーがトップ(/)を開くと Keycloak ログインページへリダイレクトされる。
 // これが full-stack の「トップ表示」の正常系。

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "lib": ["ES2022"],
+    "lib": ["ES2022", "DOM"],
     "module": "CommonJS",
     "moduleResolution": "node",
     "strict": true,


### PR DESCRIPTION
## Summary

- `e2e/fixtures/test.ts` を新設: `securitypolicyviolation` イベントを全テストに自動適用する Playwright auto fixture
- `page.exposeFunction` + `page.addInitScript` の組み合わせで全ナビゲーション(cross-origin 含む)の違反を Node.js 側に集約し、テスト終了時に違反 0 件を assert する
- `e2e/tsconfig.json` に `"DOM"` lib を追加（`Window` / `SecurityPolicyViolationEvent` の型解決）
- 全 4 spec の import を `@playwright/test` → `../fixtures/test` に変更（`_csp` fixture は `auto: true` のため spec 側の記述変更は不要）

Closes #541
Refs #530 (ADR-0022)

## Test plan

- [x] ローカルでフルスタック起動済みの状態で `npx playwright test` を実行 → 5/5 passed (8.8s)
- [x] TypeScript 型検査エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)