### PR TITLE
feat(ci): e2e-test / webapi-native-build に push:branches[main] を追加

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -4,6 +4,8 @@ name: "E2E: Test"
 
 on:
   pull_request:
+  push:
+    branches: [main]
 
 env:
   LANG: ja_JP.UTF-8

--- a/.github/workflows/webapi-native-build.yml
+++ b/.github/workflows/webapi-native-build.yml
@@ -9,6 +9,8 @@ name: "Webapi: Native Build"
 on:
   pull_request:
     branches: [main]
+  push:
+    branches: [main]
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
## Summary

- `e2e-test.yml` の `on:` に `push: branches: [main]` を追加(Playwright キャッシュを `refs/heads/main` スコープに seed)
- `webapi-native-build.yml` の `on:` に `push: branches: [main]` を追加(GraalVM / Gradle キャッシュを main スコープに seed + native の main 実体ビルド検証)
- 既存の `concurrency: cancel-in-progress: true`(`${{ github.workflow }}-${{ github.ref }}` グループ)により main 連続マージ時の直列化は維持
- `paths-filter` ゲートは push:main でも従来どおり機能(push diff ベースでフィルタ)

## Test plan

- [ ] main マージ後に `E2E: Test` / `Webapi: Native Build` が `refs/heads/main` スコープで実行されること
- [ ] Actions caches で `ref=refs/heads/main` のキャッシュエントリが作成されること
- [ ] 以降の新規 PR の初回 run で playwright / graalvm キャッシュがヒットすること
- [ ] `terraform-plan.yml` 等の対象外ワークフローに変更がないこと

## References

Closes #718
ADR-0035 (#717) に基づく実装。

🤖 Generated with [Claude Code](https://claude.ai/claude-code)