### PR TITLE
feat(audit): 認可違反の audit_logs 記録配線(*_DENIED 8値, §6.2.3)(#736)

### DIFF
--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/domain/AuditEventType.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/domain/AuditEventType.java
@@ -23,8 +23,11 @@ public enum AuditEventType {
   ANONYMIZE,
   LOGIN_FAILED,
 
-  // 認可違反 (基本設計書 §4.2.6 / §6.2.3, #734)。記録配線は #736 で実施(語彙のみ先行追加)。
-  // TENANT_CROSSED は旧 CROSS_TENANT_VIOLATION_ATTEMPT を設計標準語彙へ改称したもの(本 issue で記録配線済み)。
+  // 認可違反 (基本設計書 §4.2.6 / §6.2.3)。語彙追加は #734、記録配線は #736 で実施済み。
+  // *_DENIED は AuthorizationDeniedAuditService 経由で記録(TaskExceptionHandler /
+  // TasksAccessDeniedHandler)。
+  // TENANT_CROSSED は旧 CROSS_TENANT_VIOLATION_ATTEMPT を設計標準語彙へ改称し、CrossTenantViolationAuditService
+  // で記録。
   VIEW_DENIED,
   EDIT_DENIED,
   DELETE_DENIED,

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/usecase/AuthorizationDeniedAuditService.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/usecase/AuthorizationDeniedAuditService.java
@@ -1,0 +1,40 @@
+package xyz.dgz48.tasks.webapi.audit.usecase;
+
+import org.jspecify.annotations.Nullable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import xyz.dgz48.tasks.webapi.audit.domain.AuditEventType;
+
+/**
+ * 認可違反({@code *_DENIED})を {@code audit_logs} に記録するサービス(基本設計書 §6.2.3)。
+ *
+ * <p>呼び出し元(例外ハンドラ / {@code AccessDeniedHandler})は、認可違反でリクエストの トランザクションがロールバックされた後に実行される。記録を確実に残すため
+ * {@code REQUIRES_NEW} で独立したトランザクションにコミットする({@code CrossTenantViolationAuditService} と同方針)。
+ */
+@Service
+public class AuthorizationDeniedAuditService {
+
+  private final AuditLogPort auditLogPort;
+
+  public AuthorizationDeniedAuditService(AuditLogPort auditLogPort) {
+    this.auditLogPort = auditLogPort;
+  }
+
+  /**
+   * 認可違反を記録する。
+   *
+   * @param action §6.2.3 の {@code *_DENIED} アクション
+   * @param tenantId 現在テナント ID(未選択の場合は {@code null})
+   * @param userId 操作ユーザー ID(不明な場合は {@code null})
+   * @param detail 文脈情報(対象 entity 等)
+   */
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  public void record(
+      AuditEventType action,
+      @Nullable Long tenantId,
+      @Nullable Long userId,
+      @Nullable Object detail) {
+    auditLogPort.record(action, tenantId, userId, detail);
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/security/adapter/web/TasksAccessDeniedHandler.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/security/adapter/web/TasksAccessDeniedHandler.java
@@ -5,13 +5,22 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.OffsetDateTime;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.stereotype.Component;
 import tools.jackson.databind.json.JsonMapper;
+import xyz.dgz48.tasks.webapi.audit.domain.AuditEventType;
+import xyz.dgz48.tasks.webapi.audit.usecase.AuthorizationDeniedAuditService;
+import xyz.dgz48.tasks.webapi.shared.domain.TenantContext;
 import xyz.dgz48.tasks.webapi.shared.infra.AppZones;
 import xyz.dgz48.tasks.webapi.shared.web.ErrorCode;
 import xyz.dgz48.tasks.webapi.shared.web.ErrorResponse;
@@ -21,7 +30,10 @@ import xyz.dgz48.tasks.webapi.shared.web.ErrorResponse;
 @RequiredArgsConstructor
 public class TasksAccessDeniedHandler implements AccessDeniedHandler {
 
+  private static final Logger log = LoggerFactory.getLogger(TasksAccessDeniedHandler.class);
+
   private final JsonMapper objectMapper;
+  private final AuthorizationDeniedAuditService authorizationDeniedAuditService;
 
   @Override
   public void handle(
@@ -29,6 +41,7 @@ public class TasksAccessDeniedHandler implements AccessDeniedHandler {
       HttpServletResponse response,
       AccessDeniedException accessDeniedException)
       throws IOException {
+    recordRoleBasedDenied(request);
     response.setStatus(HttpStatus.FORBIDDEN.value());
     response.setContentType(MediaType.APPLICATION_JSON_VALUE);
     response.setCharacterEncoding(StandardCharsets.UTF_8.name());
@@ -41,5 +54,29 @@ public class TasksAccessDeniedHandler implements AccessDeniedHandler {
             "アクセス権限がありません",
             request.getRequestURI());
     objectMapper.writeValue(response.getWriter(), errorResponse);
+  }
+
+  /**
+   * ロール権限不足(SaaS Admin 専用 API 等)を {@code ROLE_BASED_DENIED} として記録する(§6.2.3)。記録失敗で 本来の 403
+   * 応答を妨げないよう、例外はログ出力に留める。
+   */
+  private void recordRoleBasedDenied(HttpServletRequest request) {
+    try {
+      authorizationDeniedAuditService.record(
+          AuditEventType.ROLE_BASED_DENIED,
+          TenantContext.get(),
+          currentUserId(),
+          Map.of("method", request.getMethod(), "path", request.getRequestURI()));
+    } catch (RuntimeException e) {
+      log.warn("ROLE_BASED_DENIED の監査記録に失敗しました", e);
+    }
+  }
+
+  private static @Nullable Long currentUserId() {
+    Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+    if (auth instanceof TasksAuthenticationToken token) {
+      return token.getPrincipal().getId();
+    }
+    return null;
   }
 }

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/adapter/web/TaskExceptionHandler.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/adapter/web/TaskExceptionHandler.java
@@ -2,12 +2,22 @@ package xyz.dgz48.tasks.webapi.task.adapter.web;
 
 import jakarta.servlet.http.HttpServletRequest;
 import java.time.OffsetDateTime;
+import java.util.Map;
 import java.util.Objects;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.MissingRequestHeaderException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import xyz.dgz48.tasks.webapi.audit.domain.AuditEventType;
+import xyz.dgz48.tasks.webapi.audit.usecase.AuthorizationDeniedAuditService;
+import xyz.dgz48.tasks.webapi.security.adapter.web.TasksAuthenticationToken;
+import xyz.dgz48.tasks.webapi.shared.domain.TenantContext;
 import xyz.dgz48.tasks.webapi.shared.exception.DomainException;
 import xyz.dgz48.tasks.webapi.shared.exception.PreconditionFailedException;
 import xyz.dgz48.tasks.webapi.shared.infra.AppZones;
@@ -22,11 +32,15 @@ import xyz.dgz48.tasks.webapi.task.domain.TaskOwnershipException;
 @RestControllerAdvice(assignableTypes = TaskController.class)
 public class TaskExceptionHandler {
 
-  @ExceptionHandler({
-    TaskNotFoundException.class,
-    TaskNotViewableException.class,
-    StakeholderNotFoundException.class
-  })
+  private static final Logger log = LoggerFactory.getLogger(TaskExceptionHandler.class);
+
+  private final AuthorizationDeniedAuditService authorizationDeniedAuditService;
+
+  public TaskExceptionHandler(AuthorizationDeniedAuditService authorizationDeniedAuditService) {
+    this.authorizationDeniedAuditService = authorizationDeniedAuditService;
+  }
+
+  @ExceptionHandler({TaskNotFoundException.class, StakeholderNotFoundException.class})
   @ResponseStatus(HttpStatus.NOT_FOUND)
   public ErrorResponse handleNotFound(DomainException ex, HttpServletRequest request) {
     return new ErrorResponse(
@@ -38,9 +52,28 @@ public class TaskExceptionHandler {
         request.getRequestURI());
   }
 
+  /** タスク参照拒否(可視性フィルタ不通過): 404 + 監査ログ {@code VIEW_DENIED}(§6.2.3)。 */
+  @ExceptionHandler(TaskNotViewableException.class)
+  @ResponseStatus(HttpStatus.NOT_FOUND)
+  public ErrorResponse handleNotViewable(TaskNotViewableException ex, HttpServletRequest request) {
+    recordDenied(AuditEventType.VIEW_DENIED, ex.getTaskId());
+    return new ErrorResponse(
+        OffsetDateTime.now(AppZones.JST),
+        HttpStatus.NOT_FOUND.value(),
+        HttpStatus.NOT_FOUND.getReasonPhrase(),
+        ErrorCode.E_NOT_FOUND,
+        Objects.requireNonNullElse(ex.getMessage(), "リソースが見つかりません"),
+        request.getRequestURI());
+  }
+
+  /** タスク操作権限違反: 403 +(該当時)監査ログ {@code *_DENIED}(§6.2.3)。 */
   @ExceptionHandler(TaskOwnershipException.class)
   @ResponseStatus(HttpStatus.FORBIDDEN)
-  public ErrorResponse handleForbidden(DomainException ex, HttpServletRequest request) {
+  public ErrorResponse handleForbidden(TaskOwnershipException ex, HttpServletRequest request) {
+    AuditEventType deniedAction = ex.getDeniedAction();
+    if (deniedAction != null) {
+      recordDenied(deniedAction, ex.getTaskId());
+    }
     return new ErrorResponse(
         OffsetDateTime.now(AppZones.JST),
         HttpStatus.FORBIDDEN.value(),
@@ -99,5 +132,23 @@ public class TaskExceptionHandler {
         ErrorCode.E_VALIDATION,
         Objects.requireNonNullElse(ex.getMessage(), "If-Match ヘッダの形式が不正です"),
         request.getRequestURI());
+  }
+
+  /** 認可違反を {@code audit_logs} に記録する。記録失敗で本来の認可応答(403/404)を 500 に化けさせないよう、 例外は握りつぶしてログ出力に留める。 */
+  private void recordDenied(AuditEventType action, Long taskId) {
+    try {
+      authorizationDeniedAuditService.record(
+          action, TenantContext.get(), currentUserId(), Map.of("taskId", taskId));
+    } catch (RuntimeException e) {
+      log.warn("認可違反の監査記録に失敗しました: action={}", action, e);
+    }
+  }
+
+  private static @Nullable Long currentUserId() {
+    Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+    if (auth instanceof TasksAuthenticationToken token) {
+      return token.getPrincipal().getId();
+    }
+    return null;
   }
 }

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/domain/TaskNotViewableException.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/domain/TaskNotViewableException.java
@@ -2,8 +2,17 @@ package xyz.dgz48.tasks.webapi.task.domain;
 
 import xyz.dgz48.tasks.webapi.shared.exception.DomainException;
 
+/** タスク参照拒否(可視性フィルタ不通過)。404 + 監査ログ {@code VIEW_DENIED}(基本設計書 §6.2.3)。 */
 public class TaskNotViewableException extends DomainException {
+
+  private final Long taskId;
+
   public TaskNotViewableException(Long taskId) {
     super("タスクを参照できません: " + taskId);
+    this.taskId = taskId;
+  }
+
+  public Long getTaskId() {
+    return taskId;
   }
 }

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/domain/TaskOwnershipException.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/domain/TaskOwnershipException.java
@@ -1,9 +1,42 @@
 package xyz.dgz48.tasks.webapi.task.domain;
 
+import org.jspecify.annotations.Nullable;
+import xyz.dgz48.tasks.webapi.audit.domain.AuditEventType;
 import xyz.dgz48.tasks.webapi.shared.exception.DomainException;
 
+/**
+ * タスク操作権限違反。403 + 監査ログ(基本設計書 §6.2.3)。
+ *
+ * <p>{@code deniedAction} が指定された場合のみ §6.2.3 の {@code *_DENIED} として記録される。クロステナント 関係者登録の拒否など、§6.2.3
+ * の認可違反シナリオに該当しない権限違反では {@code null} を渡す。
+ */
 public class TaskOwnershipException extends DomainException {
+
+  private final Long taskId;
+  private final @Nullable AuditEventType deniedAction;
+
+  /** 監査記録対象外の操作権限違反(例: クロステナント関係者登録の拒否)。 */
   public TaskOwnershipException(Long taskId) {
+    this(taskId, null);
+  }
+
+  /**
+   * 操作権限違反。
+   *
+   * @param taskId 対象タスク ID
+   * @param deniedAction §6.2.3 の {@code *_DENIED} アクション。記録不要なら {@code null}
+   */
+  public TaskOwnershipException(Long taskId, @Nullable AuditEventType deniedAction) {
     super("タスクの操作権限がありません: " + taskId);
+    this.taskId = taskId;
+    this.deniedAction = deniedAction;
+  }
+
+  public Long getTaskId() {
+    return taskId;
+  }
+
+  public @Nullable AuditEventType getDeniedAction() {
+    return deniedAction;
   }
 }

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/usecase/AddStakeholderUseCase.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/usecase/AddStakeholderUseCase.java
@@ -41,7 +41,7 @@ public class AddStakeholderUseCase {
       throw new TaskNotViewableException(taskId);
     }
     if (!taskAuthorizationDomainService.canManageStakeholdersBy(task, operatorUserId)) {
-      throw new TaskOwnershipException(taskId);
+      throw new TaskOwnershipException(taskId, AuditEventType.STAKEHOLDER_EDIT_DENIED);
     }
     // クロステナント登録を拒否(同一テナントの ACTIVE メンバーのみ登録可)
     if (tenantMembershipPort.findActiveRole(targetUserId, task.getTenantId()).isEmpty()) {

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/usecase/ChangeTaskStatusUseCase.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/usecase/ChangeTaskStatusUseCase.java
@@ -8,6 +8,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import xyz.dgz48.tasks.webapi.audit.domain.AuditEventType;
 import xyz.dgz48.tasks.webapi.task.domain.Task;
 import xyz.dgz48.tasks.webapi.task.domain.TaskAuthorizationDomainService;
 import xyz.dgz48.tasks.webapi.task.domain.TaskNotFoundException;
@@ -36,7 +37,7 @@ public class ChangeTaskStatusUseCase {
       throw new TaskNotViewableException(taskId);
     }
     if (!taskAuthorizationDomainService.canChangeStatusBy(task, userId)) {
-      throw new TaskOwnershipException(taskId);
+      throw new TaskOwnershipException(taskId, AuditEventType.STATUS_CHANGE_DENIED);
     }
     LocalDateTime now = LocalDateTime.now(clock);
     task.changeStatus(newStatus, now);

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/usecase/ChangeVisibilityUseCase.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/usecase/ChangeVisibilityUseCase.java
@@ -49,7 +49,7 @@ public class ChangeVisibilityUseCase {
       throw new TaskNotViewableException(taskId);
     }
     if (!taskAuthorizationDomainService.canChangeVisibilityBy(task, userId)) {
-      throw new TaskOwnershipException(taskId);
+      throw new TaskOwnershipException(taskId, AuditEventType.VISIBILITY_CHANGE_DENIED);
     }
     if (!task.getVersion().equals(ifMatchVersion)) {
       throw new PreconditionFailedException("バージョンが競合しています: task=" + taskId);

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/usecase/DeleteTaskUseCase.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/usecase/DeleteTaskUseCase.java
@@ -40,7 +40,7 @@ public class DeleteTaskUseCase {
       throw new TaskNotViewableException(taskId);
     }
     if (!taskAuthorizationDomainService.canBeDeletedBy(task, userId)) {
-      throw new TaskOwnershipException(taskId);
+      throw new TaskOwnershipException(taskId, AuditEventType.DELETE_DENIED);
     }
     if (!task.getVersion().equals(ifMatchVersion)) {
       throw new PreconditionFailedException("バージョンが競合しています: task=" + taskId);

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/usecase/RemoveStakeholderUseCase.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/usecase/RemoveStakeholderUseCase.java
@@ -35,7 +35,7 @@ public class RemoveStakeholderUseCase {
       throw new TaskNotViewableException(taskId);
     }
     if (!taskAuthorizationDomainService.canManageStakeholdersBy(task, operatorUserId)) {
-      throw new TaskOwnershipException(taskId);
+      throw new TaskOwnershipException(taskId, AuditEventType.STAKEHOLDER_EDIT_DENIED);
     }
     if (!stakeholderRepository.existsByTaskIdAndUserId(taskId, targetUserId)) {
       throw new StakeholderNotFoundException(taskId, targetUserId);

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/usecase/UpdateTaskUseCase.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/usecase/UpdateTaskUseCase.java
@@ -42,7 +42,7 @@ public class UpdateTaskUseCase {
       throw new TaskNotViewableException(taskId);
     }
     if (!taskAuthorizationDomainService.canBeEditedBy(task, userId)) {
-      throw new TaskOwnershipException(taskId);
+      throw new TaskOwnershipException(taskId, AuditEventType.EDIT_DENIED);
     }
     if (!task.getVersion().equals(ifMatchVersion)) {
       throw new PreconditionFailedException("バージョンが競合しています: task=" + taskId);

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/audit/AuthorizationDeniedAuditIT.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/audit/AuthorizationDeniedAuditIT.java
@@ -1,0 +1,335 @@
+package xyz.dgz48.tasks.webapi.audit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import jakarta.persistence.EntityManager;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.support.TransactionTemplate;
+import xyz.dgz48.tasks.webapi.FixedClockConfiguration;
+import xyz.dgz48.tasks.webapi.MockJwtDecoderConfiguration;
+import xyz.dgz48.tasks.webapi.TestcontainersConfiguration;
+import xyz.dgz48.tasks.webapi.security.adapter.web.TasksAuthenticationToken;
+import xyz.dgz48.tasks.webapi.security.domain.TasksPrincipal;
+import xyz.dgz48.tasks.webapi.shared.domain.TenantContext;
+import xyz.dgz48.tasks.webapi.task.adapter.persistence.TaskJpaEntity;
+import xyz.dgz48.tasks.webapi.task.domain.Priority;
+import xyz.dgz48.tasks.webapi.task.domain.TaskStatus;
+import xyz.dgz48.tasks.webapi.task.domain.Visibility;
+import xyz.dgz48.tasks.webapi.tenant.adapter.persistence.TenantJpaEntity;
+import xyz.dgz48.tasks.webapi.user.adapter.persistence.UserJpaEntity;
+
+/**
+ * 認可違反({@code *_DENIED})の {@code audit_logs} 記録配線を検証する統合 IT(基本設計書 §6.2.3 / #736)。
+ *
+ * <p>§6.2.3 の 8 シナリオのうち {@code TENANT_CROSSED} は {@link CrossTenantViolationDetectionIT} で検証済み。 本
+ * IT は残り 7 アクション(VIEW / EDIT / DELETE / STATUS_CHANGE / VISIBILITY_CHANGE / STAKEHOLDER_EDIT /
+ * ROLE_BASED)の記録漏れを防ぐ。
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@Import({
+  TestcontainersConfiguration.class,
+  MockJwtDecoderConfiguration.class,
+  FixedClockConfiguration.class
+})
+class AuthorizationDeniedAuditIT {
+
+  @Autowired MockMvc mockMvc;
+  @Autowired EntityManager em;
+  @Autowired TransactionTemplate txTemplate;
+
+  private Long ownerId;
+  private Long memberUserId;
+  private Long tenantId;
+  private Long tenantTaskId;
+  private Long privateTaskId;
+
+  /** 所有者でも担当者でも関係者でもない、テナント内の一般 Member(認可違反の主体)。 */
+  private TasksAuthenticationToken memberToken;
+
+  @BeforeEach
+  void setUp() {
+    txTemplate.execute(
+        ignored -> {
+          var owner =
+              new UserJpaEntity(
+                  "sub-ad-owner", "ad-owner@example.com", "所有者 太郎", "ショユウシャ タロウ", null);
+          var member =
+              new UserJpaEntity(
+                  "sub-ad-member", "ad-member@example.com", "メンバー 太郎", "メンバー タロウ", null);
+          em.persist(owner);
+          em.persist(member);
+          em.flush();
+          ownerId = owner.getId();
+          memberUserId = member.getId();
+
+          // JPA Auditing(created_by / updated_by)に必要な SecurityContext
+          var ownerPrincipal =
+              new TasksPrincipal(
+                  ownerId, "sub-ad-owner", "ad-owner@example.com", "所有者 太郎", "ショユウシャ タロウ", null);
+          SecurityContextHolder.getContext()
+              .setAuthentication(new TasksAuthenticationToken(ownerPrincipal, List.of()));
+
+          var tenant = new TenantJpaEntity("AD-TENANT", "認可違反テナント");
+          em.persist(tenant);
+          em.flush();
+          tenantId = tenant.getId();
+
+          insertUserTenant(ownerId, tenantId, "MEMBER");
+          insertUserTenant(memberUserId, tenantId, "MEMBER");
+
+          var tenantTask =
+              new TaskJpaEntity(
+                  tenantId,
+                  ownerId,
+                  "TENANT task",
+                  null,
+                  TaskStatus.NOT_STARTED,
+                  Priority.MEDIUM,
+                  LocalDate.of(2026, 12, 31));
+          var privateTask =
+              new TaskJpaEntity(
+                  tenantId,
+                  ownerId,
+                  "PRIVATE task",
+                  null,
+                  TaskStatus.NOT_STARTED,
+                  Priority.MEDIUM,
+                  Visibility.PRIVATE,
+                  null,
+                  LocalDate.of(2026, 12, 31));
+          em.persist(tenantTask);
+          em.persist(privateTask);
+          em.flush();
+          tenantTaskId = tenantTask.getId();
+          privateTaskId = privateTask.getId();
+
+          return null;
+        });
+
+    SecurityContextHolder.clearContext();
+    deleteAllAuditLogs();
+
+    var memberPrincipal =
+        new TasksPrincipal(
+            memberUserId, "sub-ad-member", "ad-member@example.com", "メンバー 太郎", "メンバー タロウ", null);
+    memberToken = new TasksAuthenticationToken(memberPrincipal, List.of());
+  }
+
+  @AfterEach
+  void tearDown() {
+    SecurityContextHolder.clearContext();
+    if (tenantId == null) return;
+    TenantContext.set(tenantId);
+    try {
+      txTemplate.execute(
+          ignored -> {
+            em.createNativeQuery("DELETE FROM audit_logs").executeUpdate();
+            em.createNativeQuery("DELETE FROM tasks WHERE tenant_id = ?")
+                .setParameter(1, tenantId)
+                .executeUpdate();
+            em.createNativeQuery("DELETE FROM user_tenants WHERE tenant_id = ?")
+                .setParameter(1, tenantId)
+                .executeUpdate();
+            em.createNativeQuery("DELETE FROM tenants WHERE id = ?")
+                .setParameter(1, tenantId)
+                .executeUpdate();
+            em.createNativeQuery("DELETE FROM users WHERE id IN (?,?)")
+                .setParameter(1, ownerId)
+                .setParameter(2, memberUserId)
+                .executeUpdate();
+            return null;
+          });
+    } finally {
+      TenantContext.clear();
+    }
+  }
+
+  @Test
+  void getTask_byNonViewer_recordsViewDenied() throws Exception {
+    mockMvc
+        .perform(
+            get("/api/tasks/" + privateTaskId)
+                .header("X-Tenant-Id", String.valueOf(tenantId))
+                .with(authentication(memberToken)))
+        .andExpect(status().isNotFound());
+
+    assertDeniedRecorded("VIEW_DENIED", privateTaskId);
+  }
+
+  @Test
+  void patchTask_byNonOwner_recordsEditDenied() throws Exception {
+    mockMvc
+        .perform(
+            patch("/api/tasks/" + tenantTaskId)
+                .header("X-Tenant-Id", String.valueOf(tenantId))
+                .header(HttpHeaders.IF_MATCH, "W/\"0\"")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"title\":\"New title\"}")
+                .with(authentication(memberToken)))
+        .andExpect(status().isForbidden());
+
+    assertDeniedRecorded("EDIT_DENIED", tenantTaskId);
+  }
+
+  @Test
+  void deleteTask_byNonOwner_recordsDeleteDenied() throws Exception {
+    mockMvc
+        .perform(
+            delete("/api/tasks/" + tenantTaskId)
+                .header("X-Tenant-Id", String.valueOf(tenantId))
+                .header(HttpHeaders.IF_MATCH, "W/\"0\"")
+                .with(authentication(memberToken)))
+        .andExpect(status().isForbidden());
+
+    assertDeniedRecorded("DELETE_DENIED", tenantTaskId);
+  }
+
+  @Test
+  void changeStatus_byNonOwnerNonAssignee_recordsStatusChangeDenied() throws Exception {
+    mockMvc
+        .perform(
+            patch("/api/tasks/" + tenantTaskId + "/status")
+                .header("X-Tenant-Id", String.valueOf(tenantId))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"status\":\"IN_PROGRESS\"}")
+                .with(authentication(memberToken)))
+        .andExpect(status().isForbidden());
+
+    assertDeniedRecorded("STATUS_CHANGE_DENIED", tenantTaskId);
+  }
+
+  @Test
+  void changeVisibility_byNonOwner_recordsVisibilityChangeDenied() throws Exception {
+    mockMvc
+        .perform(
+            patch("/api/tasks/" + tenantTaskId + "/visibility")
+                .header("X-Tenant-Id", String.valueOf(tenantId))
+                .header(HttpHeaders.IF_MATCH, "W/\"0\"")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"visibility\":\"PRIVATE\"}")
+                .with(authentication(memberToken)))
+        .andExpect(status().isForbidden());
+
+    assertDeniedRecorded("VISIBILITY_CHANGE_DENIED", tenantTaskId);
+  }
+
+  @Test
+  void addStakeholder_byNonOwnerNonAssignee_recordsStakeholderEditDenied() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/tasks/" + tenantTaskId + "/stakeholders")
+                .header("X-Tenant-Id", String.valueOf(tenantId))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"userId\":" + memberUserId + "}")
+                .with(authentication(memberToken)))
+        .andExpect(status().isForbidden());
+
+    assertDeniedRecorded("STAKEHOLDER_EDIT_DENIED", tenantTaskId);
+  }
+
+  @Test
+  void adminApi_byNonAdmin_recordsRoleBasedDenied() throws Exception {
+    // /api/tenants は SaaS Admin 専用(@PreAuthorize hasRole('APP_ADMIN'))。テナント免除パスのため
+    // X-Tenant-Id は付与しない。一般 Member には APP_ADMIN ロールが無く AccessDeniedException となる。
+    mockMvc
+        .perform(get("/api/tenants").with(authentication(memberToken)))
+        .andExpect(status().isForbidden());
+
+    txTemplate.execute(
+        ignored -> {
+          List<?> rows =
+              em.createNativeQuery(
+                      "SELECT detail FROM audit_logs WHERE action = 'ROLE_BASED_DENIED'")
+                  .getResultList();
+          assertThat(rows).as("ROLE_BASED_DENIED が記録される").hasSize(1);
+          assertThat((String) rows.get(0)).contains("/api/tenants");
+          return null;
+        });
+  }
+
+  @Test
+  void deniedRecords_maintainHashChain() throws Exception {
+    mockMvc
+        .perform(
+            patch("/api/tasks/" + tenantTaskId)
+                .header("X-Tenant-Id", String.valueOf(tenantId))
+                .header(HttpHeaders.IF_MATCH, "W/\"0\"")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"title\":\"New title\"}")
+                .with(authentication(memberToken)))
+        .andExpect(status().isForbidden());
+    mockMvc
+        .perform(
+            delete("/api/tasks/" + tenantTaskId)
+                .header("X-Tenant-Id", String.valueOf(tenantId))
+                .header(HttpHeaders.IF_MATCH, "W/\"0\"")
+                .with(authentication(memberToken)))
+        .andExpect(status().isForbidden());
+
+    txTemplate.execute(
+        ignored -> {
+          @SuppressWarnings("unchecked")
+          List<String> hashes =
+              em.createNativeQuery("SELECT hash_chain FROM audit_logs ORDER BY id").getResultList();
+          assertThat(hashes).hasSize(2);
+          assertThat(hashes.get(0)).isEqualTo("0".repeat(64));
+          assertThat(hashes.get(1)).isNotEqualTo("0".repeat(64)).matches("[0-9a-f]{64}");
+          return null;
+        });
+  }
+
+  private void assertDeniedRecorded(String action, Long taskId) {
+    txTemplate.execute(
+        ignored -> {
+          List<?> rows =
+              em.createNativeQuery(
+                      "SELECT detail FROM audit_logs WHERE tenant_id = ? AND action = ?")
+                  .setParameter(1, tenantId)
+                  .setParameter(2, action)
+                  .getResultList();
+          assertThat(rows).as("%s が記録される", action).hasSize(1);
+          assertThat(((String) rows.get(0)).replace(" ", "")).contains("\"taskId\":" + taskId);
+          return null;
+        });
+  }
+
+  private void deleteAllAuditLogs() {
+    txTemplate.execute(
+        ignored -> {
+          em.createNativeQuery("DELETE FROM audit_logs").executeUpdate();
+          return null;
+        });
+  }
+
+  private void insertUserTenant(Long userId, Long tid, String role) {
+    em.createNativeQuery(
+            "INSERT INTO user_tenants (user_id, tenant_id, role, status, joined_at)"
+                + " VALUES (?,?,?,?,?)")
+        .setParameter(1, userId)
+        .setParameter(2, tid)
+        .setParameter(3, role)
+        .setParameter(4, "ACTIVE")
+        .setParameter(5, LocalDateTime.of(2026, 1, 1, 0, 0))
+        .executeUpdate();
+  }
+}

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/LogoutControllerTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/LogoutControllerTest.java
@@ -14,6 +14,7 @@ import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import xyz.dgz48.tasks.webapi.audit.usecase.AuditLogPort;
+import xyz.dgz48.tasks.webapi.audit.usecase.AuthorizationDeniedAuditService;
 import xyz.dgz48.tasks.webapi.security.adapter.persistence.AppAdminUserRepository;
 import xyz.dgz48.tasks.webapi.security.usecase.LogoutUseCase;
 import xyz.dgz48.tasks.webapi.tenant.usecase.TenantMembershipPort;
@@ -39,6 +40,7 @@ class LogoutControllerTest {
 
   @MockitoBean JwtDecoder jwtDecoder;
   @MockitoBean AuditLogPort auditLogPort;
+  @MockitoBean AuthorizationDeniedAuditService authorizationDeniedAuditService;
   @MockitoBean UserRepository userRepository;
   @MockitoBean AppAdminUserRepository appAdminUserRepository;
   @MockitoBean TenantMembershipPort tenantMembershipPort;

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/MeControllerWebMvcTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/MeControllerWebMvcTest.java
@@ -14,6 +14,7 @@ import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import xyz.dgz48.tasks.webapi.audit.usecase.AuditLogPort;
+import xyz.dgz48.tasks.webapi.audit.usecase.AuthorizationDeniedAuditService;
 import xyz.dgz48.tasks.webapi.security.adapter.persistence.AppAdminUserRepository;
 import xyz.dgz48.tasks.webapi.security.usecase.GetMeUseCase;
 import xyz.dgz48.tasks.webapi.tenant.domain.TenantRole;
@@ -33,6 +34,7 @@ class MeControllerWebMvcTest {
 
   @MockitoBean JwtDecoder jwtDecoder;
   @MockitoBean AuditLogPort auditLogPort;
+  @MockitoBean AuthorizationDeniedAuditService authorizationDeniedAuditService;
   @MockitoBean UserRepository userRepository;
   @MockitoBean AppAdminUserRepository appAdminUserRepository;
   @MockitoBean TenantMembershipPort tenantMembershipPort;

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/SecurityConfigTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/SecurityConfigTest.java
@@ -33,6 +33,7 @@ import org.springframework.security.oauth2.jwt.JwtValidationException;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import xyz.dgz48.tasks.webapi.audit.usecase.AuditLogPort;
+import xyz.dgz48.tasks.webapi.audit.usecase.AuthorizationDeniedAuditService;
 import xyz.dgz48.tasks.webapi.security.adapter.persistence.AppAdminUserRepository;
 import xyz.dgz48.tasks.webapi.security.usecase.GetMeUseCase;
 import xyz.dgz48.tasks.webapi.security.usecase.LogoutUseCase;
@@ -74,6 +75,7 @@ class SecurityConfigTest {
 
   @MockitoBean JwtDecoder jwtDecoder;
   @MockitoBean AuditLogPort auditLogPort;
+  @MockitoBean AuthorizationDeniedAuditService authorizationDeniedAuditService;
   @MockitoBean UserRepository userRepository;
   @MockitoBean AppAdminUserRepository appAdminUserRepository;
   @MockitoBean LogoutUseCase logoutUseCase;

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/TenantContextFilterTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/TenantContextFilterTest.java
@@ -22,6 +22,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 import xyz.dgz48.tasks.webapi.audit.usecase.AuditLogPort;
+import xyz.dgz48.tasks.webapi.audit.usecase.AuthorizationDeniedAuditService;
 import xyz.dgz48.tasks.webapi.security.adapter.persistence.AppAdminUserRepository;
 import xyz.dgz48.tasks.webapi.security.usecase.GetMeUseCase;
 import xyz.dgz48.tasks.webapi.security.usecase.LogoutUseCase;
@@ -90,6 +91,7 @@ class TenantContextFilterTest {
 
   @MockitoBean JwtDecoder jwtDecoder;
   @MockitoBean AuditLogPort auditLogPort;
+  @MockitoBean AuthorizationDeniedAuditService authorizationDeniedAuditService;
   @MockitoBean UserRepository userRepository;
   @MockitoBean AppAdminUserRepository appAdminUserRepository;
   @MockitoBean LogoutUseCase logoutUseCase;

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/adapter/web/TaskControllerWebMvcTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/adapter/web/TaskControllerWebMvcTest.java
@@ -26,6 +26,7 @@ import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import xyz.dgz48.tasks.webapi.audit.usecase.AuditLogPort;
+import xyz.dgz48.tasks.webapi.audit.usecase.AuthorizationDeniedAuditService;
 import xyz.dgz48.tasks.webapi.security.adapter.persistence.AppAdminUserRepository;
 import xyz.dgz48.tasks.webapi.security.adapter.web.SecurityConfig;
 import xyz.dgz48.tasks.webapi.security.adapter.web.TasksAccessDeniedHandler;
@@ -70,6 +71,7 @@ class TaskControllerWebMvcTest {
 
   @MockitoBean JwtDecoder jwtDecoder;
   @MockitoBean AuditLogPort auditLogPort;
+  @MockitoBean AuthorizationDeniedAuditService authorizationDeniedAuditService;
   @MockitoBean UserRepository userRepository;
   @MockitoBean AppAdminUserRepository appAdminUserRepository;
   @MockitoBean TenantMembershipPort tenantMembershipPort;

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/adapter/web/TaskExceptionHandlerTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/adapter/web/TaskExceptionHandlerTest.java
@@ -8,6 +8,7 @@ import org.springframework.core.MethodParameter;
 import org.springframework.http.HttpStatus;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.web.bind.MissingRequestHeaderException;
+import xyz.dgz48.tasks.webapi.audit.usecase.AuthorizationDeniedAuditService;
 import xyz.dgz48.tasks.webapi.shared.web.ErrorCode;
 import xyz.dgz48.tasks.webapi.shared.web.ErrorResponse;
 
@@ -16,7 +17,8 @@ class TaskExceptionHandlerTest {
   @SuppressWarnings("unused")
   private static void placeholder(String s) {}
 
-  private final TaskExceptionHandler handler = new TaskExceptionHandler();
+  private final TaskExceptionHandler handler =
+      new TaskExceptionHandler(new AuthorizationDeniedAuditService((a, b, c, d) -> {}));
 
   @Test
   void handleMissingHeader_returns400WithEValidation() throws NoSuchMethodException {

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/tenant/adapter/web/SelectTenantControllerWebMvcTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/tenant/adapter/web/SelectTenantControllerWebMvcTest.java
@@ -14,6 +14,7 @@ import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import xyz.dgz48.tasks.webapi.audit.usecase.AuditLogPort;
+import xyz.dgz48.tasks.webapi.audit.usecase.AuthorizationDeniedAuditService;
 import xyz.dgz48.tasks.webapi.security.adapter.persistence.AppAdminUserRepository;
 import xyz.dgz48.tasks.webapi.security.adapter.web.SecurityConfig;
 import xyz.dgz48.tasks.webapi.security.adapter.web.TasksAccessDeniedHandler;
@@ -38,6 +39,7 @@ class SelectTenantControllerWebMvcTest {
 
   @MockitoBean JwtDecoder jwtDecoder;
   @MockitoBean AuditLogPort auditLogPort;
+  @MockitoBean AuthorizationDeniedAuditService authorizationDeniedAuditService;
   @MockitoBean UserRepository userRepository;
   @MockitoBean AppAdminUserRepository appAdminUserRepository;
   @MockitoBean TenantMembershipPort tenantMembershipPort;

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/tenant/adapter/web/TenantMemberControllerWebMvcTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/tenant/adapter/web/TenantMemberControllerWebMvcTest.java
@@ -19,6 +19,7 @@ import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import xyz.dgz48.tasks.webapi.audit.usecase.AuditLogPort;
+import xyz.dgz48.tasks.webapi.audit.usecase.AuthorizationDeniedAuditService;
 import xyz.dgz48.tasks.webapi.security.adapter.persistence.AppAdminUserRepository;
 import xyz.dgz48.tasks.webapi.security.adapter.web.SecurityConfig;
 import xyz.dgz48.tasks.webapi.security.adapter.web.TasksAccessDeniedHandler;
@@ -50,6 +51,7 @@ class TenantMemberControllerWebMvcTest {
 
   @MockitoBean JwtDecoder jwtDecoder;
   @MockitoBean AuditLogPort auditLogPort;
+  @MockitoBean AuthorizationDeniedAuditService authorizationDeniedAuditService;
   @MockitoBean UserRepository userRepository;
   @MockitoBean AppAdminUserRepository appAdminUserRepository;
   @MockitoBean TenantMembershipPort tenantMembershipPort;

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/tenant/adapter/web/TenantUserControllerWebMvcTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/tenant/adapter/web/TenantUserControllerWebMvcTest.java
@@ -18,6 +18,7 @@ import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import xyz.dgz48.tasks.webapi.audit.usecase.AuditLogPort;
+import xyz.dgz48.tasks.webapi.audit.usecase.AuthorizationDeniedAuditService;
 import xyz.dgz48.tasks.webapi.security.adapter.persistence.AppAdminUserRepository;
 import xyz.dgz48.tasks.webapi.security.adapter.web.SecurityConfig;
 import xyz.dgz48.tasks.webapi.security.adapter.web.TasksAccessDeniedHandler;
@@ -45,6 +46,7 @@ class TenantUserControllerWebMvcTest {
 
   @MockitoBean JwtDecoder jwtDecoder;
   @MockitoBean AuditLogPort auditLogPort;
+  @MockitoBean AuthorizationDeniedAuditService authorizationDeniedAuditService;
   @MockitoBean UserRepository userRepository;
   @MockitoBean AppAdminUserRepository appAdminUserRepository;
   @MockitoBean TenantMembershipPort tenantMembershipPort;


### PR DESCRIPTION
## 概要
基本設計書 §6.2.3(認可違反シナリオ → HTTP → action マッピング)に従い、`*_DENIED` の `audit_logs` 記録を webapi 側に配線します。語彙追加は #734、本 PR はその値を使った**記録の配線**(blocked_by #734 解消)。Closes #736。

## 設計
記録はレスポンス境界(例外ハンドラ / 認可層)に集約し、「どの操作が拒否されたか」は throw 元(usecase)を SSOT とします。

- **`AuthorizationDeniedAuditService`(新規)** — `AuditLogPort` を `REQUIRES_NEW` で呼ぶ。違反でリクエスト tx がロールバックされても記録を独立コミットで保持(既存 `CrossTenantViolationAuditService` と同方針)。
- **`TaskOwnershipException`** が denied `AuditEventType` を保持(nullable)。各 usecase の throw 元で操作別 action を指定:
  - `UpdateTaskUseCase` → `EDIT_DENIED`
  - `DeleteTaskUseCase` → `DELETE_DENIED`
  - `ChangeTaskStatusUseCase` → `STATUS_CHANGE_DENIED`
  - `ChangeVisibilityUseCase` → `VISIBILITY_CHANGE_DENIED`
  - `AddStakeholderUseCase` / `RemoveStakeholderUseCase` → `STAKEHOLDER_EDIT_DENIED`
  - §6.2.3 非該当のクロステナント関係者拒否(Create / AddStakeholder の target 検証)は `null` = 記録対象外
- **`TaskNotViewableException`** → 常に `VIEW_DENIED`(404)。`TaskExceptionHandler` で記録。
- **`TasksAccessDeniedHandler`** → `@PreAuthorize` 拒否を `ROLE_BASED_DENIED`(403)で記録。
- `detail` に文脈(`taskId` / role 拒否は `method`+`path`)を格納。記録失敗はログ出力に留め、本来の 403/404 を 500 に化けさせない。
- `TENANT_CROSSED` は既存 `CrossTenantViolationAuditService` の記録に追従(変更なし)。

## §6.2.3 マッピング対応
| シナリオ | HTTP | action | 記録箇所 |
|---|---|---|---|
| 参照拒否 | 404 | `VIEW_DENIED` | TaskExceptionHandler |
| 編集拒否 | 403 | `EDIT_DENIED` | UpdateTaskUseCase → handler |
| 削除拒否 | 403 | `DELETE_DENIED` | DeleteTaskUseCase → handler |
| ステータス変更拒否 | 403 | `STATUS_CHANGE_DENIED` | ChangeTaskStatusUseCase → handler |
| 公開範囲変更拒否 | 403 | `VISIBILITY_CHANGE_DENIED` | ChangeVisibilityUseCase → handler |
| 関係者編集拒否 | 403 | `STAKEHOLDER_EDIT_DENIED` | Add/RemoveStakeholderUseCase → handler |
| テナント越境 | 403 | `TENANT_CROSSED` | 既存(追従のみ) |
| ロール権限不足 | 403 | `ROLE_BASED_DENIED` | TasksAccessDeniedHandler |

## テスト
- 新規 **`AuthorizationDeniedAuditIT`**(Testcontainers MySQL, MockMvc)で 7 アクション + hash chain 整合を検証。MockMvc 経由で実フィルタチェーン(TenantContextFilter → method security → AccessDeniedHandler / @RestControllerAdvice → usecase → 実 MySQL)を通過。
- 新依存に伴い `@WebMvcTest` スライス 8 件 + `TaskExceptionHandlerTest` を更新(`@MockitoBean AuthorizationDeniedAuditService`)。
- E2E(Playwright)は未実施。本変更は audit_logs 行追加のみで既存エンドポイントの HTTP ステータス・レスポンスボディを変えないため、E2E は新規カバレッジを与えないと判断。

## 受け入れ条件
- [x] §6.2.3 の 8 action が該当シナリオで記録される
- [x] hash chain 整合が壊れない
- [x] 各シナリオの記録テストが green
- [x] NullAway / Spotless / JaCoCo 80% ゲート通過(`./gradlew :webapi:check` 成功)

関連: 基本設計書 §6.2.3 / #185 / #734

🤖 Generated with [Claude Code](https://claude.com/claude-code)