### PR TITLE
ci(claude): impl-fix を opt-in 化 + 実装PR自動付与 + /review 再レビュー

### DIFF
--- a/.github/workflows/bot-claude-impl-autolabel.yml
+++ b/.github/workflows/bot-claude-impl-autolabel.yml
@@ -1,0 +1,31 @@
+# Claude Impl Auto-Label shim
+# 実装 Claude (claude-automation-impl[bot]) が作成した PR に claude:impl-fix を自動付与する。
+# impl bot 経路は従来どおり impl-fix が稼働、手動(local Claude Code)PR は付与されず起動しない(opt-in / fail-closed)。
+# reusable は呼ばない自己完結ジョブ(GITHUB_TOKEN のみ)。
+
+name: "Claude: Impl Auto-Label"
+
+on:
+  pull_request:
+    types: [opened]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: claude-impl-autolabel-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  autolabel:
+    if: github.event.pull_request.user.login == 'claude-automation-impl[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add claude:impl-fix label
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+        run: gh pr edit "$PR" --add-label "claude:impl-fix"

--- a/.github/workflows/bot-claude-impl-fix.yml
+++ b/.github/workflows/bot-claude-impl-fix.yml
@@ -24,11 +24,16 @@ concurrency:
 jobs:
   impl-fix:
     # 起動条件:
+    # (0) PR に claude:impl-fix ラベルが付いている(opt-in。無ければ起動しない)
+    #     実装 Claude の PR は bot-claude-impl-autolabel.yml が自動付与。手動 PR は付与しない。
     # (1) review が changes_requested で submit された(人 or レビュワ bot どちらでも)
     # (2) PR レビューコメントが投稿された かつ 投稿者が impl bot 自身でない(自己ループ防止)
     if: |
-      (github.event_name == 'pull_request_review' && github.event.review.state == 'changes_requested') ||
-      (github.event_name == 'pull_request_review_comment' && github.event.comment.user.login != 'claude-automation-impl[bot]')
+      contains(github.event.pull_request.labels.*.name, 'claude:impl-fix') &&
+      (
+        (github.event_name == 'pull_request_review' && github.event.review.state == 'changes_requested') ||
+        (github.event_name == 'pull_request_review_comment' && github.event.comment.user.login != 'claude-automation-impl[bot]')
+      )
     uses: win2cot/claude-automation/.github/workflows/reusable-impl-fix.yml@v1
     secrets:
       CLAUDE_IMPL_APP_ID: ${{ secrets.CLAUDE_IMPL_APP_ID }}

--- a/.github/workflows/bot-claude-review.yml
+++ b/.github/workflows/bot-claude-review.yml
@@ -33,9 +33,12 @@ jobs:
     #     付与され、機械承認 (renovate-approve) が no-op に倒れて詰まるため除外する。
     # (2) issue_comment が PR に投稿された かつ 投稿者が claude-automation-impl[bot] かつ
     #     本文に signal: claude-impl-done を含む(任意のユーザによる起動を防ぐため投稿者を限定)
+    # (3) OWNER/MEMBER/COLLABORATOR が PR に `/review` で始まるコメント → 再レビュー
+    #     local Claude Code の修正 push 後に再レビューを起こす(任意ユーザ起動は author_association で排除)
     if: |
       (github.event_name == 'pull_request' && github.event.pull_request.draft == false && github.event.pull_request.user.login != 'renovate[bot]') ||
-      (github.event_name == 'issue_comment' && github.event.issue.pull_request != null && github.event.comment.user.login == 'claude-automation-impl[bot]' && contains(github.event.comment.body, 'signal: claude-impl-done'))
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request != null && github.event.comment.user.login == 'claude-automation-impl[bot]' && contains(github.event.comment.body, 'signal: claude-impl-done')) ||
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request != null && startsWith(github.event.comment.body, '/review') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
     uses: win2cot/claude-automation/.github/workflows/reusable-review.yml@v1
     secrets:
       CLAUDE_REVIEW_APP_ID: ${{ secrets.CLAUDE_REVIEW_APP_ID }}


### PR DESCRIPTION
## 概要
impl-fix Claude を `claude:impl-fix` ラベルの opt-in 方式に変更する。実装 Claude の PR には自動付与し、手動(local Claude Code)PR では付与しない(fail-closed)。あわせて OWNER/MEMBER/COLLABORATOR の `/review` コメントでレビュワ Claude を再起動できる経路を追加する。

## 変更
- `bot-claude-impl-fix.yml`: `if` に `claude:impl-fix` ラベルゲートを追加(opt-in)
- `bot-claude-impl-autolabel.yml`(新規): `claude-automation-impl[bot]` の PR opened で `claude:impl-fix` を自動付与
- `bot-claude-review.yml`: `/review`(`startsWith`)+ `author_association` 限定の再レビュー経路を追加

## 影響
- reusable workflow は不変(v1 retag 不要)
- impl bot 経路は従来どおり全自動(自動ラベル付与で impl-fix まで連動)
- 手動 PR はラベル無しで impl-fix が起動しない

Closes #738