### PR TITLE
ci(keycloak): JaCoCo 80% 命令カバレッジゲートを設定 (#445)

### DIFF
--- a/.github/workflows/keycloak-ci.yml
+++ b/.github/workflows/keycloak-ci.yml
@@ -150,7 +150,7 @@ jobs:
             TEST_ROW="| テスト結果 ${TEST_ICON} | 合計 ${TOTAL}: 成功 **${PASSED}**, 失敗 $((FAIL + ERR)), スキップ ${SKIP} |"
           fi
 
-          # ── Coverage (report only, no gate) ───────────────────────────
+          # ── Coverage (report; gate is enforced by Gradle jacocoTestCoverageVerification) ──
           JACOCO_XML="keycloak/build/reports/jacoco/test/jacocoTestReport.xml"
           if [ -f "$JACOCO_XML" ]; then
             COVERAGE=$(python3 << 'PYEOF'
@@ -169,7 +169,7 @@ jobs:
               print('N/A')
           PYEOF
             )
-            COV_ROW="| カバレッジ :bar_chart: | 命令カバレッジ **${COVERAGE}%** (参考値・ゲートなし) |"
+            COV_ROW="| カバレッジ :bar_chart: | 命令カバレッジ **${COVERAGE}%** (基準 80%・ゲートあり) |"
           else
             COV_ROW="| カバレッジ :bar_chart: | レポートなし(JaCoCo 未設定) |"
           fi

--- a/keycloak/build.gradle.kts
+++ b/keycloak/build.gradle.kts
@@ -116,6 +116,19 @@ tasks.named<JacocoReport>("jacocoTestReport") {
     }
 }
 
+// webapi と同一基準: 命令(INSTRUCTION)カバレッジ 80%。JaCoCo の rule limit は既定で
+// counter=INSTRUCTION / value=COVEREDRATIO のため、webapi 同様 counter は明示しない。
+tasks.named<JacocoCoverageVerification>("jacocoTestCoverageVerification") {
+    dependsOn(tasks.named("test"))
+    violationRules {
+        rule {
+            limit {
+                minimum = "0.80".toBigDecimal()
+            }
+        }
+    }
+}
+
 spotless {
     lineEndings = com.diffplug.spotless.LineEnding.UNIX
     java {
@@ -124,5 +137,5 @@ spotless {
 }
 
 tasks.named("check") {
-    dependsOn("spotlessCheck")
+    dependsOn("spotlessCheck", "jacocoTestCoverageVerification")
 }


### PR DESCRIPTION
## 概要

keycloak サブプロジェクトに webapi 同等の JaCoCo 80% 命令カバレッジゲートを設定する (#445)。
#444 で「報告のみ・ゲート保留」とした方針を、SPI 本実装に向けてゲート有効化へ切り替える。

## 変更内容

### `keycloak/build.gradle.kts`
- `jacocoTestCoverageVerification`(命令カバレッジ 80%)を追加
  - JaCoCo の rule limit は既定で `counter=INSTRUCTION` / `value=COVEREDRATIO` のため、webapi 同様 counter は明示せず `minimum = 0.80` のみ指定(基準を webapi と一致させる)
- `check` が `jacocoTestCoverageVerification` に依存するよう配線(webapi 準拠)
- `jacoco` plugin / `jacocoTestReport` は #444 で設定済みのため今回はゲート部分のみ追加

### `.github/workflows/keycloak-ci.yml`
- CI レポートのカバレッジ表示をゲート設置後の実態に合わせて更新
  - `(参考値・ゲートなし)` → `(基準 80%・ゲートあり)`
  - 参照する JaCoCo XML は従来どおり同一(`build/reports/jacoco/test/jacocoTestReport.xml`)
- ゲート判定は Gradle 側(`jacocoTestCoverageVerification`)、CI レポートは表示のみという分担

## 受入条件

- [x] `keycloak/build.gradle.kts` に 80% 命令カバレッジ検証が設定され、`./gradlew :keycloak:check` で検証される
- [x] カバレッジ不足時に CI(keycloak-ci.yml の `:keycloak:check`)が fail する
- [x] webapi と基準(80% 命令カバレッジ)が一致している

## 検証

- `./gradlew :keycloak:check --dry-run` で `jacocoTestCoverageVerification` がタスクグラフに含まれ、config が正常にパースされることを確認

## 補足

- SPI 本実装でカバレッジ 80% を満たすことの確認は実装側 Issue の責務(本 PR は「ゲート設置」)

Closes #445

🤖 Generated with [Claude Code](https://claude.com/claude-code)