### PR TITLE
fix(ci): green run で test-results upload の警告を抑止 (#714)

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -175,3 +175,4 @@ jobs:
         with:
           name: playwright-results
           path: e2e/test-results/
+          if-no-files-found: ignore


### PR DESCRIPTION
## Summary

- `e2e-test.yml` の `Upload test results (trace / video)` ステップに `if-no-files-found: ignore` を追加
- 全 green run では `playwright.config.ts` の設定(trace: on-first-retry / screenshot: only-on-failure / video: retain-on-failure)により `test-results/` が生成されないため、`actions/upload-artifact` がデフォルト動作(warn)で警告を出していた
- `if-no-files-found: ignore` を明示することで、失敗/リトライ時のみ成果物が出る意図を示しつつ警告ノイズを除去
- `playwright-report/` の upload ステップは毎回成果物があるため変更不要

## Test plan

- [ ] green run でワークフローを実行し `No files were found` 警告が出ないことをログで確認
- [ ] 失敗 / リトライを含む run では trace / video が artifact としてアップロードされること(回帰なし)
- [ ] `playwright-report` の upload ステップが引き続き成功すること

Closes #714

🤖 Generated with [Claude Code](https://claude.com/claude-code)