### PR TITLE
feat(task): 当日対象タスク表示(基準日パラメータ化した抽出クエリ + 2セクション描画)(#665)

### DIFF
--- a/e2e/tests/tasks.spec.ts
+++ b/e2e/tests/tasks.spec.ts
@@ -17,6 +17,14 @@ test.describe('タスク一覧 + CRUD', () => {
 
   test('タスクを作成・詳細表示・ステータス変更・削除できる', async ({ page }) => {
     const taskTitle = `E2E smoke ${Date.now()}`;
+    // メイン画面は「当日対象タスク」のみ表示する(#665, 基本設計書 §3.3.1)ため、
+    // 作成タスクが「本日」セクションに現れるよう期限を当日 (JST) に設定する。
+    const today = new Intl.DateTimeFormat('en-CA', {
+      timeZone: 'Asia/Tokyo',
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    }).format(new Date());
 
     // ── Create ─────────────────────────────────────────────────────────────
     await page.click('#btn-new-task');
@@ -25,7 +33,7 @@ test.describe('タスク一覧 + CRUD', () => {
     await expect(drawer).toBeVisible({ timeout: 5_000 });
 
     await page.fill('#newTitle', taskTitle);
-    await page.fill('#newDue', '2099-12-31');
+    await page.fill('#newDue', today);
     // 優先度はデフォルト MEDIUM、公開範囲はデフォルト TENANT のまま送信
     await drawer.locator('button[type="submit"]').click();
 

--- a/web/css/app.css
+++ b/web/css/app.css
@@ -238,6 +238,19 @@ table.tasks .empty-row td {
   padding: 40px 14px;
   font-size: 13px;
 }
+table.tasks tr.group-head {
+  cursor: default;
+}
+table.tasks tr.group-head:hover {
+  background: transparent;
+}
+table.tasks tr.group-head td {
+  background: #fafbfc;
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--app-ink);
+  padding: 8px 14px;
+}
 
 /* ---- Badges (design-system.md §6.4) ---- */
 .vis-badge {

--- a/web/js/tasks.js
+++ b/web/js/tasks.js
@@ -4,7 +4,19 @@ let currentSort = 'dueDate,asc';
 let totalPages = 1;
 let totalElements = 0;
 let currentKeyword = ''; // タスク検索キーワード(タイトル・説明部分一致、#669)
+let overdueTotal = 0;
+let currentTargetDate = ''; // 表示対象日 (YYYY-MM-DD, JST)
 const PAGE_SIZE = 50;
+
+// 当日 (JST) を YYYY-MM-DD で返す。
+function todayDateStr() {
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'Asia/Tokyo',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(new Date());
+}
 
 // ---- Task / user state ----
 const taskMap = new Map(); // taskId(number) → Task object
@@ -31,13 +43,62 @@ function buildEtag(task) {
 }
 
 // ---- Render task list from API response ----
+// 当日対象タスクを「期限切れ」「本日(選択日)」の 2 セクションに分けて描画する
+// (基本設計書 §3.3.1)。期限切れ = dueDate < 表示対象日。各セクションは常時表示し、
+// 空の場合は空状態行を表示する。
 /** @param {Task[]} tasks */
 function renderTasks(tasks) {
   /** @type {HTMLElement} */ (mustQuery(document, '#total-count')).textContent =
     `${totalElements} 件`;
   rowMap.clear();
 
-  if (!tasks || tasks.length === 0) {
+  const list = tasks ?? [];
+  const overdue = list.filter((t) => t.dueDate != null && t.dueDate < currentTargetDate);
+  const onTarget = list.filter((t) => !(t.dueDate != null && t.dueDate < currentTargetDate));
+  const todayCount = Math.max(0, totalElements - overdueTotal);
+
+  /** @type {Node[]} */
+  const nodes = [];
+  nodes.push(groupHeadRow('bi-exclamation-triangle-fill text-danger', '期限切れ', overdueTotal));
+  nodes.push(...sectionRows(overdue, '期限切れのタスクはありません'));
+  nodes.push(groupHeadRow('bi-calendar-day text-primary', '本日', todayCount));
+  nodes.push(...sectionRows(onTarget, '本日のタスクはありません'));
+  tbody.replaceChildren(...nodes);
+}
+
+// ---- Section group header row ----
+/**
+ * @param {string} iconClass — Bootstrap Icons クラス (色クラス込み可)
+ * @param {string} label
+ * @param {number} count
+ * @returns {HTMLTableRowElement}
+ */
+function groupHeadRow(iconClass, label, count) {
+  const tr = document.createElement('tr');
+  tr.className = 'group-head';
+  const td = document.createElement('td');
+  td.colSpan = 7;
+  const icon = document.createElement('i');
+  icon.className = `bi ${iconClass} me-2`;
+  icon.setAttribute('aria-hidden', 'true');
+  td.appendChild(icon);
+  td.appendChild(document.createTextNode(label));
+  const cnt = document.createElement('span');
+  cnt.className = 'sec-count ms-2';
+  cnt.textContent = `${count} 件`;
+  td.appendChild(cnt);
+  tr.appendChild(td);
+  return tr;
+}
+
+// ---- Build rows (or an empty-state row) for one section ----
+/**
+ * @param {Task[]} tasks
+ * @param {string} emptyMsg
+ * @returns {Node[]}
+ */
+function sectionRows(tasks, emptyMsg) {
+  if (tasks.length === 0) {
     const tr = document.createElement('tr');
     tr.className = 'empty-row';
     const td = document.createElement('td');
@@ -48,21 +109,18 @@ function renderTasks(tasks) {
     td.appendChild(icon);
     td.appendChild(
       document.createTextNode(
-        currentKeyword ? `「${currentKeyword}」に一致するタスクはありません` : 'タスクはありません',
+        currentKeyword ? `「${currentKeyword}」に一致するタスクはありません` : emptyMsg,
       ),
     );
     tr.appendChild(td);
-    tbody.replaceChildren(tr);
-    return;
+    return [tr];
   }
-
-  const rows = tasks.map((task) => {
+  return tasks.map((task) => {
     const row = /** @type {AppTaskRowElement} */ (document.createElement('app-task-row'));
     row.setTask(task, currentUserId, tenantUsers);
     rowMap.set(task.id, row);
     return row;
   });
-  tbody.replaceChildren(...rows);
 }
 
 // ---- Re-render a single row after a successful PATCH ----
@@ -183,14 +241,18 @@ async function loadTasks() {
   cancelAllEdits();
   showLoading(true);
   try {
+    currentTargetDate = todayDateStr();
     const data = await Api.listTasks({
       page: currentPage,
       size: PAGE_SIZE,
       sort: currentSort,
       keyword: currentKeyword || undefined,
+      targetDate: currentTargetDate,
+      includeOverdue: true,
     });
     totalPages = data.totalPages || 1;
     totalElements = data.totalElements || 0;
+    overdueTotal = data.overdueCount || 0;
     taskMap.clear();
     if (data.content)
       data.content.forEach((t) => {

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/adapter/persistence/TaskJpaRepositoryAdapter.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/adapter/persistence/TaskJpaRepositoryAdapter.java
@@ -98,11 +98,23 @@ class TaskJpaRepositoryAdapter implements TaskRepository {
       @Nullable Long assigneeId,
       @Nullable Visibility visibility,
       @Nullable String keyword,
+      LocalDate targetDate,
+      boolean includeOverdue,
       Pageable pageable) {
 
     CriteriaBuilder cb = em.getCriteriaBuilder();
 
-    long total = executeCountQuery(cb, userId, statuses, ownerId, assigneeId, visibility, keyword);
+    long total =
+        executeCountQuery(
+            cb,
+            userId,
+            statuses,
+            ownerId,
+            assigneeId,
+            visibility,
+            keyword,
+            targetDate,
+            includeOverdue);
     if (total == 0) {
       return Page.empty(pageable);
     }
@@ -111,7 +123,17 @@ class TaskJpaRepositoryAdapter implements TaskRepository {
     Root<TaskJpaEntity> task = dataQuery.from(TaskJpaEntity.class);
     dataQuery.where(
         buildPredicates(
-            cb, dataQuery, task, userId, statuses, ownerId, assigneeId, visibility, keyword));
+            cb,
+            dataQuery,
+            task,
+            userId,
+            statuses,
+            ownerId,
+            assigneeId,
+            visibility,
+            keyword,
+            targetDate,
+            includeOverdue));
     dataQuery.orderBy(buildOrders(cb, task, pageable.getSort()));
 
     List<TaskJpaEntity> result =
@@ -150,7 +172,9 @@ class TaskJpaRepositoryAdapter implements TaskRepository {
       @Nullable Long ownerId,
       @Nullable Long assigneeId,
       @Nullable Visibility visibility,
-      @Nullable String keyword) {
+      @Nullable String keyword,
+      LocalDate targetDate,
+      boolean includeOverdue) {
 
     CriteriaQuery<Long> countQuery = cb.createQuery(Long.class);
     Root<TaskJpaEntity> countRoot = countQuery.from(TaskJpaEntity.class);
@@ -166,7 +190,9 @@ class TaskJpaRepositoryAdapter implements TaskRepository {
                 ownerId,
                 assigneeId,
                 visibility,
-                keyword));
+                keyword,
+                targetDate,
+                includeOverdue));
     Long result = em.createQuery(countQuery).getSingleResult();
     return result != null ? result : 0L;
   }
@@ -180,11 +206,14 @@ class TaskJpaRepositoryAdapter implements TaskRepository {
       @Nullable Long ownerId,
       @Nullable Long assigneeId,
       @Nullable Visibility visibility,
-      @Nullable String keyword) {
+      @Nullable String keyword,
+      LocalDate targetDate,
+      boolean includeOverdue) {
 
     List<Predicate> predicates = new ArrayList<>();
     predicates.add(cb.isNull(task.get("deletedAt")));
     predicates.add(buildAuthPredicate(cb, query, task, userId));
+    predicates.add(buildTargetDatePredicate(cb, task, targetDate, includeOverdue));
 
     if (statuses != null && !statuses.isEmpty()) {
       predicates.add(task.get("status").in(statuses));
@@ -226,6 +255,25 @@ class TaskJpaRepositoryAdapter implements TaskRepository {
   /** LIKE のワイルドカード文字をエスケープし、入力をリテラル一致として扱う。 */
   private static String escapeLike(String input) {
     return input.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_");
+  }
+
+  /**
+   * 表示対象日フィルタ述語(#665 / #666 共通)。
+   *
+   * <p>{@code includeOverdue == true}: 当日(due_date = targetDate)+ 期限切れ未完了(due_date &lt; targetDate
+   * かつ status != DONE)。{@code includeOverdue == false}: 当日のみ。
+   */
+  private Predicate buildTargetDatePredicate(
+      CriteriaBuilder cb, Root<TaskJpaEntity> task, LocalDate targetDate, boolean includeOverdue) {
+    Predicate dueOnTarget = cb.equal(task.get("dueDate"), targetDate);
+    if (!includeOverdue) {
+      return dueOnTarget;
+    }
+    Predicate overdue =
+        cb.and(
+            cb.lessThan(task.get("dueDate"), targetDate),
+            cb.notEqual(task.get("status"), TaskStatus.DONE));
+    return cb.or(dueOnTarget, overdue);
   }
 
   /** visibility 3 役割評価認可述語(ADR-0005)。Hibernate Filter による tenant_id 絞込は別途自動適用。 */

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/adapter/web/TaskController.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/adapter/web/TaskController.java
@@ -4,6 +4,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import java.net.URI;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -17,6 +18,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -111,8 +113,8 @@ public class TaskController {
   /**
    * タスク一覧取得(operationId: listTasks)。
    *
-   * <p>keyword 絞込(タイトル・説明部分一致)は #669 で実装済。targetDate / includeOverdue / priority 絞込は Sprint 3 の別
-   * issue(#665-668)で実装予定。現フェーズでは受理するが実装なし(フィルタ動作なし)。
+   * <p>表示対象日(targetDate、省略時は当日 TODAY)を基準に、当日 + 期限切れ未完了(includeOverdue=true、デフォルト)の タスクを返す(S-04 /
+   * 基本設計書 §3.3.1、#665 / #666 共通)。keyword 絞込(タイトル・説明部分一致)は #669 で実装済。priority 絞込は別 Issue で実装予定。
    */
   @GetMapping
   @PreAuthorize("hasAnyRole('TENANT_ADMIN', 'MEMBER')")
@@ -124,8 +126,9 @@ public class TaskController {
       @RequestParam(required = false) @Nullable Long ownerId,
       @RequestParam(required = false) @Nullable Long assigneeId,
       @RequestParam(required = false) @Nullable Visibility visibility,
-      @RequestParam(required = false) @Nullable String targetDate,
-      @RequestParam(required = false) @Nullable Boolean includeOverdue,
+      @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+          @Nullable LocalDate targetDate,
+      @RequestParam(defaultValue = "true") boolean includeOverdue,
       @RequestParam(required = false) @Nullable String priority,
       @RequestParam(required = false) @Nullable String keyword,
       TasksAuthenticationToken token) {
@@ -135,7 +138,15 @@ public class TaskController {
 
     ListTasksUseCase.Result result =
         listTasksUseCase.execute(
-            userId, statuses, ownerId, assigneeId, visibility, keyword, pageable);
+            userId,
+            statuses,
+            ownerId,
+            assigneeId,
+            visibility,
+            keyword,
+            targetDate,
+            includeOverdue,
+            pageable);
 
     Page<Task> taskPage = result.taskPage();
     Map<Long, UserJpaEntity> userMap = loadUserMap(taskPage.getContent());

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/usecase/ListTasksUseCase.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/usecase/ListTasksUseCase.java
@@ -23,7 +23,7 @@ public class ListTasksUseCase {
   private final Clock clock;
 
   /**
-   * 認可フィルタ済みタスク一覧を取得する。
+   * 認可フィルタ済みタスク一覧を取得する(表示対象日フィルタ済み、#665 / #666 共通)。
    *
    * @param userId 現在のユーザー ID(visibility 認可評価に使用)
    * @param statuses 絞込ステータス(null = 全ステータス)
@@ -31,8 +31,10 @@ public class ListTasksUseCase {
    * @param assigneeId 絞込担当者 ID(null = 全担当者)
    * @param visibility 絞込公開範囲(null = 全公開範囲)
    * @param keyword タイトル・説明部分一致検索キーワード(null / 空白のみ = 検索しない、#669)
+   * @param targetDate 表示対象日(基準日)。null のときは当日(JST、ADR-0009)に解決する
+   * @param includeOverdue 期限切れ未完了タスクを含めるか
    * @param pageable ページング / ソート指定
-   * @return ページ結果と期限切れ未完了タスク件数
+   * @return ページ結果と基準日時点の期限切れ未完了タスク件数
    */
   @Observed(name = "task.list")
   @Transactional(readOnly = true)
@@ -43,13 +45,25 @@ public class ListTasksUseCase {
       @Nullable Long assigneeId,
       @Nullable Visibility visibility,
       @Nullable String keyword,
+      @Nullable LocalDate targetDate,
+      boolean includeOverdue,
       Pageable pageable) {
+
+    LocalDate effectiveDate = targetDate != null ? targetDate : LocalDate.now(clock);
 
     Page<Task> taskPage =
         taskRepository.findVisibleTasks(
-            userId, statuses, ownerId, assigneeId, visibility, keyword, pageable);
+            userId,
+            statuses,
+            ownerId,
+            assigneeId,
+            visibility,
+            keyword,
+            effectiveDate,
+            includeOverdue,
+            pageable);
 
-    long overdueCount = taskRepository.countOverdueTasks(userId, LocalDate.now(clock));
+    long overdueCount = taskRepository.countOverdueTasks(userId, effectiveDate);
 
     return new Result(taskPage, Math.toIntExact(overdueCount));
   }

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/usecase/TaskRepository.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/usecase/TaskRepository.java
@@ -38,7 +38,17 @@ public interface TaskRepository {
    * <p>Hibernate Filter による tenant_id 自動絞込 + deleted_at IS NULL + visibility 3 役割評価(ADR-0005)を
    * 適用する。priority ソートは HIGH=3 / MEDIUM=2 / LOW=1 に内部変換。desc ソートで HIGH が先頭(重要度高い順)。
    *
+   * <p>表示対象日フィルタ(#665 / #666 共通):
+   *
+   * <ul>
+   *   <li>{@code includeOverdue == true}: {@code due_date = targetDate} または 「{@code due_date <
+   *       targetDate} かつ未完了(status != DONE)」のタスク(当日 + 期限切れ)
+   *   <li>{@code includeOverdue == false}: {@code due_date = targetDate} のタスクのみ
+   * </ul>
+   *
    * @param keyword タイトル・説明の部分一致検索キーワード(null / 空白のみ = 検索しない、#669)
+   * @param targetDate 表示対象日(基準日)。{@code null} 不可(usecase で当日に解決済み)。
+   * @param includeOverdue 期限切れ未完了タスクを含めるか
    */
   Page<Task> findVisibleTasks(
       Long userId,
@@ -47,10 +57,12 @@ public interface TaskRepository {
       @Nullable Long assigneeId,
       @Nullable Visibility visibility,
       @Nullable String keyword,
+      LocalDate targetDate,
+      boolean includeOverdue,
       Pageable pageable);
 
-  /** 認可フィルタを適用した期限切れ未完了タスク件数を返す。 */
-  long countOverdueTasks(Long userId, LocalDate today);
+  /** 認可フィルタを適用した、基準日時点の期限切れ未完了タスク件数({@code due_date < targetDate})を返す。 */
+  long countOverdueTasks(Long userId, LocalDate targetDate);
 
   /** タスクを論理削除する(deleted_at セット)。楽観ロック競合時は PreconditionFailedException を投げる。 */
   void softDelete(Task task, LocalDateTime deletedAt);

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/SecurityConfigTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/SecurityConfigTest.java
@@ -1,6 +1,7 @@
 package xyz.dgz48.tasks.webapi.security.adapter.web;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.when;
@@ -109,7 +110,9 @@ class SecurityConfigTest {
   void stubTenantResolver() {
     given(userTenantsResolverService.resolveInitial(ArgumentMatchers.anyLong()))
         .willReturn(Optional.of(new TenantMembership(1L, TenantRole.MEMBER)));
-    given(listTasksUseCase.execute(any(), any(), any(), any(), any(), any(), any()))
+    given(
+            listTasksUseCase.execute(
+                any(), any(), any(), any(), any(), any(), any(), anyBoolean(), any()))
         .willReturn(new ListTasksUseCase.Result(Page.empty(PageRequest.of(0, 50)), 0));
   }
 

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/adapter/web/ListTasksIT.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/adapter/web/ListTasksIT.java
@@ -49,6 +49,9 @@ class ListTasksIT {
   @Autowired EntityManager em;
   @Autowired TransactionTemplate txTemplate;
 
+  /** 固定クロック(FixedClockConfiguration)の当日(JST 2026-01-15)。 */
+  private static final LocalDate TODAY = LocalDate.of(2026, 1, 15);
+
   // User A: viewer(target user)
   private Long userAId;
   private TasksAuthenticationToken authTokenA;
@@ -117,7 +120,7 @@ class ListTasksIT {
                   "四半期レビュー資料の作成",
                   TaskStatus.NOT_STARTED,
                   Priority.MEDIUM,
-                  LocalDate.of(2026, 12, 31));
+                  TODAY);
           em.persist(tenantTask);
           em.flush();
           tenantTaskId = tenantTask.getId();
@@ -140,7 +143,7 @@ class ListTasksIT {
                   null,
                   TaskStatus.NOT_STARTED,
                   Priority.HIGH,
-                  LocalDate.of(2026, 12, 31));
+                  TODAY);
           em.persist(stakeholderTask);
           em.flush();
           stakeholderTaskId = stakeholderTask.getId();
@@ -167,7 +170,7 @@ class ListTasksIT {
                   null,
                   TaskStatus.NOT_STARTED,
                   Priority.LOW,
-                  LocalDate.of(2026, 12, 31));
+                  TODAY);
           em.persist(privateTask);
           em.flush();
           privateTaskId = privateTask.getId();
@@ -190,7 +193,7 @@ class ListTasksIT {
                   null,
                   TaskStatus.NOT_STARTED,
                   Priority.LOW,
-                  LocalDate.of(2026, 12, 31));
+                  TODAY);
           em.persist(privateTaskOwnedByA);
           em.flush();
           privateTaskOwnedByAId = privateTaskOwnedByA.getId();
@@ -343,7 +346,7 @@ class ListTasksIT {
                     null,
                     TaskStatus.NOT_STARTED,
                     Priority.MEDIUM,
-                    LocalDate.of(2026, 12, 31));
+                    TODAY);
             em.persist(taskB);
             em.flush();
             taskBId = taskB.getId();
@@ -550,6 +553,104 @@ class ListTasksIT {
       mockMvc
           .perform(get("/api/tasks").header("X-Tenant-Id", String.valueOf(tenantId)))
           .andExpect(status().isUnauthorized());
+    }
+  }
+
+  /** 表示対象日フィルタ(targetDate / includeOverdue、#665)の検証。 */
+  @Nested
+  class DateWindow {
+
+    private Long todayTaskId;
+    private Long overdueTaskId;
+    private Long overdueDoneTaskId;
+    private Long futureTaskId;
+
+    @BeforeEach
+    void setUpDatedTasks() {
+      txTemplate.execute(
+          ignored -> {
+            // JpaAuditorAware が created_by / updated_by を解決できるよう認証コンテキストを設定
+            var principalB =
+                new TasksPrincipal(
+                    userBId, "sub-lt-b", "lt-b@example.com", "一覧テストB太郎", "イチランテストビーたろう", null);
+            SecurityContextHolder.getContext()
+                .setAuthentication(new TasksAuthenticationToken(principalB, List.of()));
+
+            todayTaskId = persistTask("当日タスク", TaskStatus.NOT_STARTED, TODAY);
+            overdueTaskId = persistTask("期限切れタスク", TaskStatus.IN_PROGRESS, TODAY.minusDays(5));
+            overdueDoneTaskId = persistTask("期限切れ完了タスク", TaskStatus.DONE, TODAY.minusDays(5));
+            futureTaskId = persistTask("未来タスク", TaskStatus.NOT_STARTED, TODAY.plusDays(10));
+            return null;
+          });
+      SecurityContextHolder.clearContext();
+    }
+
+    private Long persistTask(String title, TaskStatus status, LocalDate dueDate) {
+      // visibility=TENANT(デフォルト)なので userA から参照可能
+      var task =
+          new TaskJpaEntity(tenantId, userBId, title, null, status, Priority.MEDIUM, dueDate);
+      em.persist(task);
+      em.flush();
+      return task.getId();
+    }
+
+    @Test
+    void targetDate_withDefaultIncludeOverdue_returnsTargetDayAndOverdueExcludingDoneAndFuture()
+        throws Exception {
+      // targetDate=TODAY 基準 + includeOverdue=true(デフォルト、明示指定なし)
+      mockMvc
+          .perform(
+              get("/api/tasks")
+                  .header("X-Tenant-Id", String.valueOf(tenantId))
+                  .param("targetDate", TODAY.toString())
+                  .with(authentication(authTokenA)))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.content[?(@.id == " + todayTaskId + ")]").exists())
+          .andExpect(jsonPath("$.content[?(@.id == " + overdueTaskId + ")]").exists())
+          .andExpect(jsonPath("$.content[?(@.id == " + overdueDoneTaskId + ")]").doesNotExist())
+          .andExpect(jsonPath("$.content[?(@.id == " + futureTaskId + ")]").doesNotExist())
+          .andExpect(
+              jsonPath("$.overdueCount").value(org.hamcrest.Matchers.greaterThanOrEqualTo(1)));
+    }
+
+    @Test
+    void includeOverdueFalse_returnsOnlyTargetDateTasks() throws Exception {
+      mockMvc
+          .perform(
+              get("/api/tasks")
+                  .header("X-Tenant-Id", String.valueOf(tenantId))
+                  .param("targetDate", TODAY.toString())
+                  .param("includeOverdue", "false")
+                  .with(authentication(authTokenA)))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.content[?(@.id == " + todayTaskId + ")]").exists())
+          .andExpect(jsonPath("$.content[?(@.id == " + overdueTaskId + ")]").doesNotExist())
+          .andExpect(jsonPath("$.content[?(@.id == " + futureTaskId + ")]").doesNotExist());
+    }
+
+    @Test
+    void targetDate_selectsThatDaysTasks() throws Exception {
+      mockMvc
+          .perform(
+              get("/api/tasks")
+                  .header("X-Tenant-Id", String.valueOf(tenantId))
+                  .param("targetDate", TODAY.plusDays(10).toString())
+                  .param("includeOverdue", "false")
+                  .with(authentication(authTokenA)))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.content[?(@.id == " + futureTaskId + ")]").exists())
+          .andExpect(jsonPath("$.content[?(@.id == " + todayTaskId + ")]").doesNotExist());
+    }
+
+    @Test
+    void invalidTargetDate_returns400() throws Exception {
+      mockMvc
+          .perform(
+              get("/api/tasks")
+                  .header("X-Tenant-Id", String.valueOf(tenantId))
+                  .param("targetDate", "not-a-date")
+                  .with(authentication(authTokenA)))
+          .andExpect(status().isBadRequest());
     }
   }
 }

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/adapter/web/TaskControllerWebMvcTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/adapter/web/TaskControllerWebMvcTest.java
@@ -353,6 +353,8 @@ class TaskControllerWebMvcTest {
                 ArgumentMatchers.isNull(),
                 ArgumentMatchers.isNull(),
                 ArgumentMatchers.isNull(),
+                ArgumentMatchers.isNull(),
+                ArgumentMatchers.eq(true),
                 ArgumentMatchers.any()))
         .willReturn(result);
 
@@ -369,6 +371,40 @@ class TaskControllerWebMvcTest {
         .andExpect(jsonPath("$.size").value(50))
         .andExpect(jsonPath("$.overdueCount").value(0))
         .andExpect(jsonPath("$.content").isArray());
+  }
+
+  @Test
+  @WithMockMember
+  void listTasks_bindsTargetDateAndIncludeOverdue() throws Exception {
+    Page<Task> taskPage = new PageImpl<>(List.of(), PageRequest.of(0, 50), 0);
+    ListTasksUseCase.Result result = new ListTasksUseCase.Result(taskPage, 0);
+    BDDMockito.given(
+            listTasksUseCase.execute(
+                ArgumentMatchers.eq(USER_ID),
+                ArgumentMatchers.isNull(),
+                ArgumentMatchers.isNull(),
+                ArgumentMatchers.isNull(),
+                ArgumentMatchers.isNull(),
+                ArgumentMatchers.isNull(),
+                ArgumentMatchers.eq(LocalDate.of(2026, 6, 7)),
+                ArgumentMatchers.eq(false),
+                ArgumentMatchers.any()))
+        .willReturn(result);
+    BDDMockito.given(userRepository.findAllById(ArgumentMatchers.anyCollection()))
+        .willReturn(List.of());
+
+    mockMvc
+        .perform(
+            get("/api/tasks").param("targetDate", "2026-06-07").param("includeOverdue", "false"))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  @WithMockMember
+  void listTasks_returns400_whenTargetDateMalformed() throws Exception {
+    mockMvc
+        .perform(get("/api/tasks").param("targetDate", "06/07/2026"))
+        .andExpect(status().isBadRequest());
   }
 
   @Test
@@ -399,6 +435,8 @@ class TaskControllerWebMvcTest {
                 ArgumentMatchers.any(),
                 ArgumentMatchers.any(),
                 ArgumentMatchers.any(),
+                ArgumentMatchers.any(),
+                ArgumentMatchers.anyBoolean(),
                 ArgumentMatchers.any()))
         .willReturn(result);
     BDDMockito.given(userRepository.findAllById(ArgumentMatchers.anyCollection()))

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/usecase/ListTasksUseCaseTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/usecase/ListTasksUseCaseTest.java
@@ -2,6 +2,7 @@ package xyz.dgz48.tasks.webapi.task.usecase;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.when;
@@ -71,12 +72,20 @@ class ListTasksUseCaseTest {
     Page<Task> taskPage = new PageImpl<>(List.of(buildTask(1L), buildTask(2L)), pageable, 2);
 
     when(taskRepository.findVisibleTasks(
-            eq(USER_ID), isNull(), isNull(), isNull(), isNull(), isNull(), eq(pageable)))
+            eq(USER_ID),
+            isNull(),
+            isNull(),
+            isNull(),
+            isNull(),
+            isNull(),
+            eq(TODAY),
+            eq(true),
+            eq(pageable)))
         .thenReturn(taskPage);
     when(taskRepository.countOverdueTasks(eq(USER_ID), eq(TODAY))).thenReturn(3L);
 
     ListTasksUseCase.Result result =
-        useCase.execute(USER_ID, null, null, null, null, null, pageable);
+        useCase.execute(USER_ID, null, null, null, null, null, null, true, pageable);
 
     assertThat(result.taskPage().getContent()).hasSize(2);
     assertThat(result.overdueCount()).isEqualTo(3);
@@ -98,12 +107,15 @@ class ListTasksUseCaseTest {
             eq(assigneeId),
             eq(visibility),
             isNull(),
+            eq(TODAY),
+            eq(true),
             eq(pageable)))
         .thenReturn(Page.empty(pageable));
     when(taskRepository.countOverdueTasks(any(), any())).thenReturn(0L);
 
     ListTasksUseCase.Result result =
-        useCase.execute(USER_ID, statuses, ownerId, assigneeId, visibility, null, pageable);
+        useCase.execute(
+            USER_ID, statuses, ownerId, assigneeId, visibility, null, null, true, pageable);
 
     assertThat(result.taskPage().getContent()).isEmpty();
     assertThat(result.overdueCount()).isZero();
@@ -116,12 +128,20 @@ class ListTasksUseCaseTest {
     String keyword = "請求書";
 
     when(taskRepository.findVisibleTasks(
-            eq(USER_ID), isNull(), isNull(), isNull(), isNull(), eq(keyword), eq(pageable)))
+            eq(USER_ID),
+            isNull(),
+            isNull(),
+            isNull(),
+            isNull(),
+            eq(keyword),
+            eq(TODAY),
+            eq(true),
+            eq(pageable)))
         .thenReturn(new PageImpl<>(List.of(buildTask(1L)), pageable, 1));
     when(taskRepository.countOverdueTasks(any(), any())).thenReturn(0L);
 
     ListTasksUseCase.Result result =
-        useCase.execute(USER_ID, null, null, null, null, keyword, pageable);
+        useCase.execute(USER_ID, null, null, null, null, keyword, null, true, pageable);
 
     assertThat(result.taskPage().getContent()).hasSize(1);
   }
@@ -130,12 +150,13 @@ class ListTasksUseCaseTest {
   void execute_returnsEmptyPage_whenRepositoryReturnsEmpty() {
     setupClock();
     Pageable pageable = PageRequest.of(0, 50);
-    when(taskRepository.findVisibleTasks(any(), any(), any(), any(), any(), any(), any()))
+    when(taskRepository.findVisibleTasks(
+            any(), any(), any(), any(), any(), any(), any(), anyBoolean(), any()))
         .thenReturn(Page.empty(pageable));
     when(taskRepository.countOverdueTasks(any(), any())).thenReturn(0L);
 
     ListTasksUseCase.Result result =
-        useCase.execute(USER_ID, null, null, null, null, null, pageable);
+        useCase.execute(USER_ID, null, null, null, null, null, null, true, pageable);
 
     assertThat(result.taskPage().isEmpty()).isTrue();
     assertThat(result.overdueCount()).isZero();


### PR DESCRIPTION
## 概要

メイン画面(S-04 タスク一覧)に「当日対象タスク」を表示する(基本設計書 §3.3.1)。表示対象日(基準日)をパラメータ化し、#666(表示基準日の切替)と共通のクエリとして設計した。

Closes #665

## backend(`listTasks` 表示対象日フィルタ)

- `targetDate`(省略時は当日 TODAY、JST / ADR-0009)+ `includeOverdue`(デフォルト `true`)を実装。受理のみで未実装だったパラメータを実動化。
- 抽出条件:
  - `includeOverdue=true`: `due_date = targetDate` **または**「`due_date < targetDate` かつ `status != DONE`」(当日 + 期限切れ未完了)
  - `includeOverdue=false`: `due_date = targetDate` のみ
- `overdueCount` を基準日相対で算出(#666 でそのまま再利用可)。
- 配線: `TaskRepository.findVisibleTasks` / `ListTasksUseCase`(`targetDate` null は当日に解決)/ `TaskController`(`LocalDate` バインド、不正フォーマットは 400)。
- visibility 3 役割評価(ADR-0005)・Hibernate Filter テナント絞込(ADR-0010)は従来どおり適用。

## frontend(`web/js/tasks.js` + CSS)

- `targetDate`(当日 JST)+ `includeOverdue=true` で取得。
- 一覧を「期限切れ」「本日」の 2 セクションに分けて描画(`due_date < 表示対象日` で振り分け)。各セクションは常時表示し、空のときは空状態行を表示。
- セクションヘッダ行のスタイルを `app.css` に追加。

## テスト

- **WebMvc**(`TaskControllerWebMvcTest`): `targetDate`/`includeOverdue` のバインド、不正な `targetDate` → 400、既存 listTasks 系の signature 追従。
- **Testcontainers IT**(`ListTasksIT` / `DateWindow`): 当日 + 期限切れ抽出、完了済み期限切れの除外、未来タスクの除外、`includeOverdue=false`、`targetDate` 明示指定、不正日付 400。既存タスクの due_date を当日へ寄せて既存 visibility テストを維持。

## 確認

- `./gradlew :webapi:check` green
- `web/` で `npx biome ci .` / `npm run html-validate` / `npx tsc --noEmit` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)