### PR TITLE
feat(observability): @Observed 計装 + adapter.persistence 計装 + OTLP 動作確認 (#585)

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -51,5 +51,22 @@ services:
       retries: 15
       start_period: 60s
 
+  # otel-lgtm: ローカル計測用 OTLP レシーバ + Grafana + Tempo + Prometheus (ADR-0029 §3.1)
+  # Grafana UI: http://localhost:3000 (admin/admin)
+  # OTLP HTTP:  http://localhost:4318  ← webapi の OTLP エンドポイントに指定する
+  otel-lgtm:
+    image: grafana/otel-lgtm:0.8.2
+    ports:
+      - "3000:3000"   # Grafana
+      - "4317:4317"   # OTLP gRPC
+      - "4318:4318"   # OTLP HTTP
+    healthcheck:
+      # otel-lgtm は起動完了時に /tmp/ready を作成する
+      test: ["CMD", "test", "-f", "/tmp/ready"]
+      interval: 5s
+      timeout: 3s
+      retries: 24
+      start_period: 20s
+
 volumes:
   mysql-data:

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/adapter/persistence/AuditLogPersistenceAdapter.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/adapter/persistence/AuditLogPersistenceAdapter.java
@@ -1,5 +1,6 @@
 package xyz.dgz48.tasks.webapi.audit.adapter.persistence;
 
+import io.micrometer.observation.annotation.Observed;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -12,6 +13,7 @@ import tools.jackson.databind.json.JsonMapper;
 import xyz.dgz48.tasks.webapi.audit.domain.AuditEventType;
 import xyz.dgz48.tasks.webapi.audit.usecase.AuditLogPort;
 
+@Observed(name = "audit.repository")
 @Component
 class AuditLogPersistenceAdapter implements AuditLogPort {
 

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/shared/infra/ObservabilityConfig.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/shared/infra/ObservabilityConfig.java
@@ -1,0 +1,21 @@
+package xyz.dgz48.tasks.webapi.shared.infra;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.support.ContextPropagatingTaskDecorator;
+
+/**
+ * Micrometer Observation / トレース伝播設定(ADR-0029 §6.1)。
+ *
+ * <p>{@link ContextPropagatingTaskDecorator} を Bean 登録することで、Spring Boot の {@code
+ * ThreadPoolTaskExecutorBuilder} が自動的にこのデコレータを適用し、{@code @Async} スレッドプール全体で Micrometer
+ * トレースコンテキストを伝播させる。
+ */
+@Configuration(proxyBeanMethods = false)
+class ObservabilityConfig {
+
+  @Bean
+  ContextPropagatingTaskDecorator contextPropagatingTaskDecorator() {
+    return new ContextPropagatingTaskDecorator();
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/adapter/persistence/TaskJpaRepositoryAdapter.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/adapter/persistence/TaskJpaRepositoryAdapter.java
@@ -1,5 +1,6 @@
 package xyz.dgz48.tasks.webapi.task.adapter.persistence;
 
+import io.micrometer.observation.annotation.Observed;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
@@ -28,6 +29,7 @@ import xyz.dgz48.tasks.webapi.task.domain.TaskStatus;
 import xyz.dgz48.tasks.webapi.task.domain.Visibility;
 import xyz.dgz48.tasks.webapi.task.usecase.TaskRepository;
 
+@Observed(name = "task.repository")
 @Component
 @RequiredArgsConstructor
 class TaskJpaRepositoryAdapter implements TaskRepository {

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/adapter/persistence/TaskStakeholderJpaRepositoryAdapter.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/adapter/persistence/TaskStakeholderJpaRepositoryAdapter.java
@@ -1,5 +1,6 @@
 package xyz.dgz48.tasks.webapi.task.adapter.persistence;
 
+import io.micrometer.observation.annotation.Observed;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -7,6 +8,7 @@ import org.springframework.stereotype.Component;
 import xyz.dgz48.tasks.webapi.task.domain.TaskStakeholder;
 import xyz.dgz48.tasks.webapi.task.usecase.StakeholderRepository;
 
+@Observed(name = "task.stakeholder.repository")
 @Component
 @RequiredArgsConstructor
 class TaskStakeholderJpaRepositoryAdapter implements StakeholderRepository {

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/usecase/AddStakeholderUseCase.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/usecase/AddStakeholderUseCase.java
@@ -1,5 +1,6 @@
 package xyz.dgz48.tasks.webapi.task.usecase;
 
+import io.micrometer.observation.annotation.Observed;
 import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -29,6 +30,7 @@ public class AddStakeholderUseCase {
   private final AuditLogPort auditLogPort;
   private final Clock clock;
 
+  @Observed(name = "task.stakeholder.add")
   @Transactional
   public TaskStakeholder execute(Long taskId, Long operatorUserId, Long targetUserId) {
     Task task =

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/usecase/ChangeTaskStatusUseCase.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/usecase/ChangeTaskStatusUseCase.java
@@ -1,5 +1,7 @@
 package xyz.dgz48.tasks.webapi.task.usecase;
 
+import io.micrometer.observation.annotation.ObservationKeyValue;
+import io.micrometer.observation.annotation.Observed;
 import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -22,8 +24,10 @@ public class ChangeTaskStatusUseCase {
   private final TaskAuthorizationDomainService taskAuthorizationDomainService;
   private final Clock clock;
 
+  @Observed(name = "task.change-status")
   @Transactional
-  public Task execute(Long taskId, Long userId, TaskStatus newStatus) {
+  public Task execute(
+      Long taskId, Long userId, @ObservationKeyValue("task.new-status") TaskStatus newStatus) {
     Task task =
         taskRepository.findById(taskId).orElseThrow(() -> new TaskNotFoundException(taskId));
     List<Long> stakeholderUserIds =

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/usecase/ChangeVisibilityUseCase.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/usecase/ChangeVisibilityUseCase.java
@@ -1,5 +1,7 @@
 package xyz.dgz48.tasks.webapi.task.usecase;
 
+import io.micrometer.observation.annotation.ObservationKeyValue;
+import io.micrometer.observation.annotation.Observed;
 import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -29,11 +31,12 @@ public class ChangeVisibilityUseCase {
   private final AuditLogPort auditLogPort;
   private final Clock clock;
 
+  @Observed(name = "task.change-visibility")
   @Transactional
   public Task execute(
       Long taskId,
       Long userId,
-      Visibility newVisibility,
+      @ObservationKeyValue("task.new-visibility") Visibility newVisibility,
       @Nullable List<Long> stakeholderUserIds,
       Long ifMatchVersion) {
 

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/usecase/CreateTaskUseCase.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/usecase/CreateTaskUseCase.java
@@ -1,5 +1,6 @@
 package xyz.dgz48.tasks.webapi.task.usecase;
 
+import io.micrometer.observation.annotation.Observed;
 import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -41,6 +42,7 @@ public class CreateTaskUseCase {
    * @param stakeholderUserIds 関係者 ID リスト(visibility=STAKEHOLDERS 時に反映)
    * @return 作成されたタスク
    */
+  @Observed(name = "task.create")
   @Transactional
   public Task execute(
       Long tenantId,

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/usecase/DeleteTaskUseCase.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/usecase/DeleteTaskUseCase.java
@@ -1,5 +1,6 @@
 package xyz.dgz48.tasks.webapi.task.usecase;
 
+import io.micrometer.observation.annotation.Observed;
 import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -27,6 +28,7 @@ public class DeleteTaskUseCase {
   private final AuditLogPort auditLogPort;
   private final Clock clock;
 
+  @Observed(name = "task.delete")
   @Transactional
   public void execute(Long taskId, Long userId, Long ifMatchVersion) {
     Task task =

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/usecase/GetTaskUseCase.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/usecase/GetTaskUseCase.java
@@ -1,5 +1,6 @@
 package xyz.dgz48.tasks.webapi.task.usecase;
 
+import io.micrometer.observation.annotation.Observed;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -17,6 +18,7 @@ public class GetTaskUseCase {
   private final StakeholderRepository stakeholderRepository;
   private final TaskAuthorizationDomainService taskAuthorizationDomainService;
 
+  @Observed(name = "task.get")
   @Transactional(readOnly = true)
   public Task execute(Long taskId, Long userId) {
     Task task =

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/usecase/ListStakeholdersUseCase.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/usecase/ListStakeholdersUseCase.java
@@ -1,5 +1,6 @@
 package xyz.dgz48.tasks.webapi.task.usecase;
 
+import io.micrometer.observation.annotation.Observed;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -18,6 +19,7 @@ public class ListStakeholdersUseCase {
   private final StakeholderRepository stakeholderRepository;
   private final TaskAuthorizationDomainService taskAuthorizationDomainService;
 
+  @Observed(name = "task.stakeholder.list")
   @Transactional(readOnly = true)
   public List<TaskStakeholder> execute(Long taskId, Long userId) {
     Task task =

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/usecase/ListTasksUseCase.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/usecase/ListTasksUseCase.java
@@ -1,5 +1,6 @@
 package xyz.dgz48.tasks.webapi.task.usecase;
 
+import io.micrometer.observation.annotation.Observed;
 import java.time.Clock;
 import java.time.LocalDate;
 import java.util.List;
@@ -32,6 +33,7 @@ public class ListTasksUseCase {
    * @param pageable ページング / ソート指定
    * @return ページ結果と期限切れ未完了タスク件数
    */
+  @Observed(name = "task.list")
   @Transactional(readOnly = true)
   public Result execute(
       Long userId,

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/usecase/RemoveStakeholderUseCase.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/usecase/RemoveStakeholderUseCase.java
@@ -1,5 +1,6 @@
 package xyz.dgz48.tasks.webapi.task.usecase;
 
+import io.micrometer.observation.annotation.Observed;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +24,7 @@ public class RemoveStakeholderUseCase {
   private final TaskAuthorizationDomainService taskAuthorizationDomainService;
   private final AuditLogPort auditLogPort;
 
+  @Observed(name = "task.stakeholder.remove")
   @Transactional
   public void execute(Long taskId, Long operatorUserId, Long targetUserId) {
     Task task =

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/usecase/UpdateTaskUseCase.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/usecase/UpdateTaskUseCase.java
@@ -1,5 +1,6 @@
 package xyz.dgz48.tasks.webapi.task.usecase;
 
+import io.micrometer.observation.annotation.Observed;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -28,6 +29,7 @@ public class UpdateTaskUseCase {
   private final TaskAuditDiffDomainService taskAuditDiffDomainService;
   private final AuditLogPort auditLogPort;
 
+  @Observed(name = "task.update")
   @Transactional(readOnly = false)
   public Task execute(Long taskId, Long userId, TaskPatchCommand cmd, Long ifMatchVersion) {
     Task task =

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/adapter/persistence/AdminTenantPersistenceAdapter.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/adapter/persistence/AdminTenantPersistenceAdapter.java
@@ -1,5 +1,6 @@
 package xyz.dgz48.tasks.webapi.tenant.adapter.persistence;
 
+import io.micrometer.observation.annotation.Observed;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -15,6 +16,7 @@ import xyz.dgz48.tasks.webapi.tenant.domain.TenantStatus;
 import xyz.dgz48.tasks.webapi.tenant.usecase.AdminTenantRepository;
 
 /** {@link AdminTenantRepository} の JPA 実装。Hibernate Filter 非適用(SaaS Admin 専用経路)。 */
+@Observed(name = "tenant.repository")
 @Component
 @RequiredArgsConstructor
 class AdminTenantPersistenceAdapter implements AdminTenantRepository {

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/adapter/persistence/ListTenantUsersAdapter.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/adapter/persistence/ListTenantUsersAdapter.java
@@ -1,5 +1,6 @@
 package xyz.dgz48.tasks.webapi.tenant.adapter.persistence;
 
+import io.micrometer.observation.annotation.Observed;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -13,6 +14,7 @@ import xyz.dgz48.tasks.webapi.tenant.usecase.ListTenantUsersPort;
 import xyz.dgz48.tasks.webapi.user.adapter.persistence.UserJpaEntity;
 import xyz.dgz48.tasks.webapi.user.adapter.persistence.UserRepository;
 
+@Observed(name = "tenant.repository")
 @Component
 @RequiredArgsConstructor
 class ListTenantUsersAdapter implements ListTenantUsersPort {

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/adapter/persistence/PlatformMetricsPersistenceAdapter.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/adapter/persistence/PlatformMetricsPersistenceAdapter.java
@@ -1,5 +1,6 @@
 package xyz.dgz48.tasks.webapi.tenant.adapter.persistence;
 
+import io.micrometer.observation.annotation.Observed;
 import java.time.Clock;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
@@ -11,6 +12,7 @@ import xyz.dgz48.tasks.webapi.tenant.domain.TenantStatus;
 import xyz.dgz48.tasks.webapi.tenant.usecase.PlatformMetricsPort;
 
 /** {@link PlatformMetricsPort} の JPA 実装。 */
+@Observed(name = "tenant.repository")
 @Component
 @RequiredArgsConstructor
 class PlatformMetricsPersistenceAdapter implements PlatformMetricsPort {

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/adapter/persistence/UserTenantManagementAdapter.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/adapter/persistence/UserTenantManagementAdapter.java
@@ -1,5 +1,6 @@
 package xyz.dgz48.tasks.webapi.tenant.adapter.persistence;
 
+import io.micrometer.observation.annotation.Observed;
 import java.time.Clock;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
@@ -10,6 +11,7 @@ import xyz.dgz48.tasks.webapi.tenant.domain.UserTenant;
 import xyz.dgz48.tasks.webapi.tenant.domain.UserTenantStatus;
 import xyz.dgz48.tasks.webapi.tenant.usecase.UserTenantManagementPort;
 
+@Observed(name = "tenant.repository")
 @Component
 @RequiredArgsConstructor
 class UserTenantManagementAdapter implements UserTenantManagementPort {

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/adapter/persistence/UserTenantMembershipAdapter.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/adapter/persistence/UserTenantMembershipAdapter.java
@@ -1,5 +1,6 @@
 package xyz.dgz48.tasks.webapi.tenant.adapter.persistence;
 
+import io.micrometer.observation.annotation.Observed;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -11,6 +12,7 @@ import xyz.dgz48.tasks.webapi.tenant.domain.TenantSummaryInfo;
 import xyz.dgz48.tasks.webapi.tenant.domain.UserTenantStatus;
 import xyz.dgz48.tasks.webapi.tenant.usecase.TenantMembershipPort;
 
+@Observed(name = "tenant.repository")
 @Component
 @RequiredArgsConstructor
 class UserTenantMembershipAdapter implements TenantMembershipPort {

--- a/webapi/src/main/resources/application.yml
+++ b/webapi/src/main/resources/application.yml
@@ -36,21 +36,20 @@ server:
   port: 8080
 
 # Observability: OFF by default; enable per-env via environment variables / Parameter Store (ADR-0029 §3.2 / §6.2).
-# To activate:
-#   MANAGEMENT_OPENTELEMETRY_TRACING_EXPORT_OTLP_ENDPOINT=http://<collector>:4318/v1/traces
-#   MANAGEMENT_TRACING_SAMPLING_PROBABILITY=1.0
-#   MANAGEMENT_OTLP_METRICS_EXPORT_URL=http://<collector>:4318/v1/metrics
-#   MANAGEMENT_OTLP_METRICS_EXPORT_ENABLED=true
+# Traces : MANAGEMENT_OPENTELEMETRY_TRACING_EXPORT_OTLP_ENDPOINT=http://<collector>:4318/v1/traces
+#          MANAGEMENT_TRACING_SAMPLING_PROBABILITY=1.0
+# Metrics: MANAGEMENT_OTLP_METRICS_EXPORT_ENABLED=true
+#          MANAGEMENT_OTLP_METRICS_EXPORT_URL=http://<collector>:4318/v1/metrics
+# endpoint/url キーをここに書かない理由: 空文字列でも @ConditionalOnProperty を通過し
+# OtlpHttpSpanExporter / OTLP metrics exporter が起動失敗する。
 management:
   endpoints:
     web:
       exposure:
         include: health,info
-  opentelemetry:
-    tracing:
-      export:
-        otlp:
-          endpoint: # not set → OTLP trace export disabled
+  observations:
+    annotations:
+      enabled: true   # @Observed / @ObservationKeyValue AOP を有効化(ADR-0029 §6.1)
   tracing:
     sampling:
       probability: 0
@@ -58,7 +57,6 @@ management:
     metrics:
       export:
         enabled: false
-        url: # not set → OTLP metrics export disabled
 
 logging:
   level:

--- a/webapi/src/main/resources/application.yml
+++ b/webapi/src/main/resources/application.yml
@@ -35,11 +35,22 @@ spring:
 server:
   port: 8080
 
+# Observability: OFF by default; enable per-env via environment variables / Parameter Store (ADR-0029 §3.2 / §6.2).
+# To activate:
+#   MANAGEMENT_OPENTELEMETRY_TRACING_EXPORT_OTLP_ENDPOINT=http://<collector>:4318/v1/traces
+#   MANAGEMENT_TRACING_SAMPLING_PROBABILITY=1.0
+#   MANAGEMENT_OTLP_METRICS_EXPORT_URL=http://<collector>:4318/v1/metrics
+#   MANAGEMENT_OTLP_METRICS_EXPORT_ENABLED=true
 management:
   endpoints:
     web:
       exposure:
         include: health,info
+  opentelemetry:
+    tracing:
+      export:
+        otlp:
+          endpoint: # not set → OTLP trace export disabled
   tracing:
     sampling:
       probability: 0
@@ -47,6 +58,7 @@ management:
     metrics:
       export:
         enabled: false
+        url: # not set → OTLP metrics export disabled
 
 logging:
   level:


### PR DESCRIPTION
## Summary

ADR-0029 §3.1/§3.2/§6.1/§6.2 を実装。

### 計装
- 主要 UseCase 10メソッドに `@Observed(name = "task.*")` / `@ObservationKeyValue` を付与
- adapter.persistence 全8クラスにクラスレベル `@Observed` を付与し、UseCase スパンの子スパンとして DB アクセス階層を可視化
  - `task.repository` / `task.stakeholder.repository` / `audit.repository` / `tenant.repository`
  - 例: `GetTaskUseCase#execute → TaskJpaRepositoryAdapter#findById`（N+1 検出が可能）
- `ContextPropagatingTaskDecorator` を `@Bean` 登録し `@Async` スレッドプールでトレースコンテキストを伝播

### ON/OFF 外部化
- `management.observations.annotations.enabled=true` で `@Observed` AOP を有効化（Spring Boot 4 の `ConditionalOnBooleanProperty` 対応）
- トレース・メトリクスは既定 OFF、環境変数で有効化（`@Profile` 不使用、ADR-0029 §3.2）

### ローカル検証
- `docker-compose.local.yml` に `grafana/otel-lgtm:0.8.2` を追加
- OTLP 有効化時にトレース階層・メトリクスを確認済み

```
http get /api/tasks/{id}
  └─ GetTaskUseCase#execute
       ├─ TaskJpaRepositoryAdapter#findById
       ├─ TaskStakeholderJpaRepositoryAdapter#findUserIdsByTaskId
       └─ UserTenantMembershipAdapter#findActiveRole
```

## Test plan

- [x] `./gradlew :webapi:check` 409テスト passed、カバレッジ 93.8%
- [x] E2E テスト 5/5 passed（ローカル実行済み）
- [x] ローカル otel-lgtm でトレース階層・メトリクス出力を目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)