### PR TITLE
feat(task): タスク優先度フィルタ(絞り込み)を実装(#668)

### DIFF
--- a/e2e/tests/tasks.spec.ts
+++ b/e2e/tests/tasks.spec.ts
@@ -71,6 +71,47 @@ test.describe('タスク一覧 + CRUD', () => {
     await expect(page.locator('#task-tbody')).not.toContainText(taskTitle, { timeout: 10_000 });
   });
 
+  // #668 — 優先度フィルタ
+  test('優先度フィルタで該当優先度のタスクのみ表示される', async ({ page }) => {
+    const taskTitle = `E2E priority ${Date.now()}`;
+    const today = new Intl.DateTimeFormat('en-CA', {
+      timeZone: 'Asia/Tokyo',
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    }).format(new Date());
+
+    // 期限=当日・優先度=HIGH のタスクを作成
+    await page.click('#btn-new-task');
+    const drawer = page.locator('app-task-drawer .offcanvas');
+    await expect(drawer).toBeVisible({ timeout: 5_000 });
+    await page.fill('#newTitle', taskTitle);
+    await page.fill('#newDue', today);
+    await drawer.locator('label[for="newPri-HIGH"]').click();
+    await drawer.locator('button[type="submit"]').click();
+    await expect(drawer).not.toBeVisible({ timeout: 10_000 });
+    await expect(page.locator('#task-tbody')).toContainText(taskTitle, { timeout: 10_000 });
+
+    // 優先度フィルタ=低 → HIGH タスクは消える
+    await page.selectOption('#priorityFilter', 'LOW');
+    await expect(page.locator('#task-tbody')).not.toContainText(taskTitle, { timeout: 10_000 });
+
+    // 優先度フィルタ=高 → 再び表示される
+    await page.selectOption('#priorityFilter', 'HIGH');
+    await expect(page.locator('#task-tbody')).toContainText(taskTitle, { timeout: 10_000 });
+
+    // 後始末: フィルタを戻して作成タスクを削除
+    await page.selectOption('#priorityFilter', '');
+    const taskRow = page.locator('app-task-row').filter({
+      has: page.locator('.task-title', { hasText: taskTitle }),
+    });
+    await taskRow.locator('td.cell-owner').click();
+    await expect(drawer).toBeVisible({ timeout: 5_000 });
+    await drawer.locator('.btn-outline-danger').click();
+    await drawer.locator('button.btn-danger').click();
+    await expect(drawer).not.toBeVisible({ timeout: 5_000 });
+  });
+
   // #666 — 表示基準日の前後切替
   test('表示基準日を切り替えると当該日のタスクが表示される', async ({ page }) => {
     const taskTitle = `E2E datenav ${Date.now()}`;

--- a/web/js/tasks.js
+++ b/web/js/tasks.js
@@ -4,6 +4,7 @@ let currentSort = 'dueDate,asc';
 let totalPages = 1;
 let totalElements = 0;
 let currentKeyword = ''; // タスク検索キーワード(タイトル・説明部分一致、#669)
+let currentPriority = ''; // 優先度絞込 ('' = すべて, HIGH / MEDIUM / LOW, #668)
 let overdueTotal = 0;
 let currentTargetDate = ''; // 表示対象日 (YYYY-MM-DD, JST)
 const PAGE_SIZE = 50;
@@ -286,6 +287,7 @@ async function loadTasks() {
       size: PAGE_SIZE,
       sort: currentSort,
       keyword: currentKeyword || undefined,
+      priority: currentPriority || undefined,
       targetDate: currentTargetDate,
       includeOverdue: true,
     });
@@ -304,6 +306,15 @@ async function loadTasks() {
     /** @type {HTMLElement} */ (mustQuery(document, '#loading-skeleton')).classList.add('d-none');
     errorBanner.show(/** @type {any} */ (err).message || 'タスクの取得に失敗しました');
   }
+}
+
+// ---- Priority filter (#668, GET /api/tasks?priority=) ----
+/** @param {string} value — '' | HIGH | MEDIUM | LOW */
+function onPriorityFilterChange(value) {
+  if (value === currentPriority) return;
+  currentPriority = value;
+  currentPage = 0;
+  loadTasks();
 }
 
 // ---- Sort ----
@@ -449,6 +460,10 @@ pager.addEventListener('page-change', (e) => {
 );
 /** @type {HTMLElement} */ (mustQuery(document, '#sortSel')).addEventListener('change', (e) =>
   onSortChange(/** @type {HTMLSelectElement} */ (e.target).value),
+);
+/** @type {HTMLElement} */ (mustQuery(document, '#priorityFilter')).addEventListener(
+  'change',
+  (e) => onPriorityFilterChange(/** @type {HTMLSelectElement} */ (e.target).value),
 );
 /** @type {HTMLElement} */ (mustQuery(document, '#btn-new-task')).addEventListener('click', () =>
   // 新規タスクの期限初期値は表示中の日付(基本設計書 §3.3.1)。

--- a/web/tasks.html
+++ b/web/tasks.html
@@ -78,6 +78,15 @@
             </button>
           </div>
         </form>
+        <label for="priorityFilter" class="text-muted small mb-0">
+          <i class="bi bi-flag me-1" aria-hidden="true"></i>優先度
+        </label>
+        <select id="priorityFilter" class="form-select form-select-sm w-auto">
+          <option value="">すべて</option>
+          <option value="HIGH">高</option>
+          <option value="MEDIUM">中</option>
+          <option value="LOW">低</option>
+        </select>
         <label for="sortSel" class="text-muted small mb-0">
           <i class="bi bi-sort-down me-1" aria-hidden="true"></i>並び替え
         </label>

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/adapter/persistence/TaskJpaRepositoryAdapter.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/adapter/persistence/TaskJpaRepositoryAdapter.java
@@ -97,6 +97,7 @@ class TaskJpaRepositoryAdapter implements TaskRepository {
       @Nullable Long ownerId,
       @Nullable Long assigneeId,
       @Nullable Visibility visibility,
+      @Nullable Priority priority,
       @Nullable String keyword,
       LocalDate targetDate,
       LocalDate today,
@@ -113,6 +114,7 @@ class TaskJpaRepositoryAdapter implements TaskRepository {
             ownerId,
             assigneeId,
             visibility,
+            priority,
             keyword,
             targetDate,
             today,
@@ -133,6 +135,7 @@ class TaskJpaRepositoryAdapter implements TaskRepository {
             ownerId,
             assigneeId,
             visibility,
+            priority,
             keyword,
             targetDate,
             today,
@@ -175,6 +178,7 @@ class TaskJpaRepositoryAdapter implements TaskRepository {
       @Nullable Long ownerId,
       @Nullable Long assigneeId,
       @Nullable Visibility visibility,
+      @Nullable Priority priority,
       @Nullable String keyword,
       LocalDate targetDate,
       LocalDate today,
@@ -194,6 +198,7 @@ class TaskJpaRepositoryAdapter implements TaskRepository {
                 ownerId,
                 assigneeId,
                 visibility,
+                priority,
                 keyword,
                 targetDate,
                 today,
@@ -211,6 +216,7 @@ class TaskJpaRepositoryAdapter implements TaskRepository {
       @Nullable Long ownerId,
       @Nullable Long assigneeId,
       @Nullable Visibility visibility,
+      @Nullable Priority priority,
       @Nullable String keyword,
       LocalDate targetDate,
       LocalDate today,
@@ -232,6 +238,9 @@ class TaskJpaRepositoryAdapter implements TaskRepository {
     }
     if (visibility != null) {
       predicates.add(cb.equal(task.get("visibility"), visibility));
+    }
+    if (priority != null) {
+      predicates.add(cb.equal(task.get("priority"), priority));
     }
     Predicate keywordPredicate = buildKeywordPredicate(cb, task, keyword);
     if (keywordPredicate != null) {

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/adapter/web/TaskController.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/adapter/web/TaskController.java
@@ -46,6 +46,7 @@ import xyz.dgz48.tasks.webapi.task.adapter.web.dto.TaskListItemResponse;
 import xyz.dgz48.tasks.webapi.task.adapter.web.dto.TaskPageResponse;
 import xyz.dgz48.tasks.webapi.task.adapter.web.dto.TaskPatchRequest;
 import xyz.dgz48.tasks.webapi.task.adapter.web.dto.TaskResponse;
+import xyz.dgz48.tasks.webapi.task.domain.Priority;
 import xyz.dgz48.tasks.webapi.task.domain.Task;
 import xyz.dgz48.tasks.webapi.task.domain.TaskPatchCommand;
 import xyz.dgz48.tasks.webapi.task.domain.TaskStakeholder;
@@ -114,7 +115,7 @@ public class TaskController {
    * タスク一覧取得(operationId: listTasks)。
    *
    * <p>表示対象日(targetDate、省略時は当日 TODAY)を基準に、当日 + 期限切れ未完了(includeOverdue=true、デフォルト)の タスクを返す(S-04 /
-   * 基本設計書 §3.3.1、#665 / #666 共通)。keyword 絞込(タイトル・説明部分一致)は #669 で実装済。priority 絞込は別 Issue で実装予定。
+   * 基本設計書 §3.3.1、#665 / #666 共通)。keyword 絞込(タイトル・説明部分一致)は #669、priority 絞込は #668 で実装済。
    */
   @GetMapping
   @PreAuthorize("hasAnyRole('TENANT_ADMIN', 'MEMBER')")
@@ -129,7 +130,7 @@ public class TaskController {
       @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
           @Nullable LocalDate targetDate,
       @RequestParam(defaultValue = "true") boolean includeOverdue,
-      @RequestParam(required = false) @Nullable String priority,
+      @RequestParam(required = false) @Nullable Priority priority,
       @RequestParam(required = false) @Nullable String keyword,
       TasksAuthenticationToken token) {
 
@@ -143,6 +144,7 @@ public class TaskController {
             ownerId,
             assigneeId,
             visibility,
+            priority,
             keyword,
             targetDate,
             includeOverdue,

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/usecase/ListTasksUseCase.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/usecase/ListTasksUseCase.java
@@ -10,6 +10,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import xyz.dgz48.tasks.webapi.task.domain.Priority;
 import xyz.dgz48.tasks.webapi.task.domain.Task;
 import xyz.dgz48.tasks.webapi.task.domain.TaskStatus;
 import xyz.dgz48.tasks.webapi.task.domain.Visibility;
@@ -30,6 +31,7 @@ public class ListTasksUseCase {
    * @param ownerId 絞込所有者 ID(null = 全所有者)
    * @param assigneeId 絞込担当者 ID(null = 全担当者)
    * @param visibility 絞込公開範囲(null = 全公開範囲)
+   * @param priority 絞込優先度(null = 全優先度、#668)
    * @param keyword タイトル・説明部分一致検索キーワード(null / 空白のみ = 検索しない、#669)
    * @param targetDate 表示対象日(選択日)。null のときは当日(JST、ADR-0009)に解決する
    * @param includeOverdue 期限切れ未完了タスクを含めるか(期限切れは選択日に関わらず当日基準で常時含める、#667)
@@ -44,6 +46,7 @@ public class ListTasksUseCase {
       @Nullable Long ownerId,
       @Nullable Long assigneeId,
       @Nullable Visibility visibility,
+      @Nullable Priority priority,
       @Nullable String keyword,
       @Nullable LocalDate targetDate,
       boolean includeOverdue,
@@ -59,6 +62,7 @@ public class ListTasksUseCase {
             ownerId,
             assigneeId,
             visibility,
+            priority,
             keyword,
             effectiveDate,
             today,

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/usecase/TaskRepository.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/task/usecase/TaskRepository.java
@@ -47,6 +47,7 @@ public interface TaskRepository {
    *   <li>{@code includeOverdue == false}: {@code due_date = targetDate} のタスクのみ
    * </ul>
    *
+   * @param priority 絞込優先度(null = 全優先度、#668)
    * @param keyword タイトル・説明の部分一致検索キーワード(null / 空白のみ = 検索しない、#669)
    * @param targetDate 表示対象日(選択日)。{@code null} 不可(usecase で当日に解決済み)。
    * @param today 期限切れ判定の基準となる当日(JST、ADR-0009)。{@code null} 不可。
@@ -58,6 +59,7 @@ public interface TaskRepository {
       @Nullable Long ownerId,
       @Nullable Long assigneeId,
       @Nullable Visibility visibility,
+      @Nullable Priority priority,
       @Nullable String keyword,
       LocalDate targetDate,
       LocalDate today,

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/SecurityConfigTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/SecurityConfigTest.java
@@ -112,7 +112,7 @@ class SecurityConfigTest {
         .willReturn(Optional.of(new TenantMembership(1L, TenantRole.MEMBER)));
     given(
             listTasksUseCase.execute(
-                any(), any(), any(), any(), any(), any(), any(), anyBoolean(), any()))
+                any(), any(), any(), any(), any(), any(), any(), any(), anyBoolean(), any()))
         .willReturn(new ListTasksUseCase.Result(Page.empty(PageRequest.of(0, 50)), 0));
   }
 

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/adapter/web/ListTasksIT.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/adapter/web/ListTasksIT.java
@@ -434,6 +434,48 @@ class ListTasksIT {
     }
 
     @Test
+    void priorityFilter_returnsOnlyMatchingPriority() throws Exception {
+      // #668: priority=HIGH は stakeholderTask(HIGH)のみ返し、MEDIUM / LOW のタスクは除外する。
+      mockMvc
+          .perform(
+              get("/api/tasks")
+                  .header("X-Tenant-Id", String.valueOf(tenantId))
+                  .param("priority", "HIGH")
+                  .with(authentication(authTokenA)))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.content[?(@.id == " + stakeholderTaskId + ")]").exists())
+          .andExpect(jsonPath("$.content[?(@.id == " + tenantTaskId + ")]").doesNotExist())
+          .andExpect(jsonPath("$.content[?(@.priority != 'HIGH')]").doesNotExist());
+    }
+
+    @Test
+    void priorityFilter_low_returnsOnlyLowPriority() throws Exception {
+      // #668: priority=LOW は privateTaskOwnedByA(LOW、Aが所有者)を返す。
+      mockMvc
+          .perform(
+              get("/api/tasks")
+                  .header("X-Tenant-Id", String.valueOf(tenantId))
+                  .param("priority", "LOW")
+                  .with(authentication(authTokenA)))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.content[?(@.id == " + privateTaskOwnedByAId + ")]").exists())
+          .andExpect(jsonPath("$.content[?(@.id == " + stakeholderTaskId + ")]").doesNotExist())
+          .andExpect(jsonPath("$.content[?(@.priority != 'LOW')]").doesNotExist());
+    }
+
+    @Test
+    void priorityFilter_invalid_returns400() throws Exception {
+      // #668: 不正な priority 値は enum バインド失敗で 400。
+      mockMvc
+          .perform(
+              get("/api/tasks")
+                  .header("X-Tenant-Id", String.valueOf(tenantId))
+                  .param("priority", "URGENT")
+                  .with(authentication(authTokenA)))
+          .andExpect(status().isBadRequest());
+    }
+
+    @Test
     void keywordFilter_matchesTitlePartial() throws Exception {
       // "STAKEHOLDERS" は stakeholderTask のタイトルにのみ含まれる(#669)
       mockMvc

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/adapter/web/TaskControllerWebMvcTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/adapter/web/TaskControllerWebMvcTest.java
@@ -354,6 +354,7 @@ class TaskControllerWebMvcTest {
                 ArgumentMatchers.isNull(),
                 ArgumentMatchers.isNull(),
                 ArgumentMatchers.isNull(),
+                ArgumentMatchers.isNull(),
                 ArgumentMatchers.eq(true),
                 ArgumentMatchers.any()))
         .willReturn(result);
@@ -386,6 +387,7 @@ class TaskControllerWebMvcTest {
                 ArgumentMatchers.isNull(),
                 ArgumentMatchers.isNull(),
                 ArgumentMatchers.isNull(),
+                ArgumentMatchers.isNull(),
                 ArgumentMatchers.eq(LocalDate.of(2026, 6, 7)),
                 ArgumentMatchers.eq(false),
                 ArgumentMatchers.any()))
@@ -397,6 +399,40 @@ class TaskControllerWebMvcTest {
         .perform(
             get("/api/tasks").param("targetDate", "2026-06-07").param("includeOverdue", "false"))
         .andExpect(status().isOk());
+  }
+
+  @Test
+  @WithMockMember
+  void listTasks_bindsPriorityFilter() throws Exception {
+    // #668: ?priority=HIGH が usecase の priority 引数へバインドされること。
+    Page<Task> taskPage = new PageImpl<>(List.of(), PageRequest.of(0, 50), 0);
+    ListTasksUseCase.Result result = new ListTasksUseCase.Result(taskPage, 0);
+    BDDMockito.given(
+            listTasksUseCase.execute(
+                ArgumentMatchers.eq(USER_ID),
+                ArgumentMatchers.isNull(),
+                ArgumentMatchers.isNull(),
+                ArgumentMatchers.isNull(),
+                ArgumentMatchers.isNull(),
+                ArgumentMatchers.eq(Priority.HIGH),
+                ArgumentMatchers.isNull(),
+                ArgumentMatchers.isNull(),
+                ArgumentMatchers.eq(true),
+                ArgumentMatchers.any()))
+        .willReturn(result);
+    BDDMockito.given(userRepository.findAllById(ArgumentMatchers.anyCollection()))
+        .willReturn(List.of());
+
+    mockMvc.perform(get("/api/tasks").param("priority", "HIGH")).andExpect(status().isOk());
+  }
+
+  @Test
+  @WithMockMember
+  void listTasks_returns400_whenPriorityInvalid() throws Exception {
+    // #668: 不正な priority 値は enum バインド失敗で 400。
+    mockMvc
+        .perform(get("/api/tasks").param("priority", "URGENT"))
+        .andExpect(status().isBadRequest());
   }
 
   @Test
@@ -430,6 +466,7 @@ class TaskControllerWebMvcTest {
     BDDMockito.given(
             listTasksUseCase.execute(
                 ArgumentMatchers.anyLong(),
+                ArgumentMatchers.any(),
                 ArgumentMatchers.any(),
                 ArgumentMatchers.any(),
                 ArgumentMatchers.any(),

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/usecase/ListTasksUseCaseTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/usecase/ListTasksUseCaseTest.java
@@ -78,6 +78,7 @@ class ListTasksUseCaseTest {
             isNull(),
             isNull(),
             isNull(),
+            isNull(),
             eq(TODAY),
             eq(TODAY),
             eq(true),
@@ -86,7 +87,7 @@ class ListTasksUseCaseTest {
     when(taskRepository.countOverdueTasks(eq(USER_ID), eq(TODAY))).thenReturn(3L);
 
     ListTasksUseCase.Result result =
-        useCase.execute(USER_ID, null, null, null, null, null, null, true, pageable);
+        useCase.execute(USER_ID, null, null, null, null, null, null, null, true, pageable);
 
     assertThat(result.taskPage().getContent()).hasSize(2);
     assertThat(result.overdueCount()).isEqualTo(3);
@@ -108,6 +109,7 @@ class ListTasksUseCaseTest {
             eq(assigneeId),
             eq(visibility),
             isNull(),
+            isNull(),
             eq(TODAY),
             eq(TODAY),
             eq(true),
@@ -117,10 +119,37 @@ class ListTasksUseCaseTest {
 
     ListTasksUseCase.Result result =
         useCase.execute(
-            USER_ID, statuses, ownerId, assigneeId, visibility, null, null, true, pageable);
+            USER_ID, statuses, ownerId, assigneeId, visibility, null, null, null, true, pageable);
 
     assertThat(result.taskPage().getContent()).isEmpty();
     assertThat(result.overdueCount()).isZero();
+  }
+
+  @Test
+  void execute_passesPriorityToRepository() {
+    // #668: priority 絞込が repository へ透過的に渡されること。
+    setupClock();
+    Pageable pageable = PageRequest.of(0, 10);
+
+    when(taskRepository.findVisibleTasks(
+            eq(USER_ID),
+            isNull(),
+            isNull(),
+            isNull(),
+            isNull(),
+            eq(Priority.HIGH),
+            isNull(),
+            eq(TODAY),
+            eq(TODAY),
+            eq(true),
+            eq(pageable)))
+        .thenReturn(new PageImpl<>(List.of(buildTask(1L)), pageable, 1));
+    when(taskRepository.countOverdueTasks(any(), any())).thenReturn(0L);
+
+    ListTasksUseCase.Result result =
+        useCase.execute(USER_ID, null, null, null, null, Priority.HIGH, null, null, true, pageable);
+
+    assertThat(result.taskPage().getContent()).hasSize(1);
   }
 
   @Test
@@ -135,6 +164,7 @@ class ListTasksUseCaseTest {
             isNull(),
             isNull(),
             isNull(),
+            isNull(),
             eq(keyword),
             eq(TODAY),
             eq(TODAY),
@@ -144,7 +174,7 @@ class ListTasksUseCaseTest {
     when(taskRepository.countOverdueTasks(any(), any())).thenReturn(0L);
 
     ListTasksUseCase.Result result =
-        useCase.execute(USER_ID, null, null, null, null, keyword, null, true, pageable);
+        useCase.execute(USER_ID, null, null, null, null, null, keyword, null, true, pageable);
 
     assertThat(result.taskPage().getContent()).hasSize(1);
   }
@@ -163,6 +193,7 @@ class ListTasksUseCaseTest {
             isNull(),
             isNull(),
             isNull(),
+            isNull(),
             eq(future), // targetDate(選択日)
             eq(TODAY), // today(期限切れ基準)
             eq(true),
@@ -171,7 +202,7 @@ class ListTasksUseCaseTest {
     when(taskRepository.countOverdueTasks(eq(USER_ID), eq(TODAY))).thenReturn(2L);
 
     ListTasksUseCase.Result result =
-        useCase.execute(USER_ID, null, null, null, null, null, future, true, pageable);
+        useCase.execute(USER_ID, null, null, null, null, null, null, future, true, pageable);
 
     assertThat(result.overdueCount()).isEqualTo(2);
   }
@@ -181,12 +212,12 @@ class ListTasksUseCaseTest {
     setupClock();
     Pageable pageable = PageRequest.of(0, 50);
     when(taskRepository.findVisibleTasks(
-            any(), any(), any(), any(), any(), any(), any(), any(), anyBoolean(), any()))
+            any(), any(), any(), any(), any(), any(), any(), any(), any(), anyBoolean(), any()))
         .thenReturn(Page.empty(pageable));
     when(taskRepository.countOverdueTasks(any(), any())).thenReturn(0L);
 
     ListTasksUseCase.Result result =
-        useCase.execute(USER_ID, null, null, null, null, null, null, true, pageable);
+        useCase.execute(USER_ID, null, null, null, null, null, null, null, true, pageable);
 
     assertThat(result.taskPage().isEmpty()).isTrue();
     assertThat(result.overdueCount()).isZero();


### PR DESCRIPTION
## 概要

Issue #668(タスク優先度)の受入基準 **設定・表示・ソート** は基盤タスクモデルに既に実装済(DB 列 `V1.0.0_01`、create/PATCH、`app-priority-badge`、`buildPriorityOrder` による HIGH=3/MED=2/LOW=1 ソート、OpenAPI スキーマ)。

本 PR は唯一未配線だった **優先度の絞り込み(filter)** を end-to-end で実装し、優先度機能を完結させる。`TaskController` は従来 `priority` クエリ param を宣言しつつ usecase に渡していなかった(コメント「別 Issue で実装予定」)。

## 変更点

### backend
- `TaskController.listTasks`: `priority` param を `String` → `Priority` enum バインドに変更(`visibility` と同方式、不正値は enum バインド失敗で **400**)し、usecase へ透過。
- `ListTasksUseCase` / `TaskRepository` / `TaskJpaRepositoryAdapter`: `priority` を引数で透過し、Criteria に等価述語 `priority = :priority` を追加(count/data 両クエリ)。

### frontend
- `tasks.html`: 一覧ツールバーに優先度フィルタ `select#priorityFilter`(すべて/高/中/低)を追加。
- `tasks.js`: `currentPriority` 状態を追加し `GET /api/tasks?priority=` へ反映、変更時 1 ページ目から再取得。`api.js` は既存の `params.priority` 対応を利用。

### test
- `ListTasksUseCaseTest`: priority 透過テスト追加 + 既存シグネチャ追随。
- `TaskControllerWebMvcTest`: `?priority=HIGH` バインド(200)/ 不正値(400)。
- `ListTasksIT`: 優先度 HIGH/LOW 絞り込み + 不正値 400 の結合テスト。
- `e2e/tests/tasks.spec.ts`: 優先度フィルタの Playwright スペック追加。

## 非変更(既存のため)
- DB `tasks.priority` 列(`V1.0.0_01` に既存 → **Flyway 追加なし**)。
- OpenAPI の `priority` クエリ param / `Priority` スキーマ。

## 確認
- `./gradlew :webapi:check` green
- `web/`: `npx biome ci .` / `npm run html-validate` / `npx tsc --noEmit` green
- `e2e/`: spec を `npx biome ci` で検証

Closes #668