### PR TITLE
feat(keycloak): User Storage SPI 本体実装(Lookup/Query/Registration + email write-back)(#728)

### DIFF
--- a/keycloak/src/main/java/xyz/dgz48/tasks/keycloak/TasksWebApiUserStorageProvider.java
+++ b/keycloak/src/main/java/xyz/dgz48/tasks/keycloak/TasksWebApiUserStorageProvider.java
@@ -1,14 +1,17 @@
 package xyz.dgz48.tasks.keycloak;
 
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 import org.jspecify.annotations.Nullable;
 import org.keycloak.component.ComponentModel;
 import org.keycloak.models.GroupModel;
 import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.ModelException;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.provider.Provider;
+import org.keycloak.storage.StorageId;
 import org.keycloak.storage.user.UserLookupProvider;
 import org.keycloak.storage.user.UserQueryProvider;
 import org.keycloak.storage.user.UserRegistrationProvider;
@@ -16,48 +19,59 @@ import org.keycloak.storage.user.UserRegistrationProvider;
 /**
  * Keycloak User Storage provider (ADR-0006).
  *
- * <p>Federates tasks-webapi {@code users} table as a read-only profile directory. Email is the only
- * writable attribute (via Keycloak Update-Email flow). Credentials and MFA are owned by Keycloak
- * ({@code CredentialInputValidator} is intentionally not implemented).
+ * <p>Federates the tasks-webapi {@code users} table as a read-only profile directory. Email is the
+ * only writable profile attribute (via Keycloak Update-Email); {@code full_name_kana} / {@code
+ * department_name} are writable solely through the Custom User Profile attribute path on the admin
+ * / recovery create flow (§3.1). Credentials and MFA are owned by Keycloak's native store, so
+ * {@code CredentialInputValidator} is intentionally not implemented (§3.3).
+ *
+ * <p>JDBC access goes through a per-provider {@link UserRepository}; the connection is configured
+ * by the federation component (see {@link TasksWebApiUserStorageProviderFactory}) and closed in
+ * {@link #close()}.
  */
 public class TasksWebApiUserStorageProvider
     implements Provider, UserLookupProvider, UserQueryProvider, UserRegistrationProvider {
 
-  @SuppressWarnings("unused")
   private final KeycloakSession session;
-
-  @SuppressWarnings("unused")
   private final ComponentModel model;
+  private final UserRepository repository;
 
-  public TasksWebApiUserStorageProvider(KeycloakSession session, ComponentModel model) {
+  public TasksWebApiUserStorageProvider(
+      KeycloakSession session, ComponentModel model, UserRepository repository) {
     this.session = session;
     this.model = model;
+    this.repository = repository;
   }
 
   // --- Provider ---
 
   @Override
-  public void close() {}
+  public void close() {
+    repository.close();
+  }
 
   // --- UserLookupProvider (read-only federation) ---
 
   @Override
   public @Nullable UserModel getUserById(RealmModel realm, String id) {
-    // TODO: extract external ID via StorageId.externalId(id), look up users.id, return UserAdapter
-    return null;
+    long userId;
+    try {
+      userId = Long.parseLong(StorageId.externalId(id));
+    } catch (NumberFormatException e) {
+      return null;
+    }
+    return repository.findById(userId).map(row -> adapt(realm, row)).orElse(null);
   }
 
   @Override
   public @Nullable UserModel getUserByUsername(RealmModel realm, String username) {
     // email is the login-ID in Keycloak (username == email per ADR-0006 §3.1)
-    // TODO: SELECT * FROM users WHERE email = :username AND deleted_at IS NULL
-    return null;
+    return repository.findByEmail(username).map(row -> adapt(realm, row)).orElse(null);
   }
 
   @Override
   public @Nullable UserModel getUserByEmail(RealmModel realm, String email) {
-    // TODO: SELECT * FROM users WHERE email = :email AND deleted_at IS NULL
-    return null;
+    return repository.findByEmail(email).map(row -> adapt(realm, row)).orElse(null);
   }
 
   // --- UserQueryProvider (read-only) ---
@@ -68,8 +82,22 @@ public class TasksWebApiUserStorageProvider
       Map<String, String> params,
       @Nullable Integer firstResult,
       @Nullable Integer maxResults) {
-    // TODO: query users table with pagination; used by Admin Console user list
-    return Stream.empty();
+    String term = params.get(UserModel.SEARCH);
+    if (term == null) {
+      term = params.get(UserModel.USERNAME);
+    }
+    if (term == null) {
+      term = params.get(UserModel.EMAIL);
+    }
+    List<UserRepository.UserRow> rows =
+        repository.search(
+            term, firstResult == null ? 0 : firstResult, maxResults == null ? -1 : maxResults);
+    return rows.stream().map(row -> adapt(realm, row));
+  }
+
+  @Override
+  public int getUsersCount(RealmModel realm) {
+    return repository.count();
   }
 
   @Override
@@ -78,30 +106,44 @@ public class TasksWebApiUserStorageProvider
       GroupModel group,
       @Nullable Integer firstResult,
       @Nullable Integer maxResults) {
+    // Group membership is not federated; the SPI returns only users attributes (ADR-0006 §3.7).
     return Stream.empty();
   }
 
   @Override
   public Stream<UserModel> searchForUserByUserAttributeStream(
       RealmModel realm, String attrName, String attrValue) {
+    // Custom attribute search is not federated; users is keyed by id / email only.
     return Stream.empty();
   }
 
   // --- UserRegistrationProvider (admin / disaster-recovery path only; main path is tasks API) ---
 
   @Override
-  public @Nullable UserModel addUser(RealmModel realm, String username) {
-    // Admin Console / recovery path: insert into users (email, full_name, full_name_kana).
-    // full_name_kana and other required fields are provided via Custom User Profile attributes.
-    // Tenant assignment is NOT performed here; created user is tenant-unassigned.
-    // TODO: implement insert + return UserAdapter
-    return null;
+  public UserModel addUser(RealmModel realm, String username) {
+    // Admin Console / recovery path (ADR-0006 §3.1): insert a tenant-unassigned users row.
+    // username is the email/login-ID; full_name_kana and other Custom User Profile attributes are
+    // written back afterwards via UserAdapter#setSingleAttribute. Tenant assignment is NOT done
+    // here.
+    return adapt(realm, repository.insert(username));
   }
 
   @Override
   public boolean removeUser(RealmModel realm, UserModel user) {
-    // Anonymize per ADR-0006 §3.4: set deleted_at + placeholder email/oidc_sub/full_name.
-    // TODO: call UserAnonymizationDomainService in 1 transaction; return true on success
-    return false;
+    // Convert delete to logical-delete + anonymization (ADR-0006 §3.4) and return true so Keycloak
+    // performs its standard cleanup (credentials / sessions). No-op if already anonymized.
+    long userId;
+    try {
+      userId = Long.parseLong(StorageId.externalId(user.getId()));
+    } catch (NumberFormatException e) {
+      throw new ModelException(
+          "tasks-webapi user store: cannot remove user with id " + user.getId());
+    }
+    repository.anonymize(userId);
+    return true;
+  }
+
+  private UserAdapter adapt(RealmModel realm, UserRepository.UserRow row) {
+    return new UserAdapter(session, realm, model, repository, row);
   }
 }

--- a/keycloak/src/main/java/xyz/dgz48/tasks/keycloak/TasksWebApiUserStorageProvider.java
+++ b/keycloak/src/main/java/xyz/dgz48/tasks/keycloak/TasksWebApiUserStorageProvider.java
@@ -17,17 +17,15 @@ import org.keycloak.storage.user.UserQueryProvider;
 import org.keycloak.storage.user.UserRegistrationProvider;
 
 /**
- * Keycloak User Storage provider (ADR-0006).
+ * Keycloak User Storage provider(ADR-0006)。
  *
- * <p>Federates the tasks-webapi {@code users} table as a read-only profile directory. Email is the
- * only writable profile attribute (via Keycloak Update-Email); {@code full_name_kana} / {@code
- * department_name} are writable solely through the Custom User Profile attribute path on the admin
- * / recovery create flow (§3.1). Credentials and MFA are owned by Keycloak's native store, so
- * {@code CredentialInputValidator} is intentionally not implemented (§3.3).
+ * <p>tasks-webapi の {@code users} テーブルを read-only の profile ディレクトリとして federate する。writable な
+ * profile 属性は email のみ(Keycloak Update-Email 経由)。{@code full_name_kana} / {@code department_name} は
+ * admin / リカバリの作成フローにおける Custom User Profile attribute 経路でのみ writable(§3.1)。資格情報・MFA は Keycloak の
+ * native store が所有するため、{@code CredentialInputValidator} は意図的に実装しない(§3.3)。
  *
- * <p>JDBC access goes through a per-provider {@link UserRepository}; the connection is configured
- * by the federation component (see {@link TasksWebApiUserStorageProviderFactory}) and closed in
- * {@link #close()}.
+ * <p>JDBC アクセスは provider ごとの {@link UserRepository} を経由する。接続は federation コンポーネント({@link
+ * TasksWebApiUserStorageProviderFactory} 参照)で設定し、{@link #close()} で破棄する。
  */
 public class TasksWebApiUserStorageProvider
     implements Provider, UserLookupProvider, UserQueryProvider, UserRegistrationProvider {
@@ -50,7 +48,7 @@ public class TasksWebApiUserStorageProvider
     repository.close();
   }
 
-  // --- UserLookupProvider (read-only federation) ---
+  // --- UserLookupProvider(read-only federation) ---
 
   @Override
   public @Nullable UserModel getUserById(RealmModel realm, String id) {
@@ -65,7 +63,7 @@ public class TasksWebApiUserStorageProvider
 
   @Override
   public @Nullable UserModel getUserByUsername(RealmModel realm, String username) {
-    // email is the login-ID in Keycloak (username == email per ADR-0006 §3.1)
+    // Keycloak では email が login-ID(ADR-0006 §3.1 より username == email)
     return repository.findByEmail(username).map(row -> adapt(realm, row)).orElse(null);
   }
 
@@ -74,7 +72,7 @@ public class TasksWebApiUserStorageProvider
     return repository.findByEmail(email).map(row -> adapt(realm, row)).orElse(null);
   }
 
-  // --- UserQueryProvider (read-only) ---
+  // --- UserQueryProvider(read-only) ---
 
   @Override
   public Stream<UserModel> searchForUserStream(
@@ -106,32 +104,31 @@ public class TasksWebApiUserStorageProvider
       GroupModel group,
       @Nullable Integer firstResult,
       @Nullable Integer maxResults) {
-    // Group membership is not federated; the SPI returns only users attributes (ADR-0006 §3.7).
+    // group membership は federate しない。SPI は users 属性のみを返す(ADR-0006 §3.7)。
     return Stream.empty();
   }
 
   @Override
   public Stream<UserModel> searchForUserByUserAttributeStream(
       RealmModel realm, String attrName, String attrValue) {
-    // Custom attribute search is not federated; users is keyed by id / email only.
+    // カスタム属性検索は federate しない。users は id / email のみで引く。
     return Stream.empty();
   }
 
-  // --- UserRegistrationProvider (admin / disaster-recovery path only; main path is tasks API) ---
+  // --- UserRegistrationProvider(admin / 障害時リカバリ経路のみ。主経路は tasks API) ---
 
   @Override
   public UserModel addUser(RealmModel realm, String username) {
-    // Admin Console / recovery path (ADR-0006 §3.1): insert a tenant-unassigned users row.
-    // username is the email/login-ID; full_name_kana and other Custom User Profile attributes are
-    // written back afterwards via UserAdapter#setSingleAttribute. Tenant assignment is NOT done
-    // here.
+    // Admin Console / リカバリ経路(ADR-0006 §3.1): tenant 未所属の users 行を insert する。
+    // username は email/login-ID。full_name_kana 等の Custom User Profile attribute は後続の
+    // UserAdapter#setSingleAttribute で書き戻す。tenant 割当てはここでは行わない。
     return adapt(realm, repository.insert(username));
   }
 
   @Override
   public boolean removeUser(RealmModel realm, UserModel user) {
-    // Convert delete to logical-delete + anonymization (ADR-0006 §3.4) and return true so Keycloak
-    // performs its standard cleanup (credentials / sessions). No-op if already anonymized.
+    // delete を論理削除 + 匿名化(ADR-0006 §3.4)に変換し、Keycloak 標準の cleanup(資格情報 / セッション)に
+    // 委ねるため true を返す。匿名化済みなら no-op。
     long userId;
     try {
       userId = Long.parseLong(StorageId.externalId(user.getId()));

--- a/keycloak/src/main/java/xyz/dgz48/tasks/keycloak/TasksWebApiUserStorageProviderFactory.java
+++ b/keycloak/src/main/java/xyz/dgz48/tasks/keycloak/TasksWebApiUserStorageProviderFactory.java
@@ -6,21 +6,43 @@ import org.keycloak.component.ComponentFactory;
 import org.keycloak.component.ComponentModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.models.ModelException;
 import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.provider.ProviderConfigurationBuilder;
 
 /**
  * Registers {@link TasksWebApiUserStorageProvider} as a Keycloak User Federation component.
  *
- * <p>Registered via {@code META-INF/services/org.keycloak.component.ComponentFactory}.
+ * <p>Registered via {@code META-INF/services/org.keycloak.component.ComponentFactory}. The JDBC
+ * connection to the tasks-webapi {@code users} database is supplied per-component through the
+ * config properties below (set when the federation provider is created in the realm — realm-side
+ * wiring is a separate sub-issue).
  */
 public class TasksWebApiUserStorageProviderFactory
     implements ComponentFactory<TasksWebApiUserStorageProvider, TasksWebApiUserStorageProvider> {
 
   public static final String PROVIDER_ID = "tasks-webapi-user-storage";
 
+  static final String CONFIG_JDBC_URL = "jdbcUrl";
+  static final String CONFIG_DB_USERNAME = "dbUsername";
+  static final String CONFIG_DB_PASSWORD = "dbPassword";
+
   @Override
   public TasksWebApiUserStorageProvider create(KeycloakSession session, ComponentModel model) {
-    return new TasksWebApiUserStorageProvider(session, model);
+    UserRepository repository =
+        new UserRepository(
+            requireConfig(model, CONFIG_JDBC_URL),
+            requireConfig(model, CONFIG_DB_USERNAME),
+            requireConfig(model, CONFIG_DB_PASSWORD));
+    return new TasksWebApiUserStorageProvider(session, model, repository);
+  }
+
+  private static String requireConfig(ComponentModel model, String key) {
+    String value = model.get(key);
+    if (value == null || value.isBlank()) {
+      throw new ModelException("tasks-webapi user store: required config '" + key + "' is not set");
+    }
+    return value;
   }
 
   @Override
@@ -30,12 +52,33 @@ public class TasksWebApiUserStorageProviderFactory
 
   @Override
   public String getHelpText() {
-    return "Federates tasks-webapi users table (read-only profile, email writable via Update-Email)";
+    return "Federates tasks-webapi users table (read-only profile, email writable via"
+        + " Update-Email)";
   }
 
   @Override
   public List<ProviderConfigProperty> getConfigProperties() {
-    return List.of();
+    return ProviderConfigurationBuilder.create()
+        .property()
+        .name(CONFIG_JDBC_URL)
+        .label("JDBC URL")
+        .helpText("JDBC URL of the tasks-webapi database (e.g. jdbc:mysql://host:3306/tasks)")
+        .type(ProviderConfigProperty.STRING_TYPE)
+        .add()
+        .property()
+        .name(CONFIG_DB_USERNAME)
+        .label("DB username")
+        .helpText("Database username for the tasks-webapi users table")
+        .type(ProviderConfigProperty.STRING_TYPE)
+        .add()
+        .property()
+        .name(CONFIG_DB_PASSWORD)
+        .label("DB password")
+        .helpText("Database password for the tasks-webapi users table")
+        .type(ProviderConfigProperty.PASSWORD)
+        .secret(true)
+        .add()
+        .build();
   }
 
   @Override

--- a/keycloak/src/main/java/xyz/dgz48/tasks/keycloak/TasksWebApiUserStorageProviderFactory.java
+++ b/keycloak/src/main/java/xyz/dgz48/tasks/keycloak/TasksWebApiUserStorageProviderFactory.java
@@ -11,12 +11,11 @@ import org.keycloak.provider.ProviderConfigProperty;
 import org.keycloak.provider.ProviderConfigurationBuilder;
 
 /**
- * Registers {@link TasksWebApiUserStorageProvider} as a Keycloak User Federation component.
+ * {@link TasksWebApiUserStorageProvider} を Keycloak の User Federation コンポーネントとして登録する。
  *
- * <p>Registered via {@code META-INF/services/org.keycloak.component.ComponentFactory}. The JDBC
- * connection to the tasks-webapi {@code users} database is supplied per-component through the
- * config properties below (set when the federation provider is created in the realm — realm-side
- * wiring is a separate sub-issue).
+ * <p>{@code META-INF/services/org.keycloak.component.ComponentFactory} 経由で登録される。tasks-webapi の
+ * {@code users} データベースへの JDBC 接続は、下記の config プロパティでコンポーネントごとに与える(realm で federation provider
+ * を作成する際に設定する。 realm 側の配線は別 sub-issue)。
  */
 public class TasksWebApiUserStorageProviderFactory
     implements ComponentFactory<TasksWebApiUserStorageProvider, TasksWebApiUserStorageProvider> {

--- a/keycloak/src/main/java/xyz/dgz48/tasks/keycloak/TasksWebApiUserStorageProviderFactory.java
+++ b/keycloak/src/main/java/xyz/dgz48/tasks/keycloak/TasksWebApiUserStorageProviderFactory.java
@@ -49,6 +49,10 @@ public class TasksWebApiUserStorageProviderFactory
     return PROVIDER_ID;
   }
 
+  // TODO(#729): getHelpText / 下記 getConfigProperties の label・helpText は Admin Console 上で i18n キーとして
+  // 扱われ、対応する翻訳が無ければリテラル(英語)がそのまま全ロケールで表示される。ロケール連動させるにはカスタム admin テーマの
+  // message bundle(messages_ja/en.properties)へキーと翻訳を登録する。当面は英語リテラルのまま運用し、テーマ/realm 整備
+  // (#729)で message キー化と翻訳をまとめて行う。
   @Override
   public String getHelpText() {
     return "Federates tasks-webapi users table (read-only profile, email writable via"

--- a/keycloak/src/main/java/xyz/dgz48/tasks/keycloak/UserAdapter.java
+++ b/keycloak/src/main/java/xyz/dgz48/tasks/keycloak/UserAdapter.java
@@ -11,49 +11,100 @@ import org.keycloak.storage.adapter.AbstractInMemoryUserAdapter;
  * Adapts a {@code users} table row as a Keycloak {@link org.keycloak.models.UserModel}.
  *
  * <p>Profile attributes (full_name, department_name, etc.) are read-only — tasks-webapi is the SoT.
- * Email is the only writable attribute; updates are written back to {@code users.email} by the
- * Keycloak Update-Email flow (ADR-0006 §3.1).
+ * Email is the only writable profile attribute; it is written back to {@code users.email} by the
+ * Keycloak Update-Email flow (ADR-0006 §3.1). {@code full_name_kana} and {@code department_name}
+ * are additionally writable through {@link #setSingleAttribute} for the admin / recovery
+ * Console-create Custom User Profile path (§3.1); first/last name remain read-only no-ops. All
+ * write-backs use the {@code version} column for optimistic locking (§3.4).
  */
 public final class UserAdapter extends AbstractInMemoryUserAdapter {
+
+  /** Custom User Profile attribute keys backed by {@code users} columns (ADR-0006 §3.1). */
+  static final String FULL_NAME = "full_name";
+
+  static final String FULL_NAME_KANA = "full_name_kana";
+  static final String DEPARTMENT_NAME = "department_name";
+
+  /** {@code users.status} value for an enabled account (ADR-0006 §3.3 有効/無効). */
+  private static final String STATUS_ACTIVE = "ACTIVE";
+
+  private final UserRepository repository;
+  private final long userId;
+
+  /** Tracks the persisted {@code users.version}; advanced after each successful write-back. */
+  private long version;
+
+  /** True only while the constructor hydrates in-memory state, suppressing write-back. */
+  private boolean hydrating;
 
   public UserAdapter(
       KeycloakSession session,
       RealmModel realm,
       ComponentModel storageProviderModel,
-      long userId,
-      String email,
-      String fullName) {
-    super(session, realm, StorageId.keycloakId(storageProviderModel, String.valueOf(userId)));
-    setUsername(email);
-    setSingleAttribute(FIRST_NAME, fullName);
-    setSingleAttribute(EMAIL, email);
+      UserRepository repository,
+      UserRepository.UserRow row) {
+    super(session, realm, StorageId.keycloakId(storageProviderModel, String.valueOf(row.id())));
+    this.repository = repository;
+    this.userId = row.id();
+    this.version = row.version();
+    this.hydrating = true;
+    setUsername(row.email());
+    // Map users.status onto Keycloak enablement so an INACTIVE account cannot authenticate.
+    setEnabled(STATUS_ACTIVE.equals(row.status()));
+    setEmailVerified(true);
+    super.setEmail(row.email());
+    setSingleAttribute(FIRST_NAME, row.fullName());
+    setSingleAttribute(FULL_NAME, row.fullName());
+    setSingleAttribute(FULL_NAME_KANA, row.fullNameKana());
+    if (row.departmentName() != null) {
+      setSingleAttribute(DEPARTMENT_NAME, row.departmentName());
+    }
+    this.hydrating = false;
   }
 
   /**
-   * Credentials are owned by Keycloak's native credential store (ADR-0006 §3.3).
+   * Credentials are owned by Keycloak's native (federated) credential store (ADR-0006 §3.3).
    *
-   * <p>Returns the session-level credential manager for this user. TODO: wire to
-   * session.userCredentialManager() when JDBC integration is added.
+   * <p>Delegates to Keycloak's own credential manager for this federated user so password / MFA are
+   * stored and validated by Keycloak rather than the SPI ({@code CredentialInputValidator} is not
+   * implemented).
    */
   @Override
   public SubjectCredentialManager credentialManager() {
-    throw new UnsupportedOperationException(
-        "Credential management is delegated to Keycloak native store (ADR-0006 §3.3)");
+    return session.users().getUserCredentialManager(this);
   }
 
-  /** Email is the only writable attribute; writes back to {@code users.email} via JDBC. */
+  /** Email is the only writable profile attribute; writes back to {@code users.email} (§3.1). */
   @Override
   public void setEmail(String email) {
-    // TODO: UPDATE users SET email = :email, version = version + 1 WHERE id = :userId (ADR-0006
-    // §3.4)
+    if (!hydrating) {
+      this.version = repository.updateEmail(userId, email, version);
+    }
     super.setEmail(email);
   }
 
-  /** Ignored — full_name is read-only; SoT is tasks-webapi profile update API. */
+  /**
+   * Routes the Custom User Profile attributes {@code full_name_kana} / {@code department_name} to
+   * their {@code users} columns (ADR-0006 §3.1 Console-create); all other attributes stay
+   * in-memory.
+   */
+  @Override
+  public void setSingleAttribute(String name, String value) {
+    if (!hydrating) {
+      if (FULL_NAME_KANA.equals(name)) {
+        this.version = repository.updateFullNameKana(userId, value, version);
+      } else if (DEPARTMENT_NAME.equals(name)) {
+        this.version = repository.updateDepartmentName(userId, value, version);
+      }
+    }
+    super.setSingleAttribute(name, value);
+  }
+
+  /** Ignored — full_name is read-only; SoT is the tasks-webapi profile update API (§3.1). */
   @Override
   public void setFirstName(String firstName) {}
 
-  /** Ignored — not stored in users table. */
+  /** Ignored — not stored in the users table. */
   @Override
   public void setLastName(String lastName) {}
 }

--- a/keycloak/src/main/java/xyz/dgz48/tasks/keycloak/UserAdapter.java
+++ b/keycloak/src/main/java/xyz/dgz48/tasks/keycloak/UserAdapter.java
@@ -8,33 +8,32 @@ import org.keycloak.storage.StorageId;
 import org.keycloak.storage.adapter.AbstractInMemoryUserAdapter;
 
 /**
- * Adapts a {@code users} table row as a Keycloak {@link org.keycloak.models.UserModel}.
+ * {@code users} テーブルの 1 行を Keycloak の {@link org.keycloak.models.UserModel} として適合させるアダプタ。
  *
- * <p>Profile attributes (full_name, department_name, etc.) are read-only — tasks-webapi is the SoT.
- * Email is the only writable profile attribute; it is written back to {@code users.email} by the
- * Keycloak Update-Email flow (ADR-0006 §3.1). {@code full_name_kana} and {@code department_name}
- * are additionally writable through {@link #setSingleAttribute} for the admin / recovery
- * Console-create Custom User Profile path (§3.1); first/last name remain read-only no-ops. All
- * write-backs use the {@code version} column for optimistic locking (§3.4).
+ * <p>profile 属性(full_name、department_name など)は read-only で、SoT は tasks-webapi。writable な profile
+ * 属性は email のみで、Keycloak Update-Email フローにより {@code users.email} へ書き戻す(ADR-0006 §3.1)。{@code
+ * full_name_kana} と {@code department_name} は、admin / リカバリの Console 作成における Custom User Profile
+ * 経路向けに {@link #setSingleAttribute} 経由で追加的に writable とする(§3.1)。氏名(first/last name)は read-only の
+ * no-op のまま。すべての書き戻しは {@code version} 列で楽観排他する(§3.4)。
  */
 public final class UserAdapter extends AbstractInMemoryUserAdapter {
 
-  /** Custom User Profile attribute keys backed by {@code users} columns (ADR-0006 §3.1). */
+  /** {@code users} 列を裏付けとする Custom User Profile attribute キー(ADR-0006 §3.1)。 */
   static final String FULL_NAME = "full_name";
 
   static final String FULL_NAME_KANA = "full_name_kana";
   static final String DEPARTMENT_NAME = "department_name";
 
-  /** {@code users.status} value for an enabled account (ADR-0006 §3.3 有効/無効). */
+  /** 有効アカウントを表す {@code users.status} 値(ADR-0006 §3.3 有効/無効)。 */
   private static final String STATUS_ACTIVE = "ACTIVE";
 
   private final UserRepository repository;
   private final long userId;
 
-  /** Tracks the persisted {@code users.version}; advanced after each successful write-back. */
+  /** 永続化済みの {@code users.version} を追跡する。書き戻し成功ごとに進める。 */
   private long version;
 
-  /** True only while the constructor hydrates in-memory state, suppressing write-back. */
+  /** コンストラクタが in-memory 状態を hydrate している間だけ true。この間は書き戻しを抑止する。 */
   private boolean hydrating;
 
   public UserAdapter(
@@ -49,7 +48,7 @@ public final class UserAdapter extends AbstractInMemoryUserAdapter {
     this.version = row.version();
     this.hydrating = true;
     setUsername(row.email());
-    // Map users.status onto Keycloak enablement so an INACTIVE account cannot authenticate.
+    // users.status を Keycloak の有効状態にマッピングし、INACTIVE アカウントが認証できないようにする。
     setEnabled(STATUS_ACTIVE.equals(row.status()));
     setEmailVerified(true);
     super.setEmail(row.email());
@@ -63,18 +62,17 @@ public final class UserAdapter extends AbstractInMemoryUserAdapter {
   }
 
   /**
-   * Credentials are owned by Keycloak's native (federated) credential store (ADR-0006 §3.3).
+   * 資格情報は Keycloak の native(federated)credential store が所有する(ADR-0006 §3.3)。
    *
-   * <p>Delegates to Keycloak's own credential manager for this federated user so password / MFA are
-   * stored and validated by Keycloak rather than the SPI ({@code CredentialInputValidator} is not
-   * implemented).
+   * <p>この federated user について Keycloak 自身の credential manager に委譲し、password / MFA を SPI ではなく
+   * Keycloak が保存・検証するようにする({@code CredentialInputValidator} は実装しない)。
    */
   @Override
   public SubjectCredentialManager credentialManager() {
     return session.users().getUserCredentialManager(this);
   }
 
-  /** Email is the only writable profile attribute; writes back to {@code users.email} (§3.1). */
+  /** writable な profile 属性は email のみ。{@code users.email} へ書き戻す(§3.1)。 */
   @Override
   public void setEmail(String email) {
     if (!hydrating) {
@@ -84,9 +82,8 @@ public final class UserAdapter extends AbstractInMemoryUserAdapter {
   }
 
   /**
-   * Routes the Custom User Profile attributes {@code full_name_kana} / {@code department_name} to
-   * their {@code users} columns (ADR-0006 §3.1 Console-create); all other attributes stay
-   * in-memory.
+   * Custom User Profile attribute の {@code full_name_kana} / {@code department_name} を対応する {@code
+   * users} 列へ振り分ける(ADR-0006 §3.1 Console 作成)。その他の属性は in-memory に留める。
    */
   @Override
   public void setSingleAttribute(String name, String value) {
@@ -100,11 +97,11 @@ public final class UserAdapter extends AbstractInMemoryUserAdapter {
     super.setSingleAttribute(name, value);
   }
 
-  /** Ignored — full_name is read-only; SoT is the tasks-webapi profile update API (§3.1). */
+  /** 無視する — full_name は read-only。SoT は tasks-webapi の profile 更新 API(§3.1)。 */
   @Override
   public void setFirstName(String firstName) {}
 
-  /** Ignored — not stored in the users table. */
+  /** 無視する — users テーブルには保持しない。 */
   @Override
   public void setLastName(String lastName) {}
 }

--- a/keycloak/src/main/java/xyz/dgz48/tasks/keycloak/UserRepository.java
+++ b/keycloak/src/main/java/xyz/dgz48/tasks/keycloak/UserRepository.java
@@ -13,27 +13,24 @@ import org.jspecify.annotations.Nullable;
 import org.keycloak.models.ModelException;
 
 /**
- * JDBC data-access for the tasks-webapi {@code users} table (ADR-0006 §3.5).
+ * tasks-webapi の {@code users} テーブルへの JDBC データアクセス(ADR-0006 §3.5)。
  *
- * <p>The SPI federates {@code users} as a read-only profile directory; reads always filter {@code
- * deleted_at IS NULL} so anonymized rows (§3.4) are never resolved (authentication for a deleted
- * user is therefore refused). Per the {@code NO_CACHE} cache policy each operation hits the DB
- * directly. A single {@link Connection} is opened lazily and reused for the lifetime of the owning
- * provider instance (one Keycloak request), then closed in {@link #close()}.
+ * <p>SPI は {@code users} を read-only の profile ディレクトリとして federate する。read は常に {@code deleted_at IS
+ * NULL} で絞るため、匿名化済み行(§3.4)は解決されない(=削除済み user の認証は拒否される)。{@code NO_CACHE} 方針に従い、各操作は都度 DB を hit
+ * する。{@link Connection} は遅延生成し、所有元 provider インスタンスの生存期間(Keycloak の 1 リクエスト)中だけ再利用したのち {@link
+ * #close()} で破棄する。
  *
- * <p>Writes are limited to ADR-0006 §3.1's writable scope: {@code email} write-back (Update-Email
- * reach verification), {@code full_name_kana} / {@code department_name} via the Custom User Profile
- * attribute path (§3.1 Console-create), the {@code addUser} insert (admin / recovery), and the
- * {@code removeUser} anonymization (§3.4). All updates use optimistic locking on the {@code
- * version} column (JPA {@code @Version} equivalent); a lost update surfaces as a {@link
- * ModelException}.
+ * <p>write は ADR-0006 §3.1 の writable 範囲に限定する: {@code email} の書き戻し(Update-Email の到達検証)、Custom User
+ * Profile attribute 経路での {@code full_name_kana} / {@code department_name}(§3.1 Console 作成)、{@code
+ * addUser} の insert(admin / リカバリ)、{@code removeUser} の匿名化(§3.4)。すべての update は {@code version} 列(JPA
+ * {@code @Version} 相当)で楽観排他し、lost update は {@link ModelException} として表面化する。
  */
 final class UserRepository implements AutoCloseable {
 
   /**
-   * Immutable carrier for a non-deleted {@code users} row.
+   * 削除されていない {@code users} 行の不変キャリア。
    *
-   * @param departmentName nullable per the {@code users.department_name} schema
+   * @param departmentName {@code users.department_name} スキーマに合わせて null 許容
    */
   record UserRow(
       long id,
@@ -60,7 +57,7 @@ final class UserRepository implements AutoCloseable {
     this.password = password;
   }
 
-  // --- reads (deleted_at IS NULL only) ---
+  // --- read(deleted_at IS NULL のみ) ---
 
   Optional<UserRow> findById(long id) {
     String sql = "SELECT " + SELECT_COLUMNS + " FROM users WHERE id = ? AND deleted_at IS NULL";
@@ -83,9 +80,8 @@ final class UserRepository implements AutoCloseable {
   }
 
   /**
-   * Paginated search for the Admin Console user list. A blank or {@code "*"} term returns all
-   * non-deleted users; otherwise matches {@code email} or {@code full_name} (case-insensitive
-   * substring).
+   * Admin Console の user 一覧向けページング検索。空文字または {@code "*"} の場合は削除されていない全 user を返す。それ以外は {@code email}
+   * または {@code full_name} の部分一致(大文字小文字区別なし)。
    */
   List<UserRow> search(@Nullable String term, int firstResult, int maxResults) {
     boolean matchAll = term == null || term.isBlank() || "*".equals(term);
@@ -128,15 +124,14 @@ final class UserRepository implements AutoCloseable {
     }
   }
 
-  // --- writes ---
+  // --- write ---
 
   /**
-   * Inserts a tenant-unassigned row for the admin / recovery create path (ADR-0006 §3.1). {@code
-   * full_name_kana} starts blank and is filled via the Custom User Profile attribute write-back;
-   * {@code oidc_sub} gets a unique {@code pending:} placeholder until first-login correlation
-   * (§3.2) assigns the real Keycloak {@code sub}.
+   * admin / リカバリの作成経路向けに tenant 未所属の行を insert する(ADR-0006 §3.1)。{@code full_name_kana} は空で開始し
+   * Custom User Profile attribute の書き戻しで埋める。{@code oidc_sub} は初回ログインの correlation(§3.2)が本物の
+   * Keycloak {@code sub} を割り当てるまで、一意な {@code pending:} placeholder を入れておく。
    *
-   * @return the inserted row (re-read to obtain the generated id and version)
+   * @return insert した行(生成 id と version を取得するため再 read する)
    */
   UserRow insert(String email) {
     String sql =
@@ -161,17 +156,17 @@ final class UserRepository implements AutoCloseable {
     }
   }
 
-  /** Email write-back with optimistic lock (ADR-0006 §3.4); returns the new version. */
+  /** email の書き戻し(楽観排他、ADR-0006 §3.4)。更新後の version を返す。 */
   long updateEmail(long id, String email, long expectedVersion) {
     return updateColumn("email", email, id, expectedVersion);
   }
 
-  /** {@code full_name_kana} write-back (Custom User Profile path); returns the new version. */
+  /** {@code full_name_kana} の書き戻し(Custom User Profile 経路)。更新後の version を返す。 */
   long updateFullNameKana(long id, String value, long expectedVersion) {
     return updateColumn("full_name_kana", value, id, expectedVersion);
   }
 
-  /** {@code department_name} write-back (nullable); returns the new version. */
+  /** {@code department_name} の書き戻し(null 許容)。更新後の version を返す。 */
   long updateDepartmentName(long id, @Nullable String value, long expectedVersion) {
     return updateColumn("department_name", value, id, expectedVersion);
   }
@@ -202,15 +197,14 @@ final class UserRepository implements AutoCloseable {
   }
 
   /**
-   * Logical-delete + PII anonymization (ADR-0006 §3.4 steps 1-7), mirroring webapi's {@code
-   * UserAnonymizationDomainService} / {@code User#anonymize}. The cross-module boundary (the
-   * keycloak SPI plugin builds without the webapi project, see {@code keycloak/Dockerfile})
-   * prevents reusing that domain service directly, so the identical placeholder logic is applied
-   * here in one SQL statement. Uses the DB clock ({@code NOW()}) for {@code deleted_at} to avoid an
-   * ambient time-zone. Idempotent: re-deleting an already-anonymized row is a no-op.
+   * 論理削除 + 個人情報匿名化(ADR-0006 §3.4 step 1〜7)。webapi の {@code UserAnonymizationDomainService} / {@code
+   * User#anonymize} と同一ロジック。モジュール境界(keycloak SPI プラグインは webapi プロジェクト無しでビルドされる。{@code
+   * keycloak/Dockerfile} 参照)のためその domain service を直接再利用できないので、同一の placeholder ロジックをここで 1 つの SQL
+   * として適用する。{@code deleted_at} は ambient なタイムゾーンを避けるため DB クロック({@code NOW()})を使う。冪等: 匿名化済み行の再削除は
+   * no-op。
    *
-   * <p>TODO(#144): step 8 — record an {@code audit_logs} {@code action='ANONYMIZE'} entry (deferred
-   * here exactly as in {@code UserAnonymizationDomainService}, pending the auditing mechanism).
+   * <p>TODO(#144): step 8 — {@code audit_logs} に {@code action='ANONYMIZE'} を記録する(監査機構の整備待ちで、{@code
+   * UserAnonymizationDomainService} と同様にここでも保留)。
    */
   void anonymize(long id) {
     String sql =
@@ -230,7 +224,7 @@ final class UserRepository implements AutoCloseable {
     }
   }
 
-  // --- helpers ---
+  // --- ヘルパー ---
 
   private Connection connection() {
     Connection c = connection;
@@ -270,7 +264,7 @@ final class UserRepository implements AutoCloseable {
       try {
         c.close();
       } catch (SQLException e) {
-        // best-effort close; nothing actionable on a failed close.
+        // close 失敗時に取れる対処はないためベストエフォートで握りつぶす。
       } finally {
         connection = null;
       }

--- a/keycloak/src/main/java/xyz/dgz48/tasks/keycloak/UserRepository.java
+++ b/keycloak/src/main/java/xyz/dgz48/tasks/keycloak/UserRepository.java
@@ -79,24 +79,33 @@ final class UserRepository implements AutoCloseable {
     }
   }
 
+  /** LIKE のメタ文字をエスケープする際の ESCAPE 文字。MySQL の文字列リテラルでは特別扱いされない {@code |} を使う。 */
+  private static final char LIKE_ESCAPE = '|';
+
   /**
    * Admin Console の user 一覧向けページング検索。空文字または {@code "*"} の場合は削除されていない全 user を返す。それ以外は {@code email}
-   * または {@code full_name} の部分一致(大文字小文字区別なし)。
+   * または {@code full_name} の部分一致(大文字小文字区別なし)。入力中の LIKE メタ文字({@code %} {@code _} とエスケープ文字自身)は {@link
+   * #escapeLike} で無効化し、リテラルとして部分一致させる。
    */
   List<UserRow> search(@Nullable String term, int firstResult, int maxResults) {
-    boolean matchAll = term == null || term.isBlank() || "*".equals(term);
+    String trimmed = term == null ? "" : term;
+    boolean matchAll = trimmed.isBlank() || "*".equals(trimmed);
     StringBuilder sql =
         new StringBuilder("SELECT ")
             .append(SELECT_COLUMNS)
             .append(" FROM users WHERE deleted_at IS NULL");
     if (!matchAll) {
-      sql.append(" AND (email LIKE ? OR full_name LIKE ?)");
+      sql.append(" AND (email LIKE ? ESCAPE '")
+          .append(LIKE_ESCAPE)
+          .append("' OR full_name LIKE ? ESCAPE '")
+          .append(LIKE_ESCAPE)
+          .append("')");
     }
     sql.append(" ORDER BY id LIMIT ? OFFSET ?");
     try (PreparedStatement ps = connection().prepareStatement(sql.toString())) {
       int idx = 1;
       if (!matchAll) {
-        String like = "%" + term + "%";
+        String like = "%" + escapeLike(trimmed) + "%";
         ps.setString(idx++, like);
         ps.setString(idx++, like);
       }
@@ -240,6 +249,15 @@ final class UserRepository implements AutoCloseable {
       connection = c;
     }
     return c;
+  }
+
+  /**
+   * LIKE のメタ文字({@code %} {@code _})とエスケープ文字自身を {@link #LIKE_ESCAPE} で前置エスケープし、入力をリテラルとして部分一致させる。
+   * エスケープ文字自身の二重化を先に行う。
+   */
+  static String escapeLike(String value) {
+    String esc = String.valueOf(LIKE_ESCAPE);
+    return value.replace(esc, esc + esc).replace("%", esc + "%").replace("_", esc + "_");
   }
 
   private static Optional<UserRow> single(PreparedStatement ps) throws SQLException {

--- a/keycloak/src/main/java/xyz/dgz48/tasks/keycloak/UserRepository.java
+++ b/keycloak/src/main/java/xyz/dgz48/tasks/keycloak/UserRepository.java
@@ -1,0 +1,279 @@
+package xyz.dgz48.tasks.keycloak;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.jspecify.annotations.Nullable;
+import org.keycloak.models.ModelException;
+
+/**
+ * JDBC data-access for the tasks-webapi {@code users} table (ADR-0006 §3.5).
+ *
+ * <p>The SPI federates {@code users} as a read-only profile directory; reads always filter {@code
+ * deleted_at IS NULL} so anonymized rows (§3.4) are never resolved (authentication for a deleted
+ * user is therefore refused). Per the {@code NO_CACHE} cache policy each operation hits the DB
+ * directly. A single {@link Connection} is opened lazily and reused for the lifetime of the owning
+ * provider instance (one Keycloak request), then closed in {@link #close()}.
+ *
+ * <p>Writes are limited to ADR-0006 §3.1's writable scope: {@code email} write-back (Update-Email
+ * reach verification), {@code full_name_kana} / {@code department_name} via the Custom User Profile
+ * attribute path (§3.1 Console-create), the {@code addUser} insert (admin / recovery), and the
+ * {@code removeUser} anonymization (§3.4). All updates use optimistic locking on the {@code
+ * version} column (JPA {@code @Version} equivalent); a lost update surfaces as a {@link
+ * ModelException}.
+ */
+final class UserRepository implements AutoCloseable {
+
+  /**
+   * Immutable carrier for a non-deleted {@code users} row.
+   *
+   * @param departmentName nullable per the {@code users.department_name} schema
+   */
+  record UserRow(
+      long id,
+      String oidcSub,
+      String email,
+      String fullName,
+      String fullNameKana,
+      @Nullable String departmentName,
+      String status,
+      long version) {}
+
+  private static final String SELECT_COLUMNS =
+      "id, oidc_sub, email, full_name, full_name_kana, department_name, status, version";
+
+  private final String jdbcUrl;
+  private final String username;
+  private final String password;
+
+  private @Nullable Connection connection;
+
+  UserRepository(String jdbcUrl, String username, String password) {
+    this.jdbcUrl = jdbcUrl;
+    this.username = username;
+    this.password = password;
+  }
+
+  // --- reads (deleted_at IS NULL only) ---
+
+  Optional<UserRow> findById(long id) {
+    String sql = "SELECT " + SELECT_COLUMNS + " FROM users WHERE id = ? AND deleted_at IS NULL";
+    try (PreparedStatement ps = connection().prepareStatement(sql)) {
+      ps.setLong(1, id);
+      return single(ps);
+    } catch (SQLException e) {
+      throw new ModelException("tasks-webapi user store: findById failed", e);
+    }
+  }
+
+  Optional<UserRow> findByEmail(String email) {
+    String sql = "SELECT " + SELECT_COLUMNS + " FROM users WHERE email = ? AND deleted_at IS NULL";
+    try (PreparedStatement ps = connection().prepareStatement(sql)) {
+      ps.setString(1, email);
+      return single(ps);
+    } catch (SQLException e) {
+      throw new ModelException("tasks-webapi user store: findByEmail failed", e);
+    }
+  }
+
+  /**
+   * Paginated search for the Admin Console user list. A blank or {@code "*"} term returns all
+   * non-deleted users; otherwise matches {@code email} or {@code full_name} (case-insensitive
+   * substring).
+   */
+  List<UserRow> search(@Nullable String term, int firstResult, int maxResults) {
+    boolean matchAll = term == null || term.isBlank() || "*".equals(term);
+    StringBuilder sql =
+        new StringBuilder("SELECT ")
+            .append(SELECT_COLUMNS)
+            .append(" FROM users WHERE deleted_at IS NULL");
+    if (!matchAll) {
+      sql.append(" AND (email LIKE ? OR full_name LIKE ?)");
+    }
+    sql.append(" ORDER BY id LIMIT ? OFFSET ?");
+    try (PreparedStatement ps = connection().prepareStatement(sql.toString())) {
+      int idx = 1;
+      if (!matchAll) {
+        String like = "%" + term + "%";
+        ps.setString(idx++, like);
+        ps.setString(idx++, like);
+      }
+      ps.setInt(idx++, maxResults < 0 ? Integer.MAX_VALUE : maxResults);
+      ps.setInt(idx, Math.max(firstResult, 0));
+      List<UserRow> rows = new ArrayList<>();
+      try (ResultSet rs = ps.executeQuery()) {
+        while (rs.next()) {
+          rows.add(map(rs));
+        }
+      }
+      return rows;
+    } catch (SQLException e) {
+      throw new ModelException("tasks-webapi user store: search failed", e);
+    }
+  }
+
+  int count() {
+    try (PreparedStatement ps =
+            connection().prepareStatement("SELECT COUNT(*) FROM users WHERE deleted_at IS NULL");
+        ResultSet rs = ps.executeQuery()) {
+      return rs.next() ? rs.getInt(1) : 0;
+    } catch (SQLException e) {
+      throw new ModelException("tasks-webapi user store: count failed", e);
+    }
+  }
+
+  // --- writes ---
+
+  /**
+   * Inserts a tenant-unassigned row for the admin / recovery create path (ADR-0006 §3.1). {@code
+   * full_name_kana} starts blank and is filled via the Custom User Profile attribute write-back;
+   * {@code oidc_sub} gets a unique {@code pending:} placeholder until first-login correlation
+   * (§3.2) assigns the real Keycloak {@code sub}.
+   *
+   * @return the inserted row (re-read to obtain the generated id and version)
+   */
+  UserRow insert(String email) {
+    String sql =
+        "INSERT INTO users (oidc_sub, email, full_name, full_name_kana, department_name, status,"
+            + " version) VALUES (?, ?, ?, '', NULL, 'ACTIVE', 0)";
+    try (PreparedStatement ps =
+        connection().prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
+      ps.setString(1, "pending:" + email);
+      ps.setString(2, email);
+      ps.setString(3, email);
+      ps.executeUpdate();
+      try (ResultSet keys = ps.getGeneratedKeys()) {
+        if (!keys.next()) {
+          throw new ModelException("tasks-webapi user store: insert returned no generated key");
+        }
+        return findById(keys.getLong(1))
+            .orElseThrow(
+                () -> new ModelException("tasks-webapi user store: inserted row not found"));
+      }
+    } catch (SQLException e) {
+      throw new ModelException("tasks-webapi user store: insert failed", e);
+    }
+  }
+
+  /** Email write-back with optimistic lock (ADR-0006 §3.4); returns the new version. */
+  long updateEmail(long id, String email, long expectedVersion) {
+    return updateColumn("email", email, id, expectedVersion);
+  }
+
+  /** {@code full_name_kana} write-back (Custom User Profile path); returns the new version. */
+  long updateFullNameKana(long id, String value, long expectedVersion) {
+    return updateColumn("full_name_kana", value, id, expectedVersion);
+  }
+
+  /** {@code department_name} write-back (nullable); returns the new version. */
+  long updateDepartmentName(long id, @Nullable String value, long expectedVersion) {
+    return updateColumn("department_name", value, id, expectedVersion);
+  }
+
+  private long updateColumn(String column, @Nullable String value, long id, long expectedVersion) {
+    String sql =
+        "UPDATE users SET "
+            + column
+            + " = ?, version = version + 1 WHERE id = ? AND version = ? AND deleted_at IS NULL";
+    try (PreparedStatement ps = connection().prepareStatement(sql)) {
+      ps.setString(1, value);
+      ps.setLong(2, id);
+      ps.setLong(3, expectedVersion);
+      if (ps.executeUpdate() != 1) {
+        throw new ModelException(
+            "tasks-webapi user store: optimistic lock conflict updating "
+                + column
+                + " for user "
+                + id
+                + " (expected version "
+                + expectedVersion
+                + ")");
+      }
+      return expectedVersion + 1;
+    } catch (SQLException e) {
+      throw new ModelException("tasks-webapi user store: update " + column + " failed", e);
+    }
+  }
+
+  /**
+   * Logical-delete + PII anonymization (ADR-0006 §3.4 steps 1-7), mirroring webapi's {@code
+   * UserAnonymizationDomainService} / {@code User#anonymize}. The cross-module boundary (the
+   * keycloak SPI plugin builds without the webapi project, see {@code keycloak/Dockerfile})
+   * prevents reusing that domain service directly, so the identical placeholder logic is applied
+   * here in one SQL statement. Uses the DB clock ({@code NOW()}) for {@code deleted_at} to avoid an
+   * ambient time-zone. Idempotent: re-deleting an already-anonymized row is a no-op.
+   *
+   * <p>TODO(#144): step 8 — record an {@code audit_logs} {@code action='ANONYMIZE'} entry (deferred
+   * here exactly as in {@code UserAnonymizationDomainService}, pending the auditing mechanism).
+   */
+  void anonymize(long id) {
+    String sql =
+        "UPDATE users SET deleted_at = NOW(),"
+            + " email = CONCAT('__deleted__', id, '@deleted.invalid'),"
+            + " oidc_sub = CONCAT('__deleted__', id),"
+            + " full_name = '__deleted__',"
+            + " full_name_kana = '__deleted__',"
+            + " department_name = NULL,"
+            + " version = version + 1"
+            + " WHERE id = ? AND deleted_at IS NULL";
+    try (PreparedStatement ps = connection().prepareStatement(sql)) {
+      ps.setLong(1, id);
+      ps.executeUpdate();
+    } catch (SQLException e) {
+      throw new ModelException("tasks-webapi user store: anonymize failed for user " + id, e);
+    }
+  }
+
+  // --- helpers ---
+
+  private Connection connection() {
+    Connection c = connection;
+    if (c == null) {
+      try {
+        c = DriverManager.getConnection(jdbcUrl, username, password);
+      } catch (SQLException e) {
+        throw new ModelException("tasks-webapi user store: failed to open JDBC connection", e);
+      }
+      connection = c;
+    }
+    return c;
+  }
+
+  private static Optional<UserRow> single(PreparedStatement ps) throws SQLException {
+    try (ResultSet rs = ps.executeQuery()) {
+      return rs.next() ? Optional.of(map(rs)) : Optional.empty();
+    }
+  }
+
+  private static UserRow map(ResultSet rs) throws SQLException {
+    return new UserRow(
+        rs.getLong("id"),
+        rs.getString("oidc_sub"),
+        rs.getString("email"),
+        rs.getString("full_name"),
+        rs.getString("full_name_kana"),
+        rs.getString("department_name"),
+        rs.getString("status"),
+        rs.getLong("version"));
+  }
+
+  @Override
+  public void close() {
+    Connection c = connection;
+    if (c != null) {
+      try {
+        c.close();
+      } catch (SQLException e) {
+        // best-effort close; nothing actionable on a failed close.
+      } finally {
+        connection = null;
+      }
+    }
+  }
+}

--- a/keycloak/src/main/java/xyz/dgz48/tasks/keycloak/UserRepository.java
+++ b/keycloak/src/main/java/xyz/dgz48/tasks/keycloak/UserRepository.java
@@ -238,6 +238,10 @@ final class UserRepository implements AutoCloseable {
 
   // --- ヘルパー ---
 
+  // スレッド安全性: 本インスタンスは KeycloakSession ごとに生成され(factory#create 参照)、
+  // KeycloakSession と provider は 1 リクエスト=1 スレッドに閉じる(JDBC Connection 自体が非スレッドセーフ
+  // なため Keycloak がそう保証する)。複数スレッドからの同時アクセスは発生しないため、この遅延生成に
+  // 同期や volatile は不要。
   private Connection connection() {
     Connection c = connection;
     if (c == null) {

--- a/keycloak/src/main/java/xyz/dgz48/tasks/keycloak/UserRepository.java
+++ b/keycloak/src/main/java/xyz/dgz48/tasks/keycloak/UserRepository.java
@@ -171,6 +171,9 @@ final class UserRepository implements AutoCloseable {
     return updateColumn("department_name", value, id, expectedVersion);
   }
 
+  // SQL インジェクション不変条件: 値(value/id/expectedVersion)は全て ? でバインドする。識別子 column のみ SQL 文字列へ連結するが、
+  // 呼び出し元は本クラス内の updateEmail/updateFullNameKana/updateDepartmentName のみで、渡る値は固定リテラル
+  // ("email"/"full_name_kana"/"department_name")に限られる。ユーザー入力は column へ流入しない。
   private long updateColumn(String column, @Nullable String value, long id, long expectedVersion) {
     String sql =
         "UPDATE users SET "

--- a/keycloak/src/main/java/xyz/dgz48/tasks/keycloak/package-info.java
+++ b/keycloak/src/main/java/xyz/dgz48/tasks/keycloak/package-info.java
@@ -1,4 +1,4 @@
-/** Keycloak User Storage SPI — read-only federation + email-only writable (ADR-0006). */
+/** Keycloak User Storage SPI — read-only federation + email のみ writable(ADR-0006)。 */
 @NullMarked
 package xyz.dgz48.tasks.keycloak;
 

--- a/keycloak/src/test/java/xyz/dgz48/tasks/keycloak/UserRepositoryTest.java
+++ b/keycloak/src/test/java/xyz/dgz48/tasks/keycloak/UserRepositoryTest.java
@@ -1,0 +1,27 @@
+package xyz.dgz48.tasks.keycloak;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+/** {@link UserRepository#escapeLike} の LIKE メタ文字エスケープを検証する。 */
+class UserRepositoryTest {
+
+  @Test
+  void escapeLike_escapesWildcardsAndEscapeChar() {
+    // % と _ は前置エスケープされ、リテラルとして扱われる(ESCAPE '|' と対応)。
+    assertEquals("|%foo|_bar", UserRepository.escapeLike("%foo_bar"));
+  }
+
+  @Test
+  void escapeLike_doublesEscapeCharFirst() {
+    // エスケープ文字自身は二重化する(後続の % / _ 置換で壊れないよう先に処理する)。
+    assertEquals("a||b", UserRepository.escapeLike("a|b"));
+    assertEquals("|%|_||", UserRepository.escapeLike("%_|"));
+  }
+
+  @Test
+  void escapeLike_leavesPlainTextUnchanged() {
+    assertEquals("tanaka@example.com", UserRepository.escapeLike("tanaka@example.com"));
+  }
+}


### PR DESCRIPTION
設計正本: ADR-0006 §3.1 / §3.2 / §3.4 / §3.5。Closes #728。

全メソッド TODO スタブだった User Storage SPI を実装する。

## 変更内容

| ファイル | 内容 |
|---|---|
| `UserRepository`(新規) | `users` テーブルへの JDBC DAO。read は `deleted_at IS NULL` のみ。`NO_CACHE` 前提で provider ごとに `Connection` を遅延生成し `close()` で破棄。write 戻しは `version` 列で楽観排他 |
| `TasksWebApiUserStorageProvider` | `getUserBy{Id,Username,Email}` / `searchForUserStream` / `getUsersCount` / `addUser` / `removeUser` を配線(username == email) |
| `UserAdapter` | email 書き戻し、`full_name_kana` / `department_name` は Custom User Profile 経路で書込、氏名は read-only no-op。`credentialManager` は Keycloak native store へ委譲。`status`→enabled マッピング |
| `TasksWebApiUserStorageProviderFactory` | `jdbcUrl` / `dbUsername` / `dbPassword` の config プロパティを定義 |

## 受け入れ条件

- [x] `getUserBy{Id,Username,Email}` が `users` から解決し、削除済(`deleted_at`)user を返さない
- [x] `searchForUserStream` がページングで Admin Console list に表示(`getUsersCount` も実装)
- [x] `addUser` が tenant 未所属の `users` 行を作成(`full_name_kana` は Custom User Profile attribute 経由)
- [x] `removeUser` が匿名化(§3.4)+ `true` 返却
- [x] `setEmail` が `users.email` へ write 戻し + 楽観排他(競合時 `ModelException`)
- [x] `CredentialInputValidator` は実装しない(§3.3)
- [x] NullAway / Error Prone / 既存テスト 通過

## 設計上の判断 / レビュー観点

1. **JDBC で実装**(JPA ではない)。Issue の「JDBC 配線」指定どおり。keycloak モジュールは JPA スタックを持たず、Dockerfile が webapi 抜きで SPI JAR をビルドするため webapi の JPA エンティティを再利用できない。`@Version` 楽観排他は `SET version = version + 1 WHERE version = ?` で等価に担保。
2. **`removeUser` は `UserAnonymizationDomainService` を直接呼ばない**。同じモジュール境界の理由で import 不可のため、§3.4 と同一の匿名化ロジックを JDBC で再実装した(step 8 監査ログは webapi 側と同様 #144 待ちの TODO)。
3. **`spotlessCheck`**: 本環境は Gradle launcher が JDK 25 で google-java-format 1.24.0 が動かない(未変更ファイルでも失敗)。JDK 21 + `--add-exports` で GJF 1.24.0 を直接実行し、4ファイルとも準拠を確認済み。CI(対応 JDK)では通る想定。

## スコープ外(別 sub-issue)

- realm 側 Custom User Profile attribute 契約(`full_name_kana` 必須化等)→ sub-issue ②
- E2E 検証 → sub-issue ③

🤖 Generated with [Claude Code](https://claude.com/claude-code)