### PR TITLE
feat(observability): JDBC レベル計装を datasource-micrometer v2 で実現 (#585)

### DIFF
--- a/docs/adr/0029-performance-measurement-and-diagnostics.md
+++ b/docs/adr/0029-performance-measurement-and-diagnostics.md
@@ -143,6 +143,7 @@ tasks-webapi は実行バイナリとして GraalVM Native Image を採用し([A
 
 - 依存: `org.springframework.boot:spring-boot-starter-opentelemetry`(`micrometer-tracing-bridge-otel` と `micrometer-registry-otlp` を同梱)。`micrometer-registry-prometheus` は削除。
 - 自動計装: HTTP サーバ、JDBC、`RestClient` / `RestClientBuilder` 等。クライアントは必ずビルダー経由で生成する(自前 `new` は trace-context 伝播が効かない)。
+  - JDBC 計装は `net.ttddyy.observation:datasource-micrometer-spring-boot:2.2.1` を採用する。Spring Boot 4 の Micrometer Observation API と統合し、DataSource を透過ラップして `connection` / `query` / `result-set` / `commit` 単位のスパンを生成する。OTel Java Agent(バイトコード書き換え)は ADR-0008 の GraalVM Native Image 非互換制約により採用不可であるが、本ライブラリは Spring Boot Auto-configuration 経由で機能し Native Image と両立する。
 - 手動計装: 処理時間を測りたいメソッドに `@Observed(name = "...")`、引数の記録に `@SpanTag`。テナント識別子等の機微情報を span 属性に載せない(#451 整合)。
 - スレッド跨ぎ(`@Async` / `AsyncTaskExecutor`)では `ContextPropagatingTaskDecorator` を Bean 定義し trace-context を伝播させる。
 

--- a/webapi/build.gradle
+++ b/webapi/build.gradle
@@ -58,6 +58,9 @@ dependencies {
     // OpenTelemetry (traces + metrics via OTLP; OFF by default — ADR-0029 §3.2)
     implementation 'org.springframework.boot:spring-boot-starter-opentelemetry'
 
+    // JDBC observation: DataSource をラップし SQL クエリ単位のスパンを生成(ADR-0029 §3.1 / §6.1)
+    implementation 'net.ttddyy.observation:datasource-micrometer-spring-boot:2.2.1'
+
     // Testcontainers
     testImplementation 'org.springframework.boot:spring-boot-testcontainers'
     testImplementation 'org.testcontainers:testcontainers-mysql'


### PR DESCRIPTION
## Summary

- `datasource-micrometer-spring-boot:2.2.1`（Spring Boot 4 対応）を追加
- DataSource が自動的にラップされ、SQL クエリ単位のスパン（`connection` / `query` / `result-set` / `commit`）を生成
- JPA 遅延ロード起因の N+1 を含む JDBC レベルの観測が可能になり、ADR-0029 §3.1 / §6.1 の「自動計装(JDBC)」および「N+1 検出」の目的を達成

## 確認済みトレース階層（GET /api/tasks）

```
http get /api/tasks
  └─ ListTasksUseCase#execute
       ├─ TaskJpaRepositoryAdapter#findVisibleTasks
       │    ├─ query / result-set  ← SELECT tasks（可視性フィルタ）
       │    └─ query / result-set  ← SELECT COUNT（ページネーション）
       └─ TaskJpaRepositoryAdapter#countOverdueTasks
            └─ query / result-set  ← SELECT COUNT 期限切れ
```

`findVisibleTasks` 内で SQL が 2 本発行されていることが可視化されており、N+1 発生時は `query` スパンが増えることで検知できる。

## Test plan

- [x] `./gradlew :webapi:check` 通過
- [x] E2E テスト 5/5 passed（ローカル実行済み）
- [x] ローカル otel-lgtm で JDBC スパン階層を目視確認

## 未対応レビュー

| 指摘 | 内容 | 状態 |
|---|---|---|
| [PRR_kwDOSGmllM8AAAABDpMr0A](https://github.com/win2cot/tasks-webapi/pull/723#pullrequestreview-4539493328) | ADR-0029 §6.1 に `datasource-micrometer-spring-boot:2.2.1` のライブラリ名・選定理由を追記 | ✅ 対応済み (793577e) |

Closes #585

🤖 Generated with [Claude Code](https://claude.com/claude-code)
