### PR TITLE
feat(observability): OTel 公式スターター導入 + Prometheus レジストリ撤去 (#584)

### DIFF
--- a/webapi/build.gradle
+++ b/webapi/build.gradle
@@ -55,8 +55,8 @@ dependencies {
     // MySQL
     runtimeOnly 'com.mysql:mysql-connector-j'
 
-    // Prometheus metrics
-    implementation 'io.micrometer:micrometer-registry-prometheus'
+    // OpenTelemetry (traces + metrics via OTLP; OFF by default — ADR-0029 §3.2)
+    implementation 'org.springframework.boot:spring-boot-starter-opentelemetry'
 
     // Testcontainers
     testImplementation 'org.springframework.boot:spring-boot-testcontainers'

--- a/webapi/src/main/resources/application.yml
+++ b/webapi/src/main/resources/application.yml
@@ -39,7 +39,14 @@ management:
   endpoints:
     web:
       exposure:
-        include: health,info,prometheus
+        include: health,info
+  tracing:
+    sampling:
+      probability: 0
+  otlp:
+    metrics:
+      export:
+        enabled: false
 
 logging:
   level:

--- a/webapi/src/test/resources/application.yml
+++ b/webapi/src/test/resources/application.yml
@@ -8,6 +8,12 @@ OIDC_ISSUER_URI: http://localhost:8080/realms/tasks
 cors:
   allowed-origins: http://localhost:8080,http://localhost:5500
 
+management:
+  otlp:
+    metrics:
+      export:
+        enabled: false
+
 spring:
   security:
     oauth2:


### PR DESCRIPTION
## Summary

- `spring-boot-starter-opentelemetry` を追加 (`micrometer-tracing-bridge-otel` / `micrometer-registry-otlp` 同梱、ADR-0029 §3.1)
- `micrometer-registry-prometheus` を削除、`management.endpoints.web.exposure.include` から `prometheus` を除去
- 既定 OFF 設定: `management.tracing.sampling.probability=0` + `management.otlp.metrics.export.enabled=false`
- テスト用 `application.yml` にも `enabled=false` を追記(Spring Boot テスト実行時は test YAML が main YAML を上書きするため、条件評価に必要)

## 実装メモ

- `@ConditionalOnEnabledMetricsExport("otlp")` は `management.otlp.metrics.export.enabled` を raw `Environment` から参照するため、`@ConfigurationProperties` バインディングとは別に明示設定が必要
- OTLP エンドポイント未設定 + sampling 0 の状態でシャットダウン時に `ConnectException` WARN が出ないことをローカルテストで確認済み

## 未確認項目

- Native Image ビルド(ローカルマシンのリソース不足のため CI での確認待ち)

## Closes

Closes #584

## Test plan

- [x] `./gradlew :webapi:test` — 全テスト通過
- [x] `./gradlew :webapi:spotlessCheck` — フォーマット OK
- [ ] CI: `native-build.yml` による Native Image ビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)