### PR TITLE
feat(task): 期限切れ未完了の常時表示(当日基準で選択日に依存しない)(#667)

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -562,7 +562,7 @@ paths:
       operationId: listTasks
       parameters:
         - { name: targetDate,     in: query, schema: { type: string, format: date }, description: "表示対象日(省略時は当日 TODAY)" }
-        - { name: includeOverdue, in: query, schema: { type: boolean, default: true }, description: "期限切れ未完了タスクを含める" }
+        - { name: includeOverdue, in: query, schema: { type: boolean, default: true }, description: "期限切れ未完了タスク(`due_date < TODAY` かつ未完了)を含める。期限切れは選択日 targetDate に依存せず常時当日基準で含める(#667)" }
         - name: status
           in: query
           style: form
@@ -1469,7 +1469,7 @@ components:
         totalPages:    { type: integer }
         number:        { type: integer, description: "現在のページ番号(0始まり)" }
         size:          { type: integer }
-        overdueCount:  { type: integer, description: "期限切れ未完了タスク件数(参考)" }
+        overdueCount:  { type: integer, description: "期限切れ未完了タスク件数(JST 基準、`due_date < TODAY` かつ未完了。選択日 targetDate に依存せず常時当日基準、#667)" }
 
     TenantPage:
       type: object

--- a/e2e/tests/tasks.spec.ts
+++ b/e2e/tests/tasks.spec.ts
@@ -124,4 +124,49 @@ test.describe('タスク一覧 + CRUD', () => {
     await drawer.locator('button.btn-danger').click();
     await expect(drawer).not.toBeVisible({ timeout: 5_000 });
   });
+
+  // #667 — 期限切れ未完了の常時表示
+  test('期限切れ未完了タスクは選択日に関わらず常時上部に表示される', async ({ page }) => {
+    const taskTitle = `E2E overdue ${Date.now()}`;
+    const fmt = (d: Date) =>
+      new Intl.DateTimeFormat('en-CA', {
+        timeZone: 'Asia/Tokyo',
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+      }).format(d);
+    const today = fmt(new Date());
+    const yesterday = fmt(new Date(Date.now() - 24 * 60 * 60 * 1000));
+
+    // 期限=前日(=期限切れ・未完了)のタスクを作成
+    await page.click('#btn-new-task');
+    const drawer = page.locator('app-task-drawer .offcanvas');
+    await expect(drawer).toBeVisible({ timeout: 5_000 });
+    await page.fill('#newTitle', taskTitle);
+    await page.fill('#newDue', yesterday);
+    await drawer.locator('button[type="submit"]').click();
+    await expect(drawer).not.toBeVisible({ timeout: 10_000 });
+
+    // 当日ビューで期限切れセクションに表示される
+    await expect(page.locator('#task-tbody')).toContainText('期限切れ');
+    await expect(page.locator('#task-tbody')).toContainText(taskTitle, { timeout: 10_000 });
+
+    // 翌日へ切替しても期限切れは当日基準で常時表示される(#667 の要)
+    await page.click('#btn-date-next');
+    await expect(page.locator('#date-picker')).not.toHaveValue(today);
+    await expect(page.locator('#task-tbody')).toContainText(taskTitle, { timeout: 10_000 });
+
+    // 後始末: 当日へ戻し(期限切れは引き続き表示)、作成したタスクを削除
+    await page.click('#btn-date-today');
+    await expect(page.locator('#date-picker')).toHaveValue(today);
+    const taskRow = page.locator('app-task-row').filter({
+      has: page.locator('.task-title', { hasText: taskTitle }),
+    });
+    await expect(taskRow).toBeVisible({ timeout: 10_000 });
+    await taskRow.locator('td.cell-owner').click();
+    await expect(drawer).toBeVisible({ timeout: 5_000 });
+    await drawer.locator('.btn-outline-danger').click();
+    await drawer.locator('button.btn-danger').click();
+    await expect(drawer).not.toBeVisible({ timeout: 5_000 });
+  });
 });

--- a/web/js/tasks.js
+++ b/web/js/tasks.js
@@ -74,18 +74,22 @@ function buildEtag(task) {
 }
 
 // ---- Render task list from API response ----
-// 当日対象タスクを「期限切れ」「本日(選択日)」の 2 セクションに分けて描画する
-// (基本設計書 §3.3.1)。期限切れ = dueDate < 表示対象日。各セクションは常時表示し、
-// 空の場合は空状態行を表示する。
+// 取得したタスクを「期限切れ」「本日(選択日)」の 2 セクションに分けて描画する
+// (基本設計書 §3.3.1)。期限切れ = dueDate < 当日 かつ 未完了。期限切れは選択日に関わらず
+// 当日基準で常時上部に表示する(#667)。各セクションは常時表示し、空の場合は空状態行を表示する。
 /** @param {Task[]} tasks */
 function renderTasks(tasks) {
   /** @type {HTMLElement} */ (mustQuery(document, '#total-count')).textContent =
     `${totalElements} 件`;
   rowMap.clear();
 
+  const today = todayDateStr();
+  /** @param {Task} t */
+  const isOverdue = (t) => t.dueDate != null && t.dueDate < today && t.status !== 'DONE';
+
   const list = tasks ?? [];
-  const overdue = list.filter((t) => t.dueDate != null && t.dueDate < currentTargetDate);
-  const onTarget = list.filter((t) => !(t.dueDate != null && t.dueDate < currentTargetDate));
+  const overdue = list.filter(isOverdue);
+  const onTarget = list.filter((t) => !isOverdue(t));
   const targetCount = Math.max(0, totalElements - overdueTotal);
 
   // 表示基準日が当日なら「本日」、それ以外は選択日のラベルを表示する(#666)。

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/adapter/persistence/TaskJpaRepositoryAdapter.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/adapter/persistence/TaskJpaRepositoryAdapter.java
@@ -99,6 +99,7 @@ class TaskJpaRepositoryAdapter implements TaskRepository {
       @Nullable Visibility visibility,
       @Nullable String keyword,
       LocalDate targetDate,
+      LocalDate today,
       boolean includeOverdue,
       Pageable pageable) {
 
@@ -114,6 +115,7 @@ class TaskJpaRepositoryAdapter implements TaskRepository {
             visibility,
             keyword,
             targetDate,
+            today,
             includeOverdue);
     if (total == 0) {
       return Page.empty(pageable);
@@ -133,6 +135,7 @@ class TaskJpaRepositoryAdapter implements TaskRepository {
             visibility,
             keyword,
             targetDate,
+            today,
             includeOverdue));
     dataQuery.orderBy(buildOrders(cb, task, pageable.getSort()));
 
@@ -174,6 +177,7 @@ class TaskJpaRepositoryAdapter implements TaskRepository {
       @Nullable Visibility visibility,
       @Nullable String keyword,
       LocalDate targetDate,
+      LocalDate today,
       boolean includeOverdue) {
 
     CriteriaQuery<Long> countQuery = cb.createQuery(Long.class);
@@ -192,6 +196,7 @@ class TaskJpaRepositoryAdapter implements TaskRepository {
                 visibility,
                 keyword,
                 targetDate,
+                today,
                 includeOverdue));
     Long result = em.createQuery(countQuery).getSingleResult();
     return result != null ? result : 0L;
@@ -208,12 +213,13 @@ class TaskJpaRepositoryAdapter implements TaskRepository {
       @Nullable Visibility visibility,
       @Nullable String keyword,
       LocalDate targetDate,
+      LocalDate today,
       boolean includeOverdue) {
 
     List<Predicate> predicates = new ArrayList<>();
     predicates.add(cb.isNull(task.get("deletedAt")));
     predicates.add(buildAuthPredicate(cb, query, task, userId));
-    predicates.add(buildTargetDatePredicate(cb, task, targetDate, includeOverdue));
+    predicates.add(buildTargetDatePredicate(cb, task, targetDate, today, includeOverdue));
 
     if (statuses != null && !statuses.isEmpty()) {
       predicates.add(task.get("status").in(statuses));
@@ -258,20 +264,25 @@ class TaskJpaRepositoryAdapter implements TaskRepository {
   }
 
   /**
-   * 表示対象日フィルタ述語(#665 / #666 共通)。
+   * 表示対象日フィルタ述語(#665 / #666 / #667 共通)。
    *
-   * <p>{@code includeOverdue == true}: 当日(due_date = targetDate)+ 期限切れ未完了(due_date &lt; targetDate
-   * かつ status != DONE)。{@code includeOverdue == false}: 当日のみ。
+   * <p>{@code includeOverdue == true}: 選択日(due_date = targetDate)+ 期限切れ未完了(due_date &lt; today かつ
+   * status != DONE)。期限切れ判定は選択日ではなく <strong>当日 {@code today}</strong> を基準とし、選択日に関わらず常時含める(#667、
+   * 基本設計書 §3.3.1)。{@code includeOverdue == false}: 選択日のみ。
    */
   private Predicate buildTargetDatePredicate(
-      CriteriaBuilder cb, Root<TaskJpaEntity> task, LocalDate targetDate, boolean includeOverdue) {
+      CriteriaBuilder cb,
+      Root<TaskJpaEntity> task,
+      LocalDate targetDate,
+      LocalDate today,
+      boolean includeOverdue) {
     Predicate dueOnTarget = cb.equal(task.get("dueDate"), targetDate);
     if (!includeOverdue) {
       return dueOnTarget;
     }
     Predicate overdue =
         cb.and(
-            cb.lessThan(task.get("dueDate"), targetDate),
+            cb.lessThan(task.get("dueDate"), today),
             cb.notEqual(task.get("status"), TaskStatus.DONE));
     return cb.or(dueOnTarget, overdue);
   }

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/usecase/ListTasksUseCase.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/usecase/ListTasksUseCase.java
@@ -31,10 +31,10 @@ public class ListTasksUseCase {
    * @param assigneeId 絞込担当者 ID(null = 全担当者)
    * @param visibility 絞込公開範囲(null = 全公開範囲)
    * @param keyword タイトル・説明部分一致検索キーワード(null / 空白のみ = 検索しない、#669)
-   * @param targetDate 表示対象日(基準日)。null のときは当日(JST、ADR-0009)に解決する
-   * @param includeOverdue 期限切れ未完了タスクを含めるか
+   * @param targetDate 表示対象日(選択日)。null のときは当日(JST、ADR-0009)に解決する
+   * @param includeOverdue 期限切れ未完了タスクを含めるか(期限切れは選択日に関わらず当日基準で常時含める、#667)
    * @param pageable ページング / ソート指定
-   * @return ページ結果と基準日時点の期限切れ未完了タスク件数
+   * @return ページ結果と当日時点の期限切れ未完了タスク件数
    */
   @Observed(name = "task.list")
   @Transactional(readOnly = true)
@@ -49,7 +49,8 @@ public class ListTasksUseCase {
       boolean includeOverdue,
       Pageable pageable) {
 
-    LocalDate effectiveDate = targetDate != null ? targetDate : LocalDate.now(clock);
+    LocalDate today = LocalDate.now(clock);
+    LocalDate effectiveDate = targetDate != null ? targetDate : today;
 
     Page<Task> taskPage =
         taskRepository.findVisibleTasks(
@@ -60,10 +61,11 @@ public class ListTasksUseCase {
             visibility,
             keyword,
             effectiveDate,
+            today,
             includeOverdue,
             pageable);
 
-    long overdueCount = taskRepository.countOverdueTasks(userId, effectiveDate);
+    long overdueCount = taskRepository.countOverdueTasks(userId, today);
 
     return new Result(taskPage, Math.toIntExact(overdueCount));
   }

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/usecase/TaskRepository.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/usecase/TaskRepository.java
@@ -38,16 +38,18 @@ public interface TaskRepository {
    * <p>Hibernate Filter による tenant_id 自動絞込 + deleted_at IS NULL + visibility 3 役割評価(ADR-0005)を
    * 適用する。priority ソートは HIGH=3 / MEDIUM=2 / LOW=1 に内部変換。desc ソートで HIGH が先頭(重要度高い順)。
    *
-   * <p>表示対象日フィルタ(#665 / #666 共通):
+   * <p>表示対象日フィルタ(#665 / #666 / #667 共通):
    *
    * <ul>
    *   <li>{@code includeOverdue == true}: {@code due_date = targetDate} または 「{@code due_date <
-   *       targetDate} かつ未完了(status != DONE)」のタスク(当日 + 期限切れ)
+   *       today} かつ未完了(status != DONE)」のタスク(選択日 + 期限切れ)。期限切れ判定は選択日 {@code targetDate} ではなく
+   *       <strong>当日 {@code today}</strong> を基準とし、選択日に関わらず常時含める(#667、基本設計書 §3.3.1)。
    *   <li>{@code includeOverdue == false}: {@code due_date = targetDate} のタスクのみ
    * </ul>
    *
    * @param keyword タイトル・説明の部分一致検索キーワード(null / 空白のみ = 検索しない、#669)
-   * @param targetDate 表示対象日(基準日)。{@code null} 不可(usecase で当日に解決済み)。
+   * @param targetDate 表示対象日(選択日)。{@code null} 不可(usecase で当日に解決済み)。
+   * @param today 期限切れ判定の基準となる当日(JST、ADR-0009)。{@code null} 不可。
    * @param includeOverdue 期限切れ未完了タスクを含めるか
    */
   Page<Task> findVisibleTasks(
@@ -58,11 +60,12 @@ public interface TaskRepository {
       @Nullable Visibility visibility,
       @Nullable String keyword,
       LocalDate targetDate,
+      LocalDate today,
       boolean includeOverdue,
       Pageable pageable);
 
-  /** 認可フィルタを適用した、基準日時点の期限切れ未完了タスク件数({@code due_date < targetDate})を返す。 */
-  long countOverdueTasks(Long userId, LocalDate targetDate);
+  /** 認可フィルタを適用した、当日時点の期限切れ未完了タスク件数({@code due_date < today} かつ status != DONE)を返す(#667)。 */
+  long countOverdueTasks(Long userId, LocalDate today);
 
   /** タスクを論理削除する(deleted_at セット)。楽観ロック競合時は PreconditionFailedException を投げる。 */
   void softDelete(Task task, LocalDateTime deletedAt);

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/adapter/web/ListTasksIT.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/adapter/web/ListTasksIT.java
@@ -1,11 +1,13 @@
 package xyz.dgz48.tasks.webapi.task.adapter.web;
 
+import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import jakarta.persistence.EntityManager;
+import java.time.Clock;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -18,6 +20,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.context.annotation.Import;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.support.TransactionTemplate;
 import xyz.dgz48.tasks.webapi.FixedClockConfiguration;
@@ -25,6 +28,7 @@ import xyz.dgz48.tasks.webapi.MockJwtDecoderConfiguration;
 import xyz.dgz48.tasks.webapi.TestcontainersConfiguration;
 import xyz.dgz48.tasks.webapi.security.adapter.web.TasksAuthenticationToken;
 import xyz.dgz48.tasks.webapi.security.domain.TasksPrincipal;
+import xyz.dgz48.tasks.webapi.shared.infra.AppZones;
 import xyz.dgz48.tasks.webapi.task.adapter.persistence.TaskJpaEntity;
 import xyz.dgz48.tasks.webapi.task.domain.Priority;
 import xyz.dgz48.tasks.webapi.task.domain.TaskStatus;
@@ -49,7 +53,13 @@ class ListTasksIT {
   @Autowired EntityManager em;
   @Autowired TransactionTemplate txTemplate;
 
-  /** 固定クロック(FixedClockConfiguration)の当日(JST 2026-01-15)。 */
+  /**
+   * {@code ListTasksUseCase} が注入する {@link Clock} を固定し、期限切れ判定(#667)の基準となる当日({@code
+   * LocalDate.now(clock)})を {@link #TODAY} に一致させる。これにより「選択日に関わらず当日基準で期限切れを表示」を決定論的に検証できる。
+   */
+  @MockitoBean Clock clock;
+
+  /** 固定クロックの当日(JST 2026-01-15)。期限切れ判定(#667)が決定論的になるよう Clock を固定する。 */
   private static final LocalDate TODAY = LocalDate.of(2026, 1, 15);
 
   // User A: viewer(target user)
@@ -69,6 +79,10 @@ class ListTasksIT {
 
   @BeforeEach
   void setUp() {
+    when(clock.getZone()).thenReturn(AppZones.JST);
+    when(clock.instant())
+        .thenReturn(FixedClockConfiguration.FIXED_NOW.atZone(AppZones.JST).toInstant());
+
     txTemplate.execute(
         ignored -> {
           var userA =
@@ -640,6 +654,30 @@ class ListTasksIT {
           .andExpect(status().isOk())
           .andExpect(jsonPath("$.content[?(@.id == " + futureTaskId + ")]").exists())
           .andExpect(jsonPath("$.content[?(@.id == " + todayTaskId + ")]").doesNotExist());
+    }
+
+    @Test
+    void overdueAlwaysShown_whenTargetDateIsFuture() throws Exception {
+      // #667: 未来日を選択しても、期限切れ未完了タスクは当日(TODAY)基準で常時上部に表示される。
+      // 期限切れ判定は選択日ではなく当日基準のため、当日タスクは未来日ビューに現れない。
+      mockMvc
+          .perform(
+              get("/api/tasks")
+                  .header("X-Tenant-Id", String.valueOf(tenantId))
+                  .param("targetDate", TODAY.plusDays(10).toString())
+                  .with(authentication(authTokenA)))
+          .andExpect(status().isOk())
+          // 選択日(未来)のタスク
+          .andExpect(jsonPath("$.content[?(@.id == " + futureTaskId + ")]").exists())
+          // 期限切れ未完了は選択日に関わらず常時表示
+          .andExpect(jsonPath("$.content[?(@.id == " + overdueTaskId + ")]").exists())
+          // 当日タスクは当日基準では期限切れでなく、選択日(未来)とも一致しないため現れない
+          .andExpect(jsonPath("$.content[?(@.id == " + todayTaskId + ")]").doesNotExist())
+          // 完了済の期限切れは除外
+          .andExpect(jsonPath("$.content[?(@.id == " + overdueDoneTaskId + ")]").doesNotExist())
+          // overdueCount は当日基準で算出される(選択日に依存しない)
+          .andExpect(
+              jsonPath("$.overdueCount").value(org.hamcrest.Matchers.greaterThanOrEqualTo(1)));
     }
 
     @Test

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/usecase/ListTasksUseCaseTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/usecase/ListTasksUseCaseTest.java
@@ -79,6 +79,7 @@ class ListTasksUseCaseTest {
             isNull(),
             isNull(),
             eq(TODAY),
+            eq(TODAY),
             eq(true),
             eq(pageable)))
         .thenReturn(taskPage);
@@ -108,6 +109,7 @@ class ListTasksUseCaseTest {
             eq(visibility),
             isNull(),
             eq(TODAY),
+            eq(TODAY),
             eq(true),
             eq(pageable)))
         .thenReturn(Page.empty(pageable));
@@ -135,6 +137,7 @@ class ListTasksUseCaseTest {
             isNull(),
             eq(keyword),
             eq(TODAY),
+            eq(TODAY),
             eq(true),
             eq(pageable)))
         .thenReturn(new PageImpl<>(List.of(buildTask(1L)), pageable, 1));
@@ -147,11 +150,38 @@ class ListTasksUseCaseTest {
   }
 
   @Test
+  void execute_anchorsOverdueToToday_notTargetDate() {
+    // #667: 未来日を選択しても期限切れ判定・件数は当日(TODAY)基準。
+    setupClock();
+    Pageable pageable = PageRequest.of(0, 10);
+    LocalDate future = TODAY.plusDays(10);
+
+    when(taskRepository.findVisibleTasks(
+            eq(USER_ID),
+            isNull(),
+            isNull(),
+            isNull(),
+            isNull(),
+            isNull(),
+            eq(future), // targetDate(選択日)
+            eq(TODAY), // today(期限切れ基準)
+            eq(true),
+            eq(pageable)))
+        .thenReturn(Page.empty(pageable));
+    when(taskRepository.countOverdueTasks(eq(USER_ID), eq(TODAY))).thenReturn(2L);
+
+    ListTasksUseCase.Result result =
+        useCase.execute(USER_ID, null, null, null, null, null, future, true, pageable);
+
+    assertThat(result.overdueCount()).isEqualTo(2);
+  }
+
+  @Test
   void execute_returnsEmptyPage_whenRepositoryReturnsEmpty() {
     setupClock();
     Pageable pageable = PageRequest.of(0, 50);
     when(taskRepository.findVisibleTasks(
-            any(), any(), any(), any(), any(), any(), any(), anyBoolean(), any()))
+            any(), any(), any(), any(), any(), any(), any(), any(), anyBoolean(), any()))
         .thenReturn(Page.empty(pageable));
     when(taskRepository.countOverdueTasks(any(), any())).thenReturn(0L);
 


### PR DESCRIPTION
## 概要

選択日(#666 の日付ナビ)に関わらず、**期限切れ未完了タスク(`due_date < 当日` かつ status ≠ DONE)を常時上部に表示**する(基本設計書 §3.3.1「期限切れセクションは日付フィルタの上に常時表示」)。

従来(#665/#666)は期限切れ判定を選択日 `targetDate` 基準にしていたため、未来日を選ぶと当日タスクが期限切れ扱いになる等のズレがあった。本 PR で判定基準を**当日 `today`**(JST、ADR-0009)へ統一し、OpenAPI 契約(`overdue = due_date < 今日 AND status ≠ DONE`)とも整合させた。

## 変更点

### backend
- `ListTasksUseCase`: `today = LocalDate.now(clock)` を算出し、`findVisibleTasks` の期限切れ基準・`countOverdueTasks` に当日を渡す(選択日とは独立)。
- `TaskRepository#findVisibleTasks`: `today` 引数を追加。overdue 述語を `due_date < today AND status != DONE` に変更(`includeOverdue=true` 時に選択日タスクと union)。
- `countOverdueTasks` は当日基準(変更なし、呼び出し側で today を渡すよう修正)。

### frontend
- `renderTasks`: 期限切れ/選択日の振り分けを当日基準(`dueDate < today かつ status !== 'DONE'`)へ。期限切れセクションは引き続き常時描画。

### docs
- OpenAPI: `includeOverdue` / `overdueCount` の説明を当日基準へ明確化。

### test
- `ListTasksUseCaseTest`: 未来日選択でも overdue は当日基準であることを検証。
- `ListTasksIT`: `Clock` を `@MockitoBean` で固定し、未来日選択時も期限切れが常時表示され当日タスクは出ないことを検証(+ 既存テストの当日基準整合)。
- `e2e/tasks.spec.ts`: 期限=前日タスクが選択日を切り替えても常時表示されることを検証。

## 確認
- `./gradlew :webapi:check` green
- `web/` は `npx biome ci .` green(tsc/html-validate は CI で実行)

Closes #667