### PR TITLE
feat(task): 表示基準日の前後切替(日付ナビ UI)(#666)

### DIFF
--- a/e2e/tests/tasks.spec.ts
+++ b/e2e/tests/tasks.spec.ts
@@ -70,4 +70,58 @@ test.describe('タスク一覧 + CRUD', () => {
     await expect(drawer).not.toBeVisible({ timeout: 5_000 });
     await expect(page.locator('#task-tbody')).not.toContainText(taskTitle, { timeout: 10_000 });
   });
+
+  // #666 — 表示基準日の前後切替
+  test('表示基準日を切り替えると当該日のタスクが表示される', async ({ page }) => {
+    const taskTitle = `E2E datenav ${Date.now()}`;
+    const fmt = (d: Date) =>
+      new Intl.DateTimeFormat('en-CA', {
+        timeZone: 'Asia/Tokyo',
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+      }).format(d);
+    const today = fmt(new Date());
+    const tomorrow = fmt(new Date(Date.now() + 24 * 60 * 60 * 1000));
+
+    // 初期状態は当日 (JST) で「今日に戻る」は無効
+    await expect(page.locator('#date-picker')).toHaveValue(today);
+    await expect(page.locator('#btn-date-today')).toBeDisabled();
+
+    // 期限=翌日のタスクを作成
+    await page.click('#btn-new-task');
+    const drawer = page.locator('app-task-drawer .offcanvas');
+    await expect(drawer).toBeVisible({ timeout: 5_000 });
+    await page.fill('#newTitle', taskTitle);
+    await page.fill('#newDue', tomorrow);
+    await drawer.locator('button[type="submit"]').click();
+    await expect(drawer).not.toBeVisible({ timeout: 10_000 });
+
+    // 当日ビューには現れない(未来タスクは当日対象外、#665)
+    await expect(page.locator('#task-tbody')).not.toContainText(taskTitle, { timeout: 10_000 });
+
+    // 翌日へ切替 → 当該タスクが選択日セクションに現れる
+    await page.click('#btn-date-next');
+    await expect(page.locator('#date-picker')).toHaveValue(tomorrow);
+    await expect(page.locator('#btn-date-today')).toBeEnabled();
+    await expect(page.locator('#task-tbody')).toContainText(taskTitle, { timeout: 10_000 });
+
+    // 「今日に戻る」 → 再び消える
+    await page.click('#btn-date-today');
+    await expect(page.locator('#date-picker')).toHaveValue(today);
+    await expect(page.locator('#btn-date-today')).toBeDisabled();
+    await expect(page.locator('#task-tbody')).not.toContainText(taskTitle, { timeout: 10_000 });
+
+    // 後始末: 前日/翌日ボタンで翌日へ戻し、作成したタスクを削除
+    await page.click('#btn-date-next');
+    await expect(page.locator('#task-tbody')).toContainText(taskTitle, { timeout: 10_000 });
+    const taskRow = page.locator('app-task-row').filter({
+      has: page.locator('.task-title', { hasText: taskTitle }),
+    });
+    await taskRow.locator('td.cell-owner').click();
+    await expect(drawer).toBeVisible({ timeout: 5_000 });
+    await drawer.locator('.btn-outline-danger').click();
+    await drawer.locator('button.btn-danger').click();
+    await expect(drawer).not.toBeVisible({ timeout: 5_000 });
+  });
 });

--- a/web/js/tasks.js
+++ b/web/js/tasks.js
@@ -18,6 +18,33 @@ function todayDateStr() {
   }).format(new Date());
 }
 
+// YYYY-MM-DD に delta 日を加算した YYYY-MM-DD を返す。
+// 日付演算は UTC で行い、タイムゾーン依存のずれを避ける(#666)。
+/**
+ * @param {string} dateStr — YYYY-MM-DD
+ * @param {number} delta — 加算する日数(負値で減算)
+ * @returns {string} YYYY-MM-DD
+ */
+function addDays(dateStr, delta) {
+  const [y, m, d] = dateStr.split('-').map(Number);
+  const dt = new Date(Date.UTC(y, m - 1, d + delta));
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'UTC',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(dt);
+}
+
+// YYYY-MM-DD を「M月D日(曜)」の和文表記に整形する(表示基準日ラベル用)。
+/** @param {string} dateStr — YYYY-MM-DD */
+function formatDateLabel(dateStr) {
+  const [y, m, d] = dateStr.split('-').map(Number);
+  const dt = new Date(Date.UTC(y, m - 1, d));
+  const wd = ['日', '月', '火', '水', '木', '金', '土'][dt.getUTCDay()];
+  return `${m}月${d}日(${wd})`;
+}
+
 // ---- Task / user state ----
 const taskMap = new Map(); // taskId(number) → Task object
 const rowMap = new Map(); // taskId(number) → app-task-row element
@@ -35,6 +62,10 @@ const descPopover = /** @type {AppDescPopoverElement} */ (mustQuery(document, '#
 const taskDrawer = /** @type {AppTaskDrawerElement} */ (mustQuery(document, '#task-drawer'));
 const pager = /** @type {AppPagerElement} */ (mustQuery(document, '#task-pager'));
 const tbody = /** @type {HTMLElement} */ (mustQuery(document, '#task-tbody'));
+
+// ---- Date navigation refs (#666) ----
+const datePicker = /** @type {HTMLInputElement} */ (mustQuery(document, '#date-picker'));
+const btnDateToday = /** @type {HTMLButtonElement} */ (mustQuery(document, '#btn-date-today'));
 
 // ETag format per ADR-0012: W/"<version>"
 /** @param {{ version: number }} task */
@@ -55,14 +86,19 @@ function renderTasks(tasks) {
   const list = tasks ?? [];
   const overdue = list.filter((t) => t.dueDate != null && t.dueDate < currentTargetDate);
   const onTarget = list.filter((t) => !(t.dueDate != null && t.dueDate < currentTargetDate));
-  const todayCount = Math.max(0, totalElements - overdueTotal);
+  const targetCount = Math.max(0, totalElements - overdueTotal);
+
+  // 表示基準日が当日なら「本日」、それ以外は選択日のラベルを表示する(#666)。
+  const isToday = currentTargetDate === todayDateStr();
+  const targetLabel = isToday ? '本日' : formatDateLabel(currentTargetDate);
+  const targetEmpty = isToday ? '本日のタスクはありません' : `${targetLabel}のタスクはありません`;
 
   /** @type {Node[]} */
   const nodes = [];
   nodes.push(groupHeadRow('bi-exclamation-triangle-fill text-danger', '期限切れ', overdueTotal));
   nodes.push(...sectionRows(overdue, '期限切れのタスクはありません'));
-  nodes.push(groupHeadRow('bi-calendar-day text-primary', '本日', todayCount));
-  nodes.push(...sectionRows(onTarget, '本日のタスクはありません'));
+  nodes.push(groupHeadRow('bi-calendar-day text-primary', targetLabel, targetCount));
+  nodes.push(...sectionRows(onTarget, targetEmpty));
   tbody.replaceChildren(...nodes);
 }
 
@@ -241,7 +277,6 @@ async function loadTasks() {
   cancelAllEdits();
   showLoading(true);
   try {
-    currentTargetDate = todayDateStr();
     const data = await Api.listTasks({
       page: currentPage,
       size: PAGE_SIZE,
@@ -320,6 +355,23 @@ function applyKeyword() {
   loadTasks();
 }
 
+// ---- Date navigation (#666, 基本設計書 §3.3.1) ----
+// 表示基準日を変更し、ピッカー値・「今日に戻る」ボタンの活性を同期して再取得する。
+/** @param {string} dateStr — YYYY-MM-DD */
+function setTargetDate(dateStr) {
+  if (!dateStr || dateStr === currentTargetDate) return;
+  currentTargetDate = dateStr;
+  datePicker.value = dateStr;
+  btnDateToday.disabled = dateStr === todayDateStr();
+  currentPage = 0;
+  loadTasks();
+}
+
+/** @param {number} delta — 加算する日数(前日 = -1, 翌日 = +1) */
+function shiftTargetDate(delta) {
+  setTargetDate(addDays(currentTargetDate, delta));
+}
+
 // ---- Row click → open detail drawer (S-05) ----
 /** @param {number} id */
 function onRowClick(id) {
@@ -395,8 +447,22 @@ pager.addEventListener('page-change', (e) => {
   onSortChange(/** @type {HTMLSelectElement} */ (e.target).value),
 );
 /** @type {HTMLElement} */ (mustQuery(document, '#btn-new-task')).addEventListener('click', () =>
-  taskDrawer.open(),
+  // 新規タスクの期限初期値は表示中の日付(基本設計書 §3.3.1)。
+  taskDrawer.openNew({ dueDate: currentTargetDate }),
 );
+
+// Date navigation: prev / next / today (#666)
+/** @type {HTMLElement} */ (mustQuery(document, '#btn-date-prev')).addEventListener('click', () =>
+  shiftTargetDate(-1),
+);
+/** @type {HTMLElement} */ (mustQuery(document, '#btn-date-next')).addEventListener('click', () =>
+  shiftTargetDate(1),
+);
+btnDateToday.addEventListener('click', () => setTargetDate(todayDateStr()));
+datePicker.addEventListener('change', () => {
+  // ピッカーが空(クリア)になった場合は当日へ戻す。
+  setTargetDate(datePicker.value || todayDateStr());
+});
 /** @type {HTMLElement} */ (mustQuery(document, '#th-dueDate')).addEventListener('click', () =>
   cycleSort('dueDate'),
 );
@@ -472,6 +538,11 @@ async function main() {
   }
   taskDrawer.setUsers(tenantUsers);
 
+  // 表示基準日の初期値は当日 (JST)。ピッカーへ反映し「今日に戻る」を無効化する(#666)。
+  currentTargetDate = todayDateStr();
+  datePicker.value = currentTargetDate;
+  btnDateToday.disabled = true;
+
   updateSortCarets();
   await loadTasks();
 
@@ -481,7 +552,7 @@ async function main() {
   const editMatch = /\/tasks\/(\d+)\/edit\/?$/.exec(path);
   const detailMatch = /\/tasks\/(\d+)\/?$/.exec(path);
   if (newMatch) {
-    taskDrawer.openNew();
+    taskDrawer.openNew({ dueDate: currentTargetDate });
   } else if (editMatch) {
     await taskDrawer.openEdit(Number(editMatch[1]));
   } else if (detailMatch) {

--- a/web/tasks.html
+++ b/web/tasks.html
@@ -95,6 +95,22 @@
       </div>
     </div>
 
+    <!-- Date navigation (#666, 基本設計書 §3.3.1) — 表示基準日の前後切替 -->
+    <div id="date-nav" class="date-nav d-flex align-items-center gap-2 mb-3" role="group"
+      aria-label="表示基準日の切替">
+      <button id="btn-date-prev" type="button" class="btn btn-outline-secondary btn-sm" aria-label="前日">
+        <i class="bi bi-chevron-left" aria-hidden="true"></i>
+      </button>
+      <label for="date-picker" class="visually-hidden">表示基準日</label>
+      <input id="date-picker" type="date" class="form-control form-control-sm w-auto">
+      <button id="btn-date-next" type="button" class="btn btn-outline-secondary btn-sm" aria-label="翌日">
+        <i class="bi bi-chevron-right" aria-hidden="true"></i>
+      </button>
+      <button id="btn-date-today" type="button" class="btn btn-outline-primary btn-sm">
+        <i class="bi bi-calendar-check me-1" aria-hidden="true"></i>今日に戻る
+      </button>
+    </div>
+
     <!-- Tenant Admin role note -->
     <div class="alert alert-info py-2 small mb-3 admin-only" role="note">
       <i class="bi bi-shield-lock me-1" aria-hidden="true"></i>


### PR DESCRIPTION
## 概要

タスク一覧画面に**表示基準日ナビゲーション**を追加し、前後の任意日でその日のタスクを閲覧できるようにする(基本設計書 §3.3.1)。

backend は #665 で基準日パラメータ化済みの抽出クエリ(`targetDate` / `includeOverdue`)をそのまま再利用するため、**追加の backend 変更はなし**。

## やったこと

### frontend (`web/`)
- **日付ナビ UI**(画面上部):前日 / 翌日ボタン + 日付ピッカー + 「今日に戻る」ボタン
- 基準日切替時に当該日のタスクを再取得(`loadTasks` が固定で当日を再計算していた箇所を撤去し、`currentTargetDate` を可変化)
- 選択日セクションのラベル / 空状態文言を基準日へ追従(当日は「本日」、それ以外は「M月D日(曜)」表記)
- 「今日に戻る」ボタンは当日表示中は無効化
- 日付演算は UTC 基準で行い、タイムゾーン依存のずれを回避
- 新規タスクの期限初期値を表示中の日付に設定(§3.3.1)

### test
- **e2e**(`e2e/tests/tasks.spec.ts`):期限=翌日のタスクが当日ビューには出ず、翌日へ切替で選択日セクションに現れ、「今日に戻る」で再び消えることを確認するスモークを追加

## 確認

- `./gradlew :webapi:check` ✅(backend 無変更・既存 targetDate テストで担保)
- `web/`: `npx biome ci .` / `npm run html-validate` / `npx tsc --noEmit` ✅
- `e2e/`: `npx biome ci tests/` / `npx tsc --noEmit` ✅

Closes #666

🤖 Generated with [Claude Code](https://claude.com/claude-code)