### PR TITLE
feat(ci): e2e-test.yml に Playwright ブラウザキャッシュを追加 (#712)

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -137,9 +137,23 @@ jobs:
           done
 
       # ── Playwright ───────────────────────────────────────────────────────
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('e2e/package-lock.json') }}
+          restore-keys: |
+            playwright-${{ runner.os }}-
+
       - name: Install Playwright browsers
         working-directory: e2e
-        run: npx playwright install --with-deps chromium
+        run: |
+          if [ "${{ steps.playwright-cache.outputs.cache-hit }}" = "true" ]; then
+            npx playwright install-deps chromium
+          else
+            npx playwright install --with-deps chromium
+          fi
 
       - name: Run Playwright tests
         working-directory: e2e


### PR DESCRIPTION
## Summary

- `~/.cache/ms-playwright` を `actions/cache` でキャッシュ(キー: `playwright-{os}-{e2e/package-lock.json hash}`)
- `restore-keys` に `playwright-{os}-` を追加し、バージョン更新時の完全 cold を回避
- キャッシュヒット時は `playwright install-deps chromium` で OS 依存のみ解決(バイナリ再ダウンロードをスキップ)
- キャッシュミス時は従来どおり `playwright install --with-deps chromium` を実行

## Test plan

- [ ] CI run でキャッシュミス時: `Install Playwright browsers` が `--with-deps` を実行しテスト green
- [ ] 2回目 CI run でキャッシュヒット時: `Cache Playwright browsers` ステップが "Cache restored" を表示し、バイナリダウンロードをスキップしてテスト green
- [ ] `e2e-lint.yml` に変更なし(スコープ外)

Closes #712

🤖 Generated with [Claude Code](https://claude.com/claude-code)