### PR TITLE
test(security): クロステナント越境遮断の先行結合テスト(R-05 / ADR-0010)

### DIFF
--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/adapter/persistence/TenantFilterFailClosedIT.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/adapter/persistence/TenantFilterFailClosedIT.java
@@ -1,0 +1,207 @@
+package xyz.dgz48.tasks.webapi.task.adapter.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.persistence.EntityManager;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.hibernate.Session;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.transaction.annotation.Transactional;
+import xyz.dgz48.tasks.webapi.MockJwtDecoderConfiguration;
+import xyz.dgz48.tasks.webapi.TestcontainersConfiguration;
+import xyz.dgz48.tasks.webapi.security.adapter.web.TasksAuthenticationToken;
+import xyz.dgz48.tasks.webapi.security.domain.TasksPrincipal;
+import xyz.dgz48.tasks.webapi.shared.domain.TenantContext;
+import xyz.dgz48.tasks.webapi.task.domain.Priority;
+import xyz.dgz48.tasks.webapi.task.domain.TaskStatus;
+import xyz.dgz48.tasks.webapi.tenant.adapter.persistence.TenantJpaEntity;
+import xyz.dgz48.tasks.webapi.user.adapter.persistence.UserJpaEntity;
+
+/**
+ * Hibernate Filter "tenantFilter" + TenantContext によるクロステナント越境遮断を、機能実装に先行して結合テストで担保する IT(R-05 /
+ * ADR-0010)。
+ *
+ * <p>越境アクセスが SELECT 系の各経路で fail-closed(別テナント行が一切返らない)になることを Testcontainers MySQL 8.4 で検証する。検証対象の経路:
+ *
+ * <ul>
+ *   <li><strong>PK ロード</strong>: {@code TaskJpaRepository#findById}(JPQL override) — Filter
+ *       が乗るため別テナント行は不可視。 素の {@code EntityManager#find}(PK 直ロード)は Filter が乗らないことも併せて文書化する(JPQL
+ *       override が必要な理由)。
+ *   <li><strong>メソッド名導出クエリ</strong>: {@code TaskStakeholderJpaRepository#findByTaskId} /
+ *       JpaRepository 既定の {@code findAll} — 導出クエリ(JPQL)にも Filter が乗るため別テナント行は除外される。
+ *   <li><strong>bulk DML</strong>: {@code @Modifying} DELETE は規約上 {@code tenant_id} を明示絞り込みする
+ *       (ADR-0010 §3)。別テナントの {@code tenant_id} を渡した bulk DML は 0 行で fail-closed。
+ * </ul>
+ *
+ * <p>HTTP 層の越境応答(参照=404 / 更新=403)は {@code TaskCrossTenantIT} および {@code
+ * CrossTenantWriteForbiddenIT} で検証する。本 IT は永続化層の遮断プリミティブに集中する。
+ */
+@SpringBootTest
+@Import({TestcontainersConfiguration.class, MockJwtDecoderConfiguration.class})
+@Transactional
+class TenantFilterFailClosedIT {
+
+  @Autowired EntityManager em;
+  @Autowired TaskJpaRepository taskJpaRepository;
+  @Autowired TaskStakeholderJpaRepository taskStakeholderJpaRepository;
+
+  private Long tenantAId;
+  private Long tenantBId;
+  private Long taskAId;
+  private Long taskBId;
+  private Long stakeholderUserId;
+
+  @BeforeEach
+  void setUp() {
+    // 監査列(created_by 等)の AuditorAware 解決のため SecurityContext を確立する。
+    var auditor =
+        new UserJpaEntity(
+            "sub-fc-auditor", "fc-auditor@example.com", "遮断テスト監査", "シャダンテストカンサ", null);
+    em.persist(auditor);
+
+    var stakeholderUser =
+        new UserJpaEntity("sub-fc-stakeholder", "fc-stake@example.com", "関係者", "カンケイシャ", null);
+    em.persist(stakeholderUser);
+    em.flush();
+    stakeholderUserId = stakeholderUser.getId();
+
+    var principal =
+        new TasksPrincipal(
+            auditor.getId(),
+            "sub-fc-auditor",
+            "fc-auditor@example.com",
+            "遮断テスト監査",
+            "シャダンテストカンサ",
+            null);
+    SecurityContextHolder.getContext()
+        .setAuthentication(new TasksAuthenticationToken(principal, List.of()));
+
+    var tenantA = new TenantJpaEntity("FC-A", "遮断テナントA");
+    var tenantB = new TenantJpaEntity("FC-B", "遮断テナントB");
+    em.persist(tenantA);
+    em.persist(tenantB);
+    em.flush();
+    tenantAId = tenantA.getId();
+    tenantBId = tenantB.getId();
+
+    // 業務テーブルへの INSERT 中に StatementInspector が「TenantContext 未設定での tenant-filtered
+    // テーブルアクセス」を誤検知しないよう、TenantContext を確立してから永続化する(本番と同条件)。
+    TenantContext.set(tenantAId);
+
+    var taskA = newTask(tenantAId, auditor.getId(), "テナントAのタスク");
+    var taskB = newTask(tenantBId, auditor.getId(), "テナントBのタスク");
+    em.persist(taskA);
+    em.persist(taskB);
+    em.flush();
+    taskAId = taskA.getId();
+    taskBId = taskB.getId();
+
+    var now = LocalDateTime.of(2026, 1, 1, 0, 0);
+    em.persist(
+        new TaskStakeholderJpaEntity(taskAId, stakeholderUserId, tenantAId, auditor.getId(), now));
+    em.persist(
+        new TaskStakeholderJpaEntity(taskBId, stakeholderUserId, tenantBId, auditor.getId(), now));
+    em.flush();
+    em.clear();
+  }
+
+  @AfterEach
+  void tearDown() {
+    em.unwrap(Session.class).disableFilter("tenantFilter");
+    TenantContext.clear();
+    SecurityContextHolder.clearContext();
+  }
+
+  private TaskJpaEntity newTask(Long tenantId, Long ownerId, String title) {
+    return new TaskJpaEntity(
+        tenantId,
+        ownerId,
+        title,
+        null,
+        TaskStatus.NOT_STARTED,
+        Priority.MEDIUM,
+        LocalDate.of(2026, 12, 31));
+  }
+
+  private void enableFilterFor(Long tenantId) {
+    em.unwrap(Session.class).enableFilter("tenantFilter").setParameter("tenantId", tenantId);
+  }
+
+  @Nested
+  class PkLoadRoute {
+
+    @Test
+    void findByIdViaJpqlOverride_blocksCrossTenant() {
+      enableFilterFor(tenantAId);
+
+      // 別テナント(B)の PK ロードは空(参照 404 相当の fail-closed)
+      assertThat(taskJpaRepository.findById(taskBId)).isEmpty();
+      // 自テナント(A)の PK ロードは可視
+      assertThat(taskJpaRepository.findById(taskAId)).isPresent();
+    }
+
+    @Test
+    void rawEntityManagerFind_bypassesFilter_documentsWhyOverrideIsNeeded() {
+      enableFilterFor(tenantAId);
+
+      // Hibernate Filter は EntityManager#find(PK 直ロード)には適用されない。
+      // このため TaskJpaRepository#findById は JPQL override で再定義され、Filter を乗せている(ADR-0010)。
+      // 本アサーションはその限界(= JPQL override が fail-closed の前提であること)を文書化する。
+      assertThat(em.find(TaskJpaEntity.class, taskBId)).isNotNull();
+    }
+  }
+
+  @Nested
+  class DerivedQueryRoute {
+
+    @Test
+    void findByTaskId_blocksCrossTenant() {
+      enableFilterFor(tenantAId);
+
+      // 別テナント(B)のタスクに紐づく関係者行は導出クエリでも一切返らない
+      assertThat(taskStakeholderJpaRepository.findByTaskId(taskBId)).isEmpty();
+      // 自テナント(A)の関係者行は取得できる
+      assertThat(taskStakeholderJpaRepository.findByTaskId(taskAId))
+          .singleElement()
+          .satisfies(s -> assertThat(s.getUserId()).isEqualTo(stakeholderUserId));
+    }
+
+    @Test
+    void jpaRepositoryFindAll_excludesCrossTenant() {
+      enableFilterFor(tenantAId);
+
+      // JpaRepository 既定の findAll(JPQL)にも Filter が乗り、別テナント行は除外される
+      assertThat(taskJpaRepository.findAll())
+          .extracting(TaskJpaEntity::getTenantId)
+          .containsOnly(tenantAId);
+    }
+  }
+
+  @Nested
+  class BulkDmlRoute {
+
+    @Test
+    void bulkDelete_withForeignTenantId_affectsZeroRows() {
+      enableFilterFor(tenantAId);
+
+      // 別テナント(B)の tenant_id を渡した bulk DELETE は対象 0 行(明示絞り込みによる fail-closed)
+      int deletedWithForeignTenant =
+          taskStakeholderJpaRepository.deleteAllByTaskIdAndTenantId(taskAId, tenantBId);
+      assertThat(deletedWithForeignTenant).isZero();
+
+      // 正しい tenant_id を渡せば削除される
+      int deletedWithOwnTenant =
+          taskStakeholderJpaRepository.deleteAllByTaskIdAndTenantId(taskAId, tenantAId);
+      assertThat(deletedWithOwnTenant).isEqualTo(1);
+    }
+  }
+}

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/adapter/web/CrossTenantWriteForbiddenIT.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/adapter/web/CrossTenantWriteForbiddenIT.java
@@ -1,0 +1,193 @@
+package xyz.dgz48.tasks.webapi.task.adapter.web;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import jakarta.persistence.EntityManager;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.support.TransactionTemplate;
+import xyz.dgz48.tasks.webapi.FixedClockConfiguration;
+import xyz.dgz48.tasks.webapi.MockJwtDecoderConfiguration;
+import xyz.dgz48.tasks.webapi.TestcontainersConfiguration;
+import xyz.dgz48.tasks.webapi.security.adapter.web.TasksAuthenticationToken;
+import xyz.dgz48.tasks.webapi.security.domain.TasksPrincipal;
+import xyz.dgz48.tasks.webapi.task.adapter.persistence.TaskJpaEntity;
+import xyz.dgz48.tasks.webapi.task.domain.Priority;
+import xyz.dgz48.tasks.webapi.task.domain.TaskStatus;
+import xyz.dgz48.tasks.webapi.tenant.adapter.persistence.TenantJpaEntity;
+import xyz.dgz48.tasks.webapi.user.adapter.persistence.UserJpaEntity;
+
+/**
+ * クロステナント越境「更新」遮断の HTTP 層 IT(R-05 / ADR-0010)。
+ *
+ * <p>越境更新は 2 つの経路で fail-closed になることを Testcontainers MySQL 8.4 で検証する:
+ *
+ * <ul>
+ *   <li><strong>非メンバーテナント指定 → 403</strong>: 所属しないテナントを {@code X-Tenant-Id} に指定した更新要求は、 {@code
+ *       TenantContextFilter} がコンテキスト確立段階で拒否する(設計規約 HTTP ステータス方針「テナント越境 = 403」)。
+ *   <li><strong>自テナントコンテキストで別テナント資源を更新 → 404</strong>: 自テナントのコンテキストでは別テナントのタスクが Hibernate Filter
+ *       により不可視であり、更新ユースケースの read-before-write(Filter 付き {@code findById})が先に {@code
+ *       TaskNotFoundException} を送出する。これにより tenant_id 非絞り込みの bulk DML ({@code
+ *       updateStatusById})が越境行へ到達しないことが担保される(NIST AC-4 — 存在を漏らさない)。
+ * </ul>
+ *
+ * <p>越境「参照」= 404 は {@code TaskCrossTenantIT} で検証済。
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@Import({
+  TestcontainersConfiguration.class,
+  MockJwtDecoderConfiguration.class,
+  FixedClockConfiguration.class
+})
+class CrossTenantWriteForbiddenIT {
+
+  @Autowired MockMvc mockMvc;
+  @Autowired EntityManager em;
+  @Autowired TransactionTemplate txTemplate;
+
+  private Long userId;
+  private Long tenantAId;
+  private Long tenantBId;
+  private Long taskBId;
+  private TasksAuthenticationToken authToken;
+
+  @BeforeEach
+  void setUp() {
+    txTemplate.execute(
+        ignored -> {
+          var user =
+              new UserJpaEntity("sub-xtw", "xtw@example.com", "越境更新太郎", "エッキョウコウシンタロウ", null);
+          em.persist(user);
+          em.flush();
+          userId = user.getId();
+
+          var principal =
+              new TasksPrincipal(
+                  userId, "sub-xtw", "xtw@example.com", "越境更新太郎", "エッキョウコウシンタロウ", null);
+          SecurityContextHolder.getContext()
+              .setAuthentication(new TasksAuthenticationToken(principal, List.of()));
+
+          var tenantA = new TenantJpaEntity("XTW-A", "越境更新A");
+          var tenantB = new TenantJpaEntity("XTW-B", "越境更新B");
+          em.persist(tenantA);
+          em.persist(tenantB);
+          em.flush();
+          tenantAId = tenantA.getId();
+          tenantBId = tenantB.getId();
+
+          // user は tenantA のメンバーのみ(tenantB には所属しない)
+          em.createNativeQuery(
+                  "INSERT INTO user_tenants"
+                      + " (user_id, tenant_id, role, status, joined_at) VALUES (?,?,?,?,?)")
+              .setParameter(1, userId)
+              .setParameter(2, tenantAId)
+              .setParameter(3, "MEMBER")
+              .setParameter(4, "ACTIVE")
+              .setParameter(5, LocalDateTime.of(2026, 1, 1, 0, 0))
+              .executeUpdate();
+
+          // 更新対象のタスクは tenantB に存在する(user は越境してこれを更新しようとする)
+          var taskB =
+              new TaskJpaEntity(
+                  tenantBId,
+                  userId,
+                  "テナントBのタスク",
+                  null,
+                  TaskStatus.NOT_STARTED,
+                  Priority.MEDIUM,
+                  LocalDate.of(2026, 12, 31));
+          em.persist(taskB);
+          em.flush();
+          taskBId = taskB.getId();
+
+          return null;
+        });
+
+    SecurityContextHolder.clearContext();
+
+    var principal =
+        new TasksPrincipal(userId, "sub-xtw", "xtw@example.com", "越境更新太郎", "エッキョウコウシンタロウ", null);
+    authToken = new TasksAuthenticationToken(principal, List.of());
+  }
+
+  @AfterEach
+  void tearDown() {
+    SecurityContextHolder.clearContext();
+    if (userId == null) {
+      return;
+    }
+    txTemplate.execute(
+        ignored -> {
+          em.createNativeQuery("DELETE FROM tasks WHERE id = ?")
+              .setParameter(1, taskBId)
+              .executeUpdate();
+          em.createNativeQuery("DELETE FROM user_tenants WHERE user_id = ?")
+              .setParameter(1, userId)
+              .executeUpdate();
+          em.createNativeQuery("DELETE FROM tenants WHERE id IN (?,?)")
+              .setParameter(1, tenantAId)
+              .setParameter(2, tenantBId)
+              .executeUpdate();
+          em.createNativeQuery("DELETE FROM users WHERE id = ?")
+              .setParameter(1, userId)
+              .executeUpdate();
+          return null;
+        });
+  }
+
+  @Test
+  void statusChange_nonMemberTenantHeader_returns403() throws Exception {
+    // tenantB は user の非所属テナント → TenantContextFilter がコンテキスト確立段階で 403
+    mockMvc
+        .perform(
+            patch("/api/tasks/" + taskBId + "/status")
+                .header("X-Tenant-Id", String.valueOf(tenantBId))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"status\":\"IN_PROGRESS\"}")
+                .with(authentication(authToken)))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.code").value("E_FORBIDDEN"));
+  }
+
+  @Test
+  void delete_nonMemberTenantHeader_returns403() throws Exception {
+    mockMvc
+        .perform(
+            delete("/api/tasks/" + taskBId)
+                .header("X-Tenant-Id", String.valueOf(tenantBId))
+                .with(authentication(authToken)))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.code").value("E_FORBIDDEN"));
+  }
+
+  @Test
+  void statusChange_ownTenantContext_foreignTask_returns404() throws Exception {
+    // 自テナント(A)コンテキストでは tenantB のタスクは Filter により不可視 →
+    // read-before-write が先に 404(tenant_id 非絞り込みの bulk DML は越境行へ到達しない)
+    mockMvc
+        .perform(
+            patch("/api/tasks/" + taskBId + "/status")
+                .header("X-Tenant-Id", String.valueOf(tenantAId))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"status\":\"IN_PROGRESS\"}")
+                .with(authentication(authToken)))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.code").value("E_NOT_FOUND"));
+  }
+}


### PR DESCRIPTION
## 概要

Hibernate Filter + TenantContext によるテナント越境遮断を、機能実装に先行して結合テストで担保する(R-05 対策 / ADR-0010)。テストのみで本番コードは変更しない。

## やったこと

### `TenantFilterFailClosedIT`(永続化層 / Testcontainers MySQL 8.4)
SELECT 系の各クエリ経路で別テナント行が一切返らない(fail-closed)ことを確認:
- **PK ロード**: `TaskJpaRepository#findById`(JPQL override)で別テナントのタスクが不可視。素の `EntityManager#find`(PK 直ロード)は Filter 非適用であること(= JPQL override が fail-closed の前提)も文書化。
- **メソッド名導出クエリ**: `TaskStakeholderJpaRepository#findByTaskId` / JpaRepository 既定 `findAll` で別テナント行が除外される。
- **bulk DML**: `deleteAllByTaskIdAndTenantId` に別テナントの `tenant_id` を渡すと 0 行(明示絞り込みによる fail-closed、ADR-0010 §3)。

### `CrossTenantWriteForbiddenIT`(HTTP 層 / Testcontainers MySQL 8.4)
越境「更新」の遮断を検証:
- **非メンバーテナント指定 → 403**: 所属しないテナントを `X-Tenant-Id` に指定した PATCH/DELETE は `TenantContextFilter` がコンテキスト確立段階で拒否。
- **自テナントコンテキストで別テナント資源を更新 → 404**: Filter で不可視のため、更新ユースケースの read-before-write が `tenant_id` 非絞り込みの bulk DML(`updateStatusById`)到達前に遮断(NIST AC-4)。

越境「参照」= 404 は既存 `TaskCrossTenantIT` で検証済。

## 受入条件
- [x] 越境が設計どおり遮断 / IT green
- [x] 各経路(PK ロード / bulk DML / メソッド名導出クエリ)で fail-closed を確認
- [x] Testcontainers(H2 不可)
- [x] `./gradlew :webapi:check` green

Closes #670

🤖 Generated with [Claude Code](https://claude.com/claude-code)