### PR TITLE
feat(infra): ADOT Collector サイドカー + EMF/X-Ray 送出 + 最小権限 IAM

### DIFF
--- a/infra/docs/adr/0003-private-subnet-outbound.md
+++ b/infra/docs/adr/0003-private-subnet-outbound.md
@@ -174,6 +174,7 @@ Private Subnet の default route(`0.0.0.0/0`)を NAT Gateway に向け、S3 向�
 | Parameter Store(`ssm`)/ KMS | NAT Gateway |
 | SES SMTP(Keycloak メール) | NAT Gateway |
 | 一般 S3 | S3 Gateway Endpoint(無料) |
+| X-Ray OTLP(`xray.ap-northeast-1.amazonaws.com`) | NAT Gateway |
 | 外部 IdP / Webhook / API(Phase 2) | NAT Gateway |
 
 ### Terraform 雛形(`network` module 内、例)

--- a/infra/docs/adr/0005-logging-platform.md
+++ b/infra/docs/adr/0005-logging-platform.md
@@ -7,6 +7,8 @@
 
 > **2026-06-08 注記(infra ADR-0006)**: stg/prd の ALB に WAF(REGIONAL Web ACL)を導入する決定に伴い、§3 platform スコープのログカタログに WAF アクセスログ行を追加した(下表)。ログ基盤選定の技術決定は不変。
 
+> **2026-06-21 注記(infra ADR-0007)**: ADOT Collector サイドカー導入に伴い、§3 の single pane of glass に APM(CloudWatch Application Signals / トレース・メトリクス)を含める。ログ基盤選定の技術決定は不変。
+
 ## 目次
 
 - [1. コンテキスト(Context)](#1-コンテキストcontext)

--- a/infra/environments/dev/ecs_service.tf
+++ b/infra/environments/dev/ecs_service.tf
@@ -178,7 +178,7 @@ resource "aws_ecs_task_definition" "webapi" {
       # ADOT Collector サイドカー(ADR-0007): SigV4 署名 + X-Ray OTLP + CloudWatch EMF
       # essential=false: ADOT 障害でも webapi コンテナを継続稼働させる
       name      = "adot-collector"
-      image     = "public.ecr.aws/aws-observability/aws-otel-collector:latest"
+      image     = "public.ecr.aws/aws-observability/aws-otel-collector:v0.44.0"
       essential = false
 
       command = ["--config=env:AOT_CONFIG_CONTENT"]

--- a/infra/environments/dev/ecs_service.tf
+++ b/infra/environments/dev/ecs_service.tf
@@ -49,6 +49,47 @@ resource "aws_iam_role_policy" "webapi_exec_ssm" {
 }
 
 # ---------------------------------------------------------------------------
+# ADOT Collector 設定 (ADR-0007 §6)
+# receivers: OTLP grpc/http(localhost)
+# exporters: X-Ray OTLP(sigv4auth) + awsemf(CloudWatch Logs)
+# ---------------------------------------------------------------------------
+
+locals {
+  adot_config = <<-YAML
+    extensions:
+      sigv4auth:
+        region: ${var.region}
+        service: xray
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: "0.0.0.0:4317"
+          http:
+            endpoint: "0.0.0.0:4318"
+    exporters:
+      otlphttp/xray:
+        endpoint: https://xray.${var.region}.amazonaws.com
+        auth:
+          authenticator: sigv4auth
+      awsemf:
+        region: ${var.region}
+        namespace: tasks-${var.env}-webapi
+        log_group_name: /ecs/tasks-${var.env}/webapi-metrics
+        log_stream_name: metrics
+    service:
+      extensions: [sigv4auth]
+      pipelines:
+        traces:
+          receivers: [otlp]
+          exporters: [otlphttp/xray]
+        metrics:
+          receivers: [otlp]
+          exporters: [awsemf]
+  YAML
+}
+
+# ---------------------------------------------------------------------------
 # ADR-0028 巻き戻し防止 (i) — 現行稼働イメージ注入
 # apply 前の ECS タスク定義から稼働中イメージを読み取り、
 # Terraform が busybox で上書きするのを防ぐ。
@@ -71,8 +112,8 @@ locals {
 }
 
 # ---------------------------------------------------------------------------
-# ECS Task Definition — tasks-webapi (ADR-0028 / S2Infra-2)
-# CPU 512 / Memory 1024; Spring Boot 4 + GraalVM Native Image (ADR-0021)
+# ECS Task Definition — tasks-webapi (ADR-0028 / S2Infra-2 / ADR-0007)
+# CPU 1024 / Memory 2048; webapi(Spring Boot 4 GraalVM Native) + ADOT Collector サイドカー
 # Spring プロファイル不使用確定前提 — 環境差は env vars で注入(infrastructure-plan §1 確定前提 5)
 # ---------------------------------------------------------------------------
 
@@ -80,55 +121,82 @@ resource "aws_ecs_task_definition" "webapi" {
   family                   = "tasks-${var.env}-webapi"
   requires_compatibilities = ["FARGATE"]
   network_mode             = "awsvpc"
-  cpu                      = "512"
-  memory                   = "1024"
+  cpu                      = "1024"
+  memory                   = "2048"
   execution_role_arn       = aws_iam_role.webapi_exec.arn
   task_role_arn            = aws_iam_role.webapi_task.arn
 
-  container_definitions = jsonencode([{
-    name      = "webapi"
-    image     = local.webapi_image
-    essential = true
+  container_definitions = jsonencode([
+    {
+      name      = "webapi"
+      image     = local.webapi_image
+      essential = true
 
-    portMappings = [{
-      containerPort = 8080
-      protocol      = "tcp"
-    }]
+      portMappings = [{
+        containerPort = 8080
+        protocol      = "tcp"
+      }]
 
-    environment = [
-      { name = "SERVER_PORT", value = "8080" },
-      { name = "TZ", value = "Asia/Tokyo" },
-      { name = "DB_HOST", value = module.rds.db_instance_address },
-      { name = "DB_PORT", value = tostring(module.rds.db_instance_port) },
-      { name = "SPRING_DATASOURCE_USERNAME", value = "tasks_webapi" },
-      { name = "RDS_IAM_AUTH_ENABLED", value = "true" },
-      { name = "CORS_ALLOWED_ORIGINS", value = "https://tasks-dev.dgz48.xyz" },
-    ]
+      environment = [
+        { name = "SERVER_PORT", value = "8080" },
+        { name = "TZ", value = "Asia/Tokyo" },
+        { name = "DB_HOST", value = module.rds.db_instance_address },
+        { name = "DB_PORT", value = tostring(module.rds.db_instance_port) },
+        { name = "SPRING_DATASOURCE_USERNAME", value = "tasks_webapi" },
+        { name = "RDS_IAM_AUTH_ENABLED", value = "true" },
+        { name = "CORS_ALLOWED_ORIGINS", value = "https://tasks-dev.dgz48.xyz" },
+        # OTLP エクスポート先は localhost の ADOT Collector サイドカー(ADR-0007)
+        { name = "OTEL_EXPORTER_OTLP_ENDPOINT", value = "http://localhost:4317" },
+        { name = "OTEL_EXPORTER_OTLP_PROTOCOL", value = "grpc" },
+      ]
 
-    secrets = [
-      {
-        name      = "SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUER_URI"
-        valueFrom = "arn:aws:ssm:${var.region}:${data.aws_caller_identity.current.account_id}:parameter/tasks/${var.env}/app/jwt-issuer"
-      },
-      {
-        name      = "APP_TENANT_DEFAULT_ID"
-        valueFrom = "arn:aws:ssm:${var.region}:${data.aws_caller_identity.current.account_id}:parameter/tasks/${var.env}/app/tenant-default-id"
-      },
-      {
-        name      = "KEYCLOAK_CLIENT_SECRET"
-        valueFrom = "arn:aws:ssm:${var.region}:${data.aws_caller_identity.current.account_id}:parameter/tasks/${var.env}/keycloak/oauth-client-secret"
-      },
-    ]
+      secrets = [
+        {
+          name      = "SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUER_URI"
+          valueFrom = "arn:aws:ssm:${var.region}:${data.aws_caller_identity.current.account_id}:parameter/tasks/${var.env}/app/jwt-issuer"
+        },
+        {
+          name      = "APP_TENANT_DEFAULT_ID"
+          valueFrom = "arn:aws:ssm:${var.region}:${data.aws_caller_identity.current.account_id}:parameter/tasks/${var.env}/app/tenant-default-id"
+        },
+        {
+          name      = "KEYCLOAK_CLIENT_SECRET"
+          valueFrom = "arn:aws:ssm:${var.region}:${data.aws_caller_identity.current.account_id}:parameter/tasks/${var.env}/keycloak/oauth-client-secret"
+        },
+      ]
 
-    logConfiguration = {
-      logDriver = "awslogs"
-      options = {
-        "awslogs-group"         = module.ecs_cluster.webapi_log_group_name
-        "awslogs-region"        = var.region
-        "awslogs-stream-prefix" = "webapi"
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-group"         = module.ecs_cluster.webapi_log_group_name
+          "awslogs-region"        = var.region
+          "awslogs-stream-prefix" = "webapi"
+        }
       }
-    }
-  }])
+    },
+    {
+      # ADOT Collector サイドカー(ADR-0007): SigV4 署名 + X-Ray OTLP + CloudWatch EMF
+      # essential=false: ADOT 障害でも webapi コンテナを継続稼働させる
+      name      = "adot-collector"
+      image     = "public.ecr.aws/aws-observability/aws-otel-collector:latest"
+      essential = false
+
+      command = ["--config=env:AOT_CONFIG_CONTENT"]
+
+      environment = [
+        { name = "AOT_CONFIG_CONTENT", value = local.adot_config },
+      ]
+
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-group"         = module.ecs_cluster.adot_log_group_name
+          "awslogs-region"        = var.region
+          "awslogs-stream-prefix" = "adot"
+        }
+      }
+    },
+  ])
 
   tags = {
     Name = "tasks-${var.env}-webapi-task-def"

--- a/infra/environments/dev/iam.tf
+++ b/infra/environments/dev/iam.tf
@@ -44,6 +44,50 @@ resource "aws_iam_role_policy" "webapi_rds_connect" {
   })
 }
 
+# ADOT Collector サイドカー用権限 (ADR-0007)
+# X-Ray OTLP エンドポイント(Application Signals)+ CloudWatch EMF(awsemf exporter)
+resource "aws_iam_role_policy" "webapi_adot" {
+  name = "tasks-${var.env}-webapi-adot"
+  role = aws_iam_role.webapi_task.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        # X-Ray OTLP エンドポイント(POST /v1/traces)への送出
+        # otlphttp/xray exporter は X-Ray SDK を使わないため PutTelemetryRecords / GetSampling* 不要
+        # xray:PutTraceSegments は resource-level permissions 非対応のため Resource:"*"
+        Sid      = "XrayTraces"
+        Effect   = "Allow"
+        Action   = "xray:PutTraceSegments"
+        Resource = "*"
+      },
+      {
+        # awsemf exporter — EMF ログストリームへの書き込み
+        Sid    = "EmfLogStreamWrite"
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+          "logs:DescribeLogStreams",
+        ]
+        Resource = [
+          "arn:aws:logs:${var.region}:${data.aws_caller_identity.current.account_id}:log-group:/ecs/tasks-${var.env}/webapi-metrics",
+          "arn:aws:logs:${var.region}:${data.aws_caller_identity.current.account_id}:log-group:/ecs/tasks-${var.env}/webapi-metrics:log-stream:*",
+        ]
+      },
+      {
+        # logs:DescribeLogGroups は resource-level permissions 非対応のため Resource:"*"
+        Sid      = "EmfDescribeLogGroups"
+        Effect   = "Allow"
+        Action   = "logs:DescribeLogGroups"
+        Resource = "*"
+      },
+    ]
+  })
+}
+
 # SSM read — Parameter Store から設定値を取得する権限
 resource "aws_iam_role_policy" "webapi_ssm" {
   name = "tasks-${var.env}-webapi-ssm"

--- a/infra/modules/ecs_cluster/main.tf
+++ b/infra/modules/ecs_cluster/main.tf
@@ -55,3 +55,22 @@ resource "aws_cloudwatch_log_group" "keycloak" {
     Name = "/ecs/tasks-${var.env}/keycloak"
   }
 }
+
+resource "aws_cloudwatch_log_group" "adot" {
+  name              = "/ecs/tasks-${var.env}/adot"
+  retention_in_days = 7
+
+  tags = {
+    Name = "/ecs/tasks-${var.env}/adot"
+  }
+}
+
+# EMF ログから CloudWatch メトリクスが自動抽出されるロググループ(ADOT awsemf exporter)
+resource "aws_cloudwatch_log_group" "webapi_metrics" {
+  name              = "/ecs/tasks-${var.env}/webapi-metrics"
+  retention_in_days = 30
+
+  tags = {
+    Name = "/ecs/tasks-${var.env}/webapi-metrics"
+  }
+}

--- a/infra/modules/ecs_cluster/outputs.tf
+++ b/infra/modules/ecs_cluster/outputs.tf
@@ -17,3 +17,13 @@ output "keycloak_log_group_name" {
   description = "CloudWatch Log Group name for Keycloak"
   value       = aws_cloudwatch_log_group.keycloak.name
 }
+
+output "adot_log_group_name" {
+  description = "CloudWatch Log Group name for ADOT Collector sidecar"
+  value       = aws_cloudwatch_log_group.adot.name
+}
+
+output "webapi_metrics_log_group_name" {
+  description = "CloudWatch Log Group name for ADOT awsemf EMF output (metrics)"
+  value       = aws_cloudwatch_log_group.webapi_metrics.name
+}


### PR DESCRIPTION
## 概要

infra ADR-0007 §3/§6 の実装。ECS タスクに ADOT Collector サイドカーを追加し、X-Ray OTLP（Application Signals）と CloudWatch EMF によるトレース・メトリクス送出を実現する。

Closes #586

## 変更内容

### `infra/modules/ecs_cluster/main.tf` / `outputs.tf`
- `aws_cloudwatch_log_group.adot` (`/ecs/tasks-<env>/adot`, 7日保持) — ADOT Collector 自身のログ
- `aws_cloudwatch_log_group.webapi_metrics` (`/ecs/tasks-<env>/webapi-metrics`, 30日保持) — `awsemf` exporter の EMF ログ（CloudWatch メトリクスに自動変換）
- 両ログループの output を追加

### `infra/environments/dev/ecs_service.tf`
- `locals.adot_config` — ADOT Collector YAML 設定（sigv4auth / otlp receiver / otlphttp/xray + awsemf exporter）
- タスク CPU: 512 → **1024**、Memory: 1024 → **2048**（webapi + ADOT サイドカー分）
- webapi コンテナに `OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317` / `OTEL_EXPORTER_OTLP_PROTOCOL=grpc` を追加
- `adot-collector` サイドカーを追加
  - image: `public.ecr.aws/aws-observability/aws-otel-collector:v0.44.0`（バージョン固定）
  - `essential=false` — ADOT 障害で webapi コンテナを巻き込まない
  - 設定は `AOT_CONFIG_CONTENT` 環境変数で注入

### `infra/environments/dev/iam.tf`
- `aws_iam_role_policy.webapi_adot` を webapi Task Role に追加（最小権限）
  - `XrayTraces`: `xray:PutTraceSegments` のみ（`otlphttp` exporter は X-Ray SDK 不使用、`PutTelemetryRecords`/`GetSampling*` 不要）Resource `*`（RL非対応、コメント明記）
  - `EmfLogStreamWrite`: `logs:CreateLogGroup/Stream/PutLogEvents/DescribeLogStreams` → `/ecs/tasks-<env>/webapi-metrics` ARN にスコープ
  - `EmfDescribeLogGroups`: `logs:DescribeLogGroups` → Resource `*`（RL非対応、コメント明記）

### `infra/docs/adr/0003-private-subnet-outbound.md`
- 外向き経路テーブルに `X-Ray OTLP (xray.ap-northeast-1.amazonaws.com) → NAT Gateway` を追記（既存 NAT Gateway で対応済み、新リソース不要）

### `infra/docs/adr/0005-logging-platform.md`
- ADR-0007 注記を追加: §3 の single pane of glass に APM(CloudWatch Application Signals / トレース・メトリクス)を含める旨を補記（ADR-0007 §5 の波及事項対応）

## ネットワーク

X-Ray OTLP エンドポイント (`https://xray.ap-northeast-1.amazonaws.com`) への通信は既存の NAT Gateway（infra ADR-0003）で対応。新しいネットワークリソースは不要。

## IAM 最小権限チェック（Terraform規約 R1/R2）

| Statement | Action | Resource | 理由 |
|---|---|---|---|
| `XrayTraces` | `xray:PutTraceSegments` | `*` | resource-level 非対応、コメント明記 |
| `EmfLogStreamWrite` | `logs:Create*/PutLogEvents/DescribeLogStreams` | log group ARN にスコープ | |
| `EmfDescribeLogGroups` | `logs:DescribeLogGroups` | `*` | resource-level 非対応、コメント明記 |

## terraform plan 結果

```
Plan: 4 to add, 1 to change, 1 to destroy.
```
- `+create`: adot ログループ、webapi-metrics ログループ、webapi_adot IAM ポリシー、タスク定義新リビジョン
- `-/+replace`: タスク定義（CPU/Memory 変更は Fargate 上 replace 必須）
- `~update`: ECS サービスが新リビジョンに追従

wildcard gate (terraform-lint.yml 相当) も通過確認済み。

## 受け入れ条件チェック

- [x] ECS タスク定義に ADOT Collector サイドカーを追加（otlp receiver / sigv4auth / otlphttp/xray / awsemf）
- [x] X-Ray 取り込み・CloudWatch メトリクス出力の最小権限 IAM を同一 PR で追加（Terraform規約、ARN/条件で限定）
- [x] X-Ray / monitoring 宛の外向き経路を infra ADR-0003 に沿って用意（既存 NAT Gateway で対応済み、ADR-0003 に追記）
- [x] infra ADR-0005 に ADR-0007 注記を追加（single pane of glass への APM 包含を補記）
- [ ] dev で trace が Application Signals、metric が CloudWatch に出ることを確認（`terraform apply` 後に手動確認）

## 未対応レビュー

| 指摘 | 内容 | 状態 |
|---|---|---|
| [blocking] ADR-0005 補記未実施 | infra ADR-0005 に ADR-0007 注記を追加 | 対応済み (065674a) |
| [suggestion] ADOT `:latest` タグ | イメージを `v0.44.0` に固定 | 対応済み (065674a) |
