### PR TITLE
chore: ビルド/IDE 警告の解消(webapi + keycloak)

### DIFF
--- a/keycloak/.settings/org.eclipse.jdt.core.prefs
+++ b/keycloak/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,18 @@
+eclipse.preferences.version=1
+# Disable the IDE (Eclipse JDT) annotation-based null analysis for THIS subproject only.
+#
+# Why: keycloak/ implements Keycloak User Storage SPI interfaces (UserLookupProvider,
+# UserQueryMethodsProvider, UserRegistrationProvider, AbstractInMemoryUserAdapter, ...).
+# Those SPI types ship with NO null annotations (verified: keycloak-server-spi 26.6.3 carries
+# zero nullness annotations; nullness is documented only in Javadoc). Under the project-wide
+# JSpecify @NullMarked default, our overrides become @NonNull, and JDT's *legacy* null analysis
+# then reports "Illegal redefinition of parameter ... does not constrain this parameter" for every
+# overridden parameter. This is a false positive: JSpecify (and NullAway, our build-time SSOT for
+# null safety) correctly accept @NonNull overrides of null-unspecified supertypes.
+#
+# This specific diagnostic is hard-wired in JDT and cannot be downgraded via any problem-severity
+# key or @SuppressWarnings (verified against ecj from redhat.java 1.54.0 / JDT 3.46.0). The only
+# lever that removes it is turning the annotation null analysis off, scoped here to this boundary
+# module. webapi/ keeps full IDE null analysis (Spring 7 is JSpecify-annotated, so it is clean).
+# Null safety for keycloak/ is still enforced at build time by NullAway.
+org.eclipse.jdt.core.compiler.annotation.nullanalysis=disabled

--- a/keycloak/src/main/java/xyz/dgz48/tasks/keycloak/UserAdapter.java
+++ b/keycloak/src/main/java/xyz/dgz48/tasks/keycloak/UserAdapter.java
@@ -14,7 +14,7 @@ import org.keycloak.storage.adapter.AbstractInMemoryUserAdapter;
  * Email is the only writable attribute; updates are written back to {@code users.email} by the
  * Keycloak Update-Email flow (ADR-0006 §3.1).
  */
-public class UserAdapter extends AbstractInMemoryUserAdapter {
+public final class UserAdapter extends AbstractInMemoryUserAdapter {
 
   public UserAdapter(
       KeycloakSession session,

--- a/keycloak/src/test/java/xyz/dgz48/tasks/keycloak/TasksWebApiUserStorageProviderFactoryTest.java
+++ b/keycloak/src/test/java/xyz/dgz48/tasks/keycloak/TasksWebApiUserStorageProviderFactoryTest.java
@@ -16,7 +16,6 @@ class TasksWebApiUserStorageProviderFactoryTest {
   }
 
   @Test
-  @SuppressWarnings("rawtypes")
   void serviceLoader_registersProvider() {
     var loader =
         ServiceLoader.load(

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/shared/infra/NativeImageHintsConfig.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/shared/infra/NativeImageHintsConfig.java
@@ -24,6 +24,7 @@ class NativeImageHintsConfig {
         try {
           hints.reflection().registerType(Class.forName(cls), MemberCategory.values());
         } catch (ClassNotFoundException ignored) {
+          // Class absent on this classpath; nothing to register, skip intentionally.
         }
       }
       // Flyway classpath scanner cannot enumerate directories under the native-image resource:

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/shared/infra/RdsIamDataSourceConfig.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/shared/infra/RdsIamDataSourceConfig.java
@@ -43,7 +43,7 @@ class RdsIamDataSourceConfig {
   RdsUtilities rdsUtilities() {
     return RdsUtilities.builder()
         .region(Region.of(region))
-        .credentialsProvider(DefaultCredentialsProvider.create())
+        .credentialsProvider(DefaultCredentialsProvider.builder().build())
         .build();
   }
 

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/RdsIamAuthIntegrationTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/RdsIamAuthIntegrationTest.java
@@ -13,9 +13,9 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.aot.DisabledInAotMode;
-import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.mysql.MySQLContainer;
 import software.amazon.awssdk.services.rds.RdsUtilities;
 import software.amazon.awssdk.services.rds.model.GenerateAuthenticationTokenRequest;
 
@@ -50,9 +50,12 @@ import software.amazon.awssdk.services.rds.model.GenerateAuthenticationTokenRequ
 class RdsIamAuthIntegrationTest {
 
   // Use tasks_webapi / tasks_webapi so the mock token equals the actual MySQL password.
+  // @Container manages the container lifecycle (start/stop), so it is never explicitly closed here;
+  // suppress the false-positive resource-leak diagnostic.
+  @SuppressWarnings("resource")
   @Container
-  static MySQLContainer<?> mysql =
-      new MySQLContainer<>("mysql:8.4")
+  static MySQLContainer mysql =
+      new MySQLContainer("mysql:8.4")
           .withDatabaseName("tasks")
           .withUsername("tasks_webapi")
           .withPassword("tasks_webapi")

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/TestcontainersConfiguration.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/TestcontainersConfiguration.java
@@ -8,6 +8,9 @@ import org.testcontainers.mysql.MySQLContainer;
 @TestConfiguration(proxyBeanMethods = false)
 public class TestcontainersConfiguration {
 
+  // Spring manages this bean's lifecycle (start/stop), so the container is never explicitly closed
+  // here; suppress the false-positive resource-leak diagnostic.
+  @SuppressWarnings("resource")
   @Bean
   @ServiceConnection
   MySQLContainer mysqlContainer() {

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/shared/infra/RdsIamDataSourceConfigTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/shared/infra/RdsIamDataSourceConfigTest.java
@@ -110,7 +110,7 @@ class RdsIamDataSourceConfigTest {
       setField(config, "region", region);
       return config;
     } catch (ReflectiveOperationException e) {
-      throw new AssertionError("Test setup failed", e);
+      throw new LinkageError("Test setup failed", e);
     }
   }
 


### PR DESCRIPTION
## 概要

実装の蓄積で増えていたビルド警告・IDE 警告を、原因と対処を確認したうえで解消する。**いずれも挙動は不変**で、リファクタや機能変更は含まない。

## webapi(コンパイル/ビルド警告)

| 警告 | 対処 |
|---|---|
| `[EmptyCatch]` (NativeImageHintsConfig) | 意図的な空 catch に説明コメント追加 |
| deprecation `DefaultCredentialsProvider.create()` | `builder().build()` に置換 |
| deprecation `org.testcontainers.containers.MySQLContainer` | 新パッケージ `org.testcontainers.mysql.MySQLContainer` へ移行(非ジェネリック化に追従) |
| `[RethrowReflectiveOperationExceptionAsLinkageError]` | `AssertionError` → `LinkageError` |
| IDE resource-leak 誤検知(@Container / @Bean のコンテナ) | `@SuppressWarnings("resource")` + 理由コメント |

## keycloak(コンパイル警告 + IDE null 解析)

- `UserAdapter` を `final` 化し `this-escape` を解消
- 不要な `@SuppressWarnings("rawtypes")` を削除
- `keycloak/.settings/org.eclipse.jdt.core.prefs` を追加し、**当サブプロジェクトのみ** IDE(Eclipse JDT)の annotation null 解析を無効化

### keycloak の IDE null 解析を切る理由

`keycloak/` は**無注釈**の Keycloak User Storage SPI を実装する境界。`@NullMarked` 既定で override 引数が `@NonNull` になると、JDT の**レガシー** null 解析が `Illegal redefinition of parameter ...` を大量に誤検知する(JSpecify、およびビルドの **NullAway** は正しく受理)。この診断は severity キーや `@SuppressWarnings` では抑止できない(IDE と同一の ecj で検証済み)ため、境界モジュール限定で IDE 解析を無効化した。null 安全性の SSOT はビルド時の NullAway であり、webapi 側は Spring 7 が JSpecify 注釈済みのため影響なく厳格を維持する。

## 検証

- `:webapi:compileJava :webapi:compileTestJava :webapi:spotlessCheck` → BUILD SUCCESSFUL
- `:keycloak:compileJava :keycloak:compileTestJava :keycloak:test` → BUILD SUCCESSFUL
- IDE: keycloak の null 警告 20 → 0(リロードで確認)

## 対処しない既知の警告(上流要因)

- Lombok の `sun.misc.Unsafe` 警告(JDK 上、Lombok 側対応待ち)
- `keycloak/Dockerfile` の spi-builder ベースイメージ openssl CVE-2026-45447 — **破棄される build ステージ専用で非出荷**、かつ現時点でどの temurin ベースも未修正。上流の修正版反映後にピンを更新する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)