### PR TITLE
feat(notification): B-01 期限当日通知バッチ(ShedLock + SES)を実装 (#750)

### DIFF
--- a/docs/adr/0037-scheduled-batch-shedlock-and-ses.md
+++ b/docs/adr/0037-scheduled-batch-shedlock-and-ses.md
@@ -79,4 +79,4 @@ SES クライアントとその送出実装は `notification.email.provider=ses`
 - 基本設計書 §8(バッチ設計)/ §4.2.7(user_notification_settings)/ §4.2.8(shedlock)
 - 設計規約 §7(バッチ設計規約)/ §3.3(クエリ実装優先順位・native 許容)
 - ADR-0005 §3.4(通知ルール)/ ADR-0010(Hibernate Filter テナント分離)
-- ShedLock: https://github.com/lukas-krecan/ShedLock
+- ShedLock: [lukas-krecan/ShedLock](https://github.com/lukas-krecan/ShedLock)

--- a/docs/adr/0037-scheduled-batch-shedlock-and-ses.md
+++ b/docs/adr/0037-scheduled-batch-shedlock-and-ses.md
@@ -1,0 +1,82 @@
+# ADR-0037: スケジュールバッチ基盤(ShedLock)と通知メール送出(Amazon SES)
+
+- **Status**: Accepted
+- **Date**: 2026-06-25
+- **Deciders**: win2cot
+- **Tags**: architecture, batch, infrastructure, dependencies
+
+## 1. コンテキスト(Context)
+
+B-01 期限当日通知メール(F-18、Issue #750)を実装するにあたり、次の基盤が必要になる(基本設計書 §8 / 設計規約 §7):
+
+- **スケジュール実行**: 毎日 09:00 JST に当日期限タスクの通知を送出する。
+- **多重起動制御**: 本番は複数 ECS Fargate タスクで冗長化されるため、同一バッチが複数ノードで同時実行されないようにする。
+- **メール送出**: 基本設計書 §2 のとおり Amazon SES を用いる。
+- **ローカル/テスト**: SES 認証情報なしで起動・テストできること(SES はモック/フォールバック)。
+- **GraalVM Native Image**: 本番は native image でビルドするため、追加ライブラリが AOT/native と両立すること。
+
+新規ライブラリ(ShedLock / AWS SDK SES v2)の導入を伴うため ADR を起票する(CLAUDE.md 規約)。
+
+## 2. 検討した選択肢(Options Considered)
+
+### 選択肢 A: Spring `@Scheduled` + ShedLock(JDBC プロバイダ)+ AWS SDK SES v2(採用)
+
+- 概要: アプリ内で `@Scheduled` によりバッチを駆動し、`@SchedulerLock` + `JdbcTemplateLockProvider`(既存 `shedlock` テーブル)で多重起動を排他。メールは SES v2 `SendEmail`。
+- 利点: 設計規約 §7 / 基本設計書 §8.2 の方針そのまま。既存 `shedlock` テーブル(基本設計書 §4.2.8)・既存 DataSource・既存 AWS SDK BOM を再利用。`@ConditionalOnProperty` で SES を本番のみ有効化できる。
+- 欠点: アプリプロセスにバッチ責務が同居する。ライブラリが 2 つ増える。
+
+### 選択肢 B: ECS Scheduled Task(EventBridge)で別プロセス起動
+
+- 概要: バッチ専用のタスク定義を EventBridge スケジュールで起動。
+- 利点: アプリと分離。ShedLock 不要(単発起動)。
+- 欠点: MVP には過剰。インフラ構成(別タスク定義・IAM・イメージ起動引数)が増え、Sprint 4 のスコープを超える。基本設計書 §8.2 も「@Scheduled で実装」を主方針としている。
+
+### 選択肢 C: `@Scheduled` のみ(ロックなし)
+
+- 概要: ShedLock を入れず単純にスケジュール。
+- 欠点: 複数ノードで同一受信者に重複送信が起きる。受け入れ条件「ShedLock で単一ノード実行が担保」を満たさない。
+
+## 3. 決定(Decision)
+
+**採用**: 選択肢 A。`@Scheduled` + ShedLock(`shedlock-spring` / `shedlock-provider-jdbc-template` 6.10.0)+ AWS SDK `sesv2`(既存 BOM 2.46.15)。
+
+SES クライアントとその送出実装は `notification.email.provider=ses` のときのみ生成し、既定(`log`)はローカル/テスト用のログフォールバック(`LoggingEmailSender`)を使う。
+
+## 4. 理由(Rationale)
+
+- 設計規約 §7・基本設計書 §8.2 が `@Scheduled` + ShedLock を主方針として明記しており、最小の追加で要件を満たす。
+- `shedlock` テーブル・DataSource・AWS SDK BOM が既存。`JdbcTemplateLockProvider#usingDbTime()` で DB 時刻基準ロックとし、ノード間クロックスキューに依存しない。
+- `@ConditionalOnProperty` により SES を本番限定で有効化でき、ローカル/CI は認証情報なしで動作(テストは `EmailSenderPort` をモック、AC「SES はモック」)。
+- ShedLock 6.x / AWS SDK SES v2 は AOT/native 対応。`processTestAot` / `compileAotTestJava` がローカル check で成功することを確認済み(native build は CI ゲートで最終確認)。
+
+## 5. 影響(Consequences)
+
+### 良い影響(Positive)
+
+- 多重起動が構造的に排他され、重複送信を防止。
+- メール経路が設定で切替可能(本番 SES / 非本番ログ)。新規マイグレーション不要(既存テーブル使用)。
+
+### 悪い影響・制約(Negative)
+
+- 依存が 2 つ増える(ShedLock 2 アーティファクト + `sesv2`)。native image の到達可能性メタデータに依存するため、ライブラリ更新時は native build で回帰確認が必要。
+- アプリプロセスにバッチが同居する。将来バッチが増えて負荷分離が必要になれば選択肢 B(EventBridge 起動)へ移行余地を残す。
+
+### 既存ドキュメント・規約への波及
+
+- 基本設計書 §8.2 は「tenant_id ループで処理」と例示するが、本実装は **全テナント横断の単一 native クエリ** で対象を抽出し、結果を `(tenant_id, user_id)` でグループ化してテナント単位に分離する(設計規約 §3.3 native 許容(1)= モジュール境界越えのバッチ集計)。バッチには `TenantContext` が無く Hibernate Filter(ADR-0010)が適用されないため、native クエリで `tenant_id` を明示保持する。テナント分離の意図(§8.2)は維持される。
+
+## 6. 実装メモ(Implementation Notes)
+
+- `notification` feature(クリーンアーキ4層)に閉じる。他 feature の Java 型は参照せず、`tasks` / `users` / `user_notification_settings` への参照は native クエリのみ(モジュール自己完結)。
+- スケジューラ: `@Scheduled(cron="${notification.batch.cron:0 0 9 * * *}", zone="${notification.batch.zone:Asia/Tokyo}")` + `@SchedulerLock(name="dueTodayNotificationBatch", lockAtLeastFor=PT1M, lockAtMostFor=PT10M)`。MDC に `batchId=B-01` を設定(設計規約 §7)。`notification.batch.enabled`(既定 true)で無効化可能。
+- メール送出はトランザクション外で受信者単位に実行し、1 件の失敗が他をブロックしない。ログに PII(宛先・タスクタイトル)を出力しない(AC)。
+- 抽出条件は ADR-0005 §3.4(F-18: 所有者・担当者のみ、関係者対象外)。`email_due_today` が偽の受信者・INACTIVE/匿名化ユーザー・DONE/未来日タスクは除外。
+- MVP 対象は B-01 のみ。`email_overdue`(B-02)・`email_stakeholder` 等は後続スコープ。
+
+## 7. 参考リンク(References)
+
+- Issue #750(通知バッチ)/ 要件 F-18(要件定義書 §3.7)
+- 基本設計書 §8(バッチ設計)/ §4.2.7(user_notification_settings)/ §4.2.8(shedlock)
+- 設計規約 §7(バッチ設計規約)/ §3.3(クエリ実装優先順位・native 許容)
+- ADR-0005 §3.4(通知ルール)/ ADR-0010(Hibernate Filter テナント分離)
+- ShedLock: https://github.com/lukas-krecan/ShedLock

--- a/webapi/build.gradle
+++ b/webapi/build.gradle
@@ -73,9 +73,14 @@ dependencies {
         exclude group: 'com.fasterxml.jackson.core'
     }
 
-    // AWS SDK v2 — RDS IAM auth token generation (ECS Fargate runtime identity)
+    // AWS SDK v2 — RDS IAM auth token generation (ECS Fargate runtime identity) + SES v2 (通知メール送出)
     implementation platform('software.amazon.awssdk:bom:2.46.15')
     implementation 'software.amazon.awssdk:rds'
+    implementation 'software.amazon.awssdk:sesv2'
+
+    // ShedLock — スケジュールバッチの多重起動排他制御(設計規約 §7、shedlock テーブル使用)
+    implementation 'net.javacrumbs.shedlock:shedlock-spring:6.10.0'
+    implementation 'net.javacrumbs.shedlock:shedlock-provider-jdbc-template:6.10.0'
 
     // Other dependencies
     errorprone 'com.google.errorprone:error_prone_core:2.49.0'

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/notification/adapter/external/LoggingEmailSender.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/notification/adapter/external/LoggingEmailSender.java
@@ -1,0 +1,31 @@
+package xyz.dgz48.tasks.webapi.notification.adapter.external;
+
+import java.util.Locale;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import xyz.dgz48.tasks.webapi.notification.usecase.EmailSenderPort;
+
+/**
+ * SES 未設定環境(ローカル開発・テスト)向けのフォールバック送出実装。
+ *
+ * <p>実際には送出せず、送出が試みられた事実のみをログに残す。PII 保護のため宛先はマスクし、本文・件名は出力しない。
+ */
+public class LoggingEmailSender implements EmailSenderPort {
+
+  private static final Logger log = LoggerFactory.getLogger(LoggingEmailSender.class);
+
+  @Override
+  public void send(String toAddress, String subject, String body) {
+    log.info("メール送出(ログフォールバック、実送出なし) to={}", mask(toAddress));
+  }
+
+  /** メールアドレスをマスクする(先頭1文字 + "***@" + ドメイン)。 */
+  private static String mask(String address) {
+    int at = address.indexOf('@');
+    if (at <= 0) {
+      return "***";
+    }
+    String domain = address.substring(at + 1).toLowerCase(Locale.ROOT);
+    return address.charAt(0) + "***@" + domain;
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/notification/adapter/external/SesEmailSender.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/notification/adapter/external/SesEmailSender.java
@@ -1,0 +1,46 @@
+package xyz.dgz48.tasks.webapi.notification.adapter.external;
+
+import lombok.RequiredArgsConstructor;
+import software.amazon.awssdk.services.sesv2.SesV2Client;
+import software.amazon.awssdk.services.sesv2.model.Body;
+import software.amazon.awssdk.services.sesv2.model.Content;
+import software.amazon.awssdk.services.sesv2.model.Destination;
+import software.amazon.awssdk.services.sesv2.model.EmailContent;
+import software.amazon.awssdk.services.sesv2.model.Message;
+import software.amazon.awssdk.services.sesv2.model.SendEmailRequest;
+import xyz.dgz48.tasks.webapi.notification.usecase.EmailSenderPort;
+
+/** Amazon SES v2 によるメール送出実装(基本設計書 §2 メール送信 = Amazon SES)。 */
+@RequiredArgsConstructor
+public class SesEmailSender implements EmailSenderPort {
+
+  private static final String UTF_8 = "UTF-8";
+
+  private final SesV2Client client;
+  private final String fromAddress;
+
+  @Override
+  public void send(String toAddress, String subject, String body) {
+    try {
+      SendEmailRequest request =
+          SendEmailRequest.builder()
+              .fromEmailAddress(fromAddress)
+              .destination(Destination.builder().toAddresses(toAddress).build())
+              .content(
+                  EmailContent.builder()
+                      .simple(
+                          Message.builder()
+                              .subject(Content.builder().data(subject).charset(UTF_8).build())
+                              .body(
+                                  Body.builder()
+                                      .text(Content.builder().data(body).charset(UTF_8).build())
+                                      .build())
+                              .build())
+                      .build())
+              .build();
+      client.sendEmail(request);
+    } catch (RuntimeException e) {
+      throw new EmailSendException("SES 送出に失敗しました", e);
+    }
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/notification/adapter/external/package-info.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/notification/adapter/external/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package xyz.dgz48.tasks.webapi.notification.adapter.external;
+
+import org.jspecify.annotations.NullMarked;

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/notification/adapter/package-info.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/notification/adapter/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package xyz.dgz48.tasks.webapi.notification.adapter;
+
+import org.jspecify.annotations.NullMarked;

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/notification/adapter/persistence/NotificationQueryAdapter.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/notification/adapter/persistence/NotificationQueryAdapter.java
@@ -1,0 +1,93 @@
+package xyz.dgz48.tasks.webapi.notification.adapter.persistence;
+
+import io.micrometer.observation.annotation.Observed;
+import jakarta.persistence.EntityManager;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import xyz.dgz48.tasks.webapi.notification.domain.DueTodayNotification;
+import xyz.dgz48.tasks.webapi.notification.domain.DueTodayNotification.DueTask;
+import xyz.dgz48.tasks.webapi.notification.usecase.DueTodayNotificationQueryPort;
+
+/**
+ * {@link DueTodayNotificationQueryPort} の JPA 実装。
+ *
+ * <p><b>バッチ横断クエリ</b>: 全テナントの当日期限通知対象を 1 度に抽出する。バッチには {@code TenantContext} が無く Hibernate
+ * Filter(ADR-0010)は適用されないため、native query で {@code tenant_id} を明示保持する(設計規約 §3.3 native 許容(1)= バッチ集計
+ * / §8.2 テナント分離)。受信者の通知は結果を {@code (tenant_id, user_id)} でグループ化することでテナント単位に分離する。
+ */
+@Observed(name = "notification.query")
+@Component
+@RequiredArgsConstructor
+class NotificationQueryAdapter implements DueTodayNotificationQueryPort {
+
+  // native 理由: モジュール境界(task/user/notification)を越えた 3 テーブル結合のバッチ抽出。
+  // tenant_id 明示: バッチは Filter 非適用のため tenant_id を結果に保持し受信者をテナント単位に分離(設計規約 §3.3 / §8.2)。
+  private static final String DUE_TODAY_SQL =
+      """
+      SELECT t.tenant_id, u.id, u.email, u.full_name, t.id, t.title
+      FROM tasks t
+      JOIN users u ON (u.id = t.owner_id OR u.id = t.assignee_id)
+      LEFT JOIN user_notification_settings s
+        ON s.user_id = u.id AND s.tenant_id = t.tenant_id
+      WHERE t.deleted_at IS NULL
+        AND t.status <> 'DONE'
+        AND t.due_date = :today
+        AND u.status = 'ACTIVE'
+        AND u.deleted_at IS NULL
+        AND COALESCE(s.email_due_today, TRUE) = TRUE
+      ORDER BY t.tenant_id, u.id, t.id
+      """;
+
+  private final EntityManager em;
+
+  @Override
+  @Transactional(readOnly = true)
+  public List<DueTodayNotification> findDueTodayRecipients(LocalDate today) {
+    @SuppressWarnings("unchecked")
+    List<Object[]> rows =
+        em.createNativeQuery(DUE_TODAY_SQL).setParameter("today", today).getResultList();
+
+    Map<RecipientKey, Accumulator> grouped = new LinkedHashMap<>();
+    for (Object[] row : rows) {
+      long tenantId = ((Number) row[0]).longValue();
+      long userId = ((Number) row[1]).longValue();
+      String email = (String) row[2];
+      String fullName = (String) row[3];
+      long taskId = ((Number) row[4]).longValue();
+      String title = (String) row[5];
+
+      grouped
+          .computeIfAbsent(
+              new RecipientKey(tenantId, userId), k -> new Accumulator(email, fullName))
+          .tasks
+          .add(new DueTask(taskId, title));
+    }
+
+    List<DueTodayNotification> result = new ArrayList<>(grouped.size());
+    grouped.forEach(
+        (key, acc) ->
+            result.add(
+                new DueTodayNotification(
+                    key.tenantId(), key.userId(), acc.email, acc.fullName, acc.tasks)));
+    return result;
+  }
+
+  private record RecipientKey(long tenantId, long userId) {}
+
+  private static final class Accumulator {
+    private final String email;
+    private final String fullName;
+    private final List<DueTask> tasks = new ArrayList<>();
+
+    Accumulator(String email, String fullName) {
+      this.email = email;
+      this.fullName = fullName;
+    }
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/notification/adapter/persistence/package-info.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/notification/adapter/persistence/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package xyz.dgz48.tasks.webapi.notification.adapter.persistence;
+
+import org.jspecify.annotations.NullMarked;

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/notification/domain/DueTodayNotification.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/notification/domain/DueTodayNotification.java
@@ -1,0 +1,16 @@
+package xyz.dgz48.tasks.webapi.notification.domain;
+
+import java.util.List;
+
+/**
+ * 1 受信者(テナント × ユーザー)あての期限当日通知(B-01 / F-18)。
+ *
+ * <p>1 ユーザーが複数テナントに所属する場合はテナントごとに別通知になる(通知設定・対象タスクはテナント単位)。{@code tasks} は当該ユーザーが <b>所有者または担当者</b>
+ * である当日期限の未完了タスク(ADR-0005 §3.4、関係者は対象外)。
+ */
+public record DueTodayNotification(
+    Long tenantId, Long userId, String email, String fullName, List<DueTask> tasks) {
+
+  /** 通知メール 1 行分のタスク要約。タイトルは PII を含みうるため本文専用でログには出力しない。 */
+  public record DueTask(Long taskId, String title) {}
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/notification/domain/package-info.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/notification/domain/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package xyz.dgz48.tasks.webapi.notification.domain;
+
+import org.jspecify.annotations.NullMarked;

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/notification/infra/NotificationBatchScheduler.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/notification/infra/NotificationBatchScheduler.java
@@ -1,0 +1,44 @@
+package xyz.dgz48.tasks.webapi.notification.infra;
+
+import lombok.RequiredArgsConstructor;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.slf4j.MDC;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import xyz.dgz48.tasks.webapi.notification.usecase.SendDueTodayNotificationsUseCase;
+
+/**
+ * B-01 期限当日通知メールのスケジューラ(基本設計書 §8.1、毎日 09:00 JST)。
+ *
+ * <p>{@link SchedulerLock} により複数ノードでも単一ノードのみが実行する(設計規約 §7)。実行時刻・タイムゾーン・有効化は {@code
+ * notification.batch.*} で設定可能(既定: 09:00 / Asia/Tokyo / 有効)。MDC に {@code batchId} を設定しログ追跡可能にする。
+ */
+@Component
+@ConditionalOnProperty(
+    name = "notification.batch.enabled",
+    havingValue = "true",
+    matchIfMissing = true)
+@RequiredArgsConstructor
+public class NotificationBatchScheduler {
+
+  private static final String BATCH_ID = "B-01";
+
+  private final SendDueTodayNotificationsUseCase sendDueTodayNotificationsUseCase;
+
+  @Scheduled(
+      cron = "${notification.batch.cron:0 0 9 * * *}",
+      zone = "${notification.batch.zone:Asia/Tokyo}")
+  @SchedulerLock(
+      name = "dueTodayNotificationBatch",
+      lockAtLeastFor = "PT1M",
+      lockAtMostFor = "PT10M")
+  public void runDueTodayNotification() {
+    MDC.put("batchId", BATCH_ID);
+    try {
+      sendDueTodayNotificationsUseCase.execute();
+    } finally {
+      MDC.remove("batchId");
+    }
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/notification/infra/NotificationConfig.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/notification/infra/NotificationConfig.java
@@ -1,0 +1,42 @@
+package xyz.dgz48.tasks.webapi.notification.infra;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.services.sesv2.SesV2Client;
+import xyz.dgz48.tasks.webapi.notification.adapter.external.LoggingEmailSender;
+import xyz.dgz48.tasks.webapi.notification.adapter.external.SesEmailSender;
+import xyz.dgz48.tasks.webapi.notification.usecase.EmailSenderPort;
+
+/**
+ * 通知機能のメール送出経路を構成する。
+ *
+ * <p>{@code notification.email.provider=ses} のときのみ SES クライアントと {@link SesEmailSender} を生成する。それ以外(既定
+ * {@code log})は {@link LoggingEmailSender} をフォールバックとして使う。{@code @Bean} の宣言順により、ses 経路が無いときだけ
+ * フォールバックが選択される。
+ */
+@Configuration(proxyBeanMethods = false)
+@EnableConfigurationProperties(NotificationProperties.class)
+class NotificationConfig {
+
+  @Bean
+  @ConditionalOnProperty(name = "notification.email.provider", havingValue = "ses")
+  SesV2Client sesV2Client() {
+    // リージョン・認証情報は AWS SDK の標準プロバイダチェーン(ECS Fargate タスクロール / 環境変数)から解決する。
+    return SesV2Client.create();
+  }
+
+  @Bean
+  @ConditionalOnProperty(name = "notification.email.provider", havingValue = "ses")
+  EmailSenderPort sesEmailSender(SesV2Client client, NotificationProperties properties) {
+    return new SesEmailSender(client, properties.email().from());
+  }
+
+  @Bean
+  @ConditionalOnMissingBean(EmailSenderPort.class)
+  EmailSenderPort loggingEmailSender() {
+    return new LoggingEmailSender();
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/notification/infra/NotificationProperties.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/notification/infra/NotificationProperties.java
@@ -1,0 +1,17 @@
+package xyz.dgz48.tasks.webapi.notification.infra;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.bind.DefaultValue;
+
+/**
+ * 通知機能の設定(application.yml の {@code notification.*})。
+ *
+ * <p>{@code email.provider} が {@code ses} のときのみ SES クライアントを生成し、それ以外(既定 {@code log})はログ出力フォールバックを使う。
+ */
+@ConfigurationProperties("notification")
+public record NotificationProperties(@DefaultValue Email email) {
+
+  public record Email(
+      @DefaultValue("log") String provider,
+      @DefaultValue("no-reply@example.invalid") String from) {}
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/notification/infra/NotificationSchedulingConfig.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/notification/infra/NotificationSchedulingConfig.java
@@ -1,0 +1,32 @@
+package xyz.dgz48.tasks.webapi.notification.infra;
+
+import javax.sql.DataSource;
+import net.javacrumbs.shedlock.core.LockProvider;
+import net.javacrumbs.shedlock.provider.jdbctemplate.JdbcTemplateLockProvider;
+import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+/**
+ * スケジュールバッチと ShedLock による多重起動排他制御を有効化する(設計規約 §7、基本設計書 §4.2.8 / §8.2)。
+ *
+ * <p>{@link JdbcTemplateLockProvider} は既存の {@code shedlock} テーブルを使用し、{@code usingDbTime()} で DB
+ * 時刻基準の ロック判定を行う(複数 ECS Fargate タスク間のクロックスキューに依存しない)。
+ */
+@Configuration(proxyBeanMethods = false)
+@EnableScheduling
+@EnableSchedulerLock(defaultLockAtMostFor = "PT10M")
+class NotificationSchedulingConfig {
+
+  @Bean
+  LockProvider lockProvider(DataSource dataSource) {
+    return new JdbcTemplateLockProvider(
+        JdbcTemplateLockProvider.Configuration.builder()
+            .withJdbcTemplate(new JdbcTemplate(dataSource))
+            .withTableName("shedlock")
+            .usingDbTime()
+            .build());
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/notification/infra/package-info.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/notification/infra/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package xyz.dgz48.tasks.webapi.notification.infra;
+
+import org.jspecify.annotations.NullMarked;

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/notification/package-info.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/notification/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package xyz.dgz48.tasks.webapi.notification;
+
+import org.jspecify.annotations.NullMarked;

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/notification/usecase/DueTodayNotificationQueryPort.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/notification/usecase/DueTodayNotificationQueryPort.java
@@ -1,0 +1,28 @@
+package xyz.dgz48.tasks.webapi.notification.usecase;
+
+import java.time.LocalDate;
+import java.util.List;
+import xyz.dgz48.tasks.webapi.notification.domain.DueTodayNotification;
+
+/** 期限当日通知(B-01)の対象受信者を抽出する out port。実装は adapter.persistence。 */
+public interface DueTodayNotificationQueryPort {
+
+  /**
+   * 当日(JST)期限の未完了タスクについて、通知対象となる受信者を抽出する。
+   *
+   * <p>抽出条件(ADR-0005 §3.4 / 基本設計書 §8.1 B-01):
+   *
+   * <ul>
+   *   <li>{@code due_date = today} かつ {@code status <> DONE} かつ未削除のタスク
+   *   <li>受信者はそのタスクの <b>所有者または担当者</b>(関係者は対象外)
+   *   <li>受信者の {@code user_notification_settings.email_due_today} が真(行が無い場合は既定 TRUE)
+   *   <li>受信者ユーザーが ACTIVE かつ未匿名化
+   * </ul>
+   *
+   * <p>テナント横断の抽出だが、各受信者の通知は所属テナント単位で分離される(テナント分離維持)。
+   *
+   * @param today サーバ側システム日付(JST)
+   * @return テナント × ユーザー単位にまとめた通知(タスク 0 件の受信者は含まない)
+   */
+  List<DueTodayNotification> findDueTodayRecipients(LocalDate today);
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/notification/usecase/EmailSenderPort.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/notification/usecase/EmailSenderPort.java
@@ -1,0 +1,22 @@
+package xyz.dgz48.tasks.webapi.notification.usecase;
+
+/** メール送出の out port。実装は adapter.external(SES もしくはログ出力フォールバック)。 */
+public interface EmailSenderPort {
+
+  /**
+   * メールを 1 通送出する。
+   *
+   * @param toAddress 宛先メールアドレス
+   * @param subject 件名
+   * @param body 本文(プレーンテキスト)
+   * @throws EmailSendException 送出に失敗した場合
+   */
+  void send(String toAddress, String subject, String body);
+
+  /** メール送出失敗を表す実行時例外。呼び出し側は受信者単位で捕捉し処理を継続する。 */
+  class EmailSendException extends RuntimeException {
+    public EmailSendException(String message, Throwable cause) {
+      super(message, cause);
+    }
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/notification/usecase/SendDueTodayNotificationsUseCase.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/notification/usecase/SendDueTodayNotificationsUseCase.java
@@ -1,0 +1,78 @@
+package xyz.dgz48.tasks.webapi.notification.usecase;
+
+import io.micrometer.observation.annotation.Observed;
+import java.time.Clock;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import xyz.dgz48.tasks.webapi.notification.domain.DueTodayNotification;
+
+/**
+ * B-01 期限当日通知メール(F-18)の送出ユースケース。
+ *
+ * <p>DB 読み取り(対象抽出)は {@link DueTodayNotificationQueryPort} 実装側でトランザクション境界を持ち、外部 I/O であるメール送出は
+ * トランザクション外で受信者単位に行う(1 件の送出失敗が他受信者をブロックしないよう個別に捕捉)。ログには PII(メールアドレス・タスクタイトル)を出力しない。
+ */
+@Service
+@RequiredArgsConstructor
+public class SendDueTodayNotificationsUseCase {
+
+  private static final Logger log = LoggerFactory.getLogger(SendDueTodayNotificationsUseCase.class);
+
+  private final DueTodayNotificationQueryPort queryPort;
+  private final EmailSenderPort emailSender;
+  private final Clock clock;
+
+  @Observed(name = "notification.dueToday")
+  public SendResult execute() {
+    LocalDate today = LocalDate.now(clock);
+    List<DueTodayNotification> notifications = queryPort.findDueTodayRecipients(today);
+
+    int sent = 0;
+    int failed = 0;
+    for (DueTodayNotification n : notifications) {
+      try {
+        emailSender.send(n.email(), buildSubject(n), buildBody(n));
+        sent++;
+      } catch (RuntimeException e) {
+        failed++;
+        // PII 非出力: 宛先・タイトルは記録せず、テナント/ユーザー ID と件数のみ。
+        log.warn(
+            "期限当日通知の送出に失敗 tenantId={} userId={} taskCount={}: {}",
+            n.tenantId(),
+            n.userId(),
+            n.tasks().size(),
+            e.getMessage());
+      }
+    }
+    SendResult result = new SendResult(notifications.size(), sent, failed);
+    log.info(
+        "期限当日通知バッチ完了 date={} recipients={} sent={} failed={}",
+        today,
+        result.recipientCount(),
+        result.sentCount(),
+        result.failedCount());
+    return result;
+  }
+
+  private static String buildSubject(DueTodayNotification n) {
+    return "本日が期限のタスクが " + n.tasks().size() + " 件あります";
+  }
+
+  private static String buildBody(DueTodayNotification n) {
+    StringBuilder sb = new StringBuilder();
+    sb.append(n.fullName()).append(" 様\n\n");
+    sb.append("本日が期限のタスクは以下のとおりです。\n\n");
+    for (DueTodayNotification.DueTask task : n.tasks()) {
+      sb.append("・").append(task.title()).append("\n");
+    }
+    sb.append("\nタスク管理システム\n");
+    return sb.toString();
+  }
+
+  /** バッチ実行結果(ログ・監視用、PII を含まない)。 */
+  public record SendResult(int recipientCount, int sentCount, int failedCount) {}
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/notification/usecase/package-info.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/notification/usecase/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package xyz.dgz48.tasks.webapi.notification.usecase;
+
+import org.jspecify.annotations.NullMarked;

--- a/webapi/src/main/resources/application.yml
+++ b/webapi/src/main/resources/application.yml
@@ -70,3 +70,14 @@ rds:
   iam-auth:
     enabled: ${RDS_IAM_AUTH_ENABLED:false}
     region: ${AWS_DEFAULT_REGION:ap-northeast-1}
+
+# 通知バッチ(B-01 期限当日通知メール、設計規約 §7 / 基本設計書 §8.1)。
+# email.provider=ses のときのみ SES クライアントを生成。既定 log はローカル/テスト用のログフォールバック。
+notification:
+  email:
+    provider: ${NOTIFICATION_EMAIL_PROVIDER:log}
+    from: ${NOTIFICATION_EMAIL_FROM:no-reply@example.invalid}
+  batch:
+    enabled: ${NOTIFICATION_BATCH_ENABLED:true}
+    cron: ${NOTIFICATION_BATCH_CRON:0 0 9 * * *}
+    zone: ${NOTIFICATION_BATCH_ZONE:Asia/Tokyo}

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/notification/adapter/external/LoggingEmailSenderTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/notification/adapter/external/LoggingEmailSenderTest.java
@@ -1,0 +1,19 @@
+package xyz.dgz48.tasks.webapi.notification.adapter.external;
+
+import org.junit.jupiter.api.Test;
+
+/** ログフォールバック送出が例外を投げずに完了することの確認(マスク処理は内部実装)。 */
+class LoggingEmailSenderTest {
+
+  private final LoggingEmailSender sender = new LoggingEmailSender();
+
+  @Test
+  void send_doesNotThrow_forNormalAddress() {
+    sender.send("user@example.com", "件名", "本文");
+  }
+
+  @Test
+  void send_doesNotThrow_forAddressWithoutAtSign() {
+    sender.send("invalid-address", "件名", "本文");
+  }
+}

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/notification/adapter/external/SesEmailSenderTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/notification/adapter/external/SesEmailSenderTest.java
@@ -1,0 +1,47 @@
+package xyz.dgz48.tasks.webapi.notification.adapter.external;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import software.amazon.awssdk.services.sesv2.SesV2Client;
+import software.amazon.awssdk.services.sesv2.model.SendEmailRequest;
+import software.amazon.awssdk.services.sesv2.model.SendEmailResponse;
+import software.amazon.awssdk.services.sesv2.model.SesV2Exception;
+import xyz.dgz48.tasks.webapi.notification.usecase.EmailSenderPort.EmailSendException;
+
+class SesEmailSenderTest {
+
+  private final SesV2Client client = mock(SesV2Client.class);
+  private final SesEmailSender sender = new SesEmailSender(client, "from@example.com");
+
+  @Test
+  void send_buildsSesRequestWithFromToSubjectBody() {
+    when(client.sendEmail(any(SendEmailRequest.class)))
+        .thenReturn(SendEmailResponse.builder().messageId("mid").build());
+
+    sender.send("to@example.com", "件名", "本文");
+
+    ArgumentCaptor<SendEmailRequest> captor = ArgumentCaptor.forClass(SendEmailRequest.class);
+    verify(client).sendEmail(captor.capture());
+    SendEmailRequest req = captor.getValue();
+    assertThat(req.fromEmailAddress()).isEqualTo("from@example.com");
+    assertThat(req.destination().toAddresses()).containsExactly("to@example.com");
+    assertThat(req.content().simple().subject().data()).isEqualTo("件名");
+    assertThat(req.content().simple().body().text().data()).isEqualTo("本文");
+  }
+
+  @Test
+  void send_wrapsSesFailureInEmailSendException() {
+    when(client.sendEmail(any(SendEmailRequest.class)))
+        .thenThrow(SesV2Exception.builder().message("ses down").build());
+
+    assertThatThrownBy(() -> sender.send("to@example.com", "s", "b"))
+        .isInstanceOf(EmailSendException.class);
+  }
+}

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/notification/adapter/persistence/DueTodayNotificationQueryIT.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/notification/adapter/persistence/DueTodayNotificationQueryIT.java
@@ -1,0 +1,270 @@
+package xyz.dgz48.tasks.webapi.notification.adapter.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.persistence.EntityManager;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.transaction.support.TransactionTemplate;
+import xyz.dgz48.tasks.webapi.MockJwtDecoderConfiguration;
+import xyz.dgz48.tasks.webapi.TestcontainersConfiguration;
+import xyz.dgz48.tasks.webapi.notification.domain.DueTodayNotification;
+import xyz.dgz48.tasks.webapi.notification.usecase.DueTodayNotificationQueryPort;
+import xyz.dgz48.tasks.webapi.security.adapter.web.TasksAuthenticationToken;
+import xyz.dgz48.tasks.webapi.security.domain.TasksPrincipal;
+import xyz.dgz48.tasks.webapi.task.adapter.persistence.TaskJpaEntity;
+import xyz.dgz48.tasks.webapi.task.domain.Priority;
+import xyz.dgz48.tasks.webapi.task.domain.TaskStatus;
+import xyz.dgz48.tasks.webapi.task.domain.Visibility;
+import xyz.dgz48.tasks.webapi.tenant.adapter.persistence.TenantJpaEntity;
+import xyz.dgz48.tasks.webapi.user.adapter.persistence.UserJpaEntity;
+
+/**
+ * B-01 期限当日通知の対象抽出({@link DueTodayNotificationQueryPort})の統合テスト。
+ *
+ * <p>抽出ルール(所有者・担当者のみ / DONE・未来日除外 / 設定 OFF 除外 / 関係者除外 / INACTIVE 除外)と、テナント横断バッチでの テナント単位グループ化を検証する。
+ */
+@SpringBootTest
+@Import({TestcontainersConfiguration.class, MockJwtDecoderConfiguration.class})
+class DueTodayNotificationQueryIT {
+
+  private static final LocalDate TODAY = LocalDate.of(2026, 1, 15);
+
+  @Autowired DueTodayNotificationQueryPort queryPort;
+  @Autowired EntityManager em;
+  @Autowired TransactionTemplate txTemplate;
+
+  private Long tenant1Id;
+  private Long tenant2Id;
+  private Long userAId; // T1, default ON
+  private Long userBId; // T1, email_due_today OFF
+  private Long userCId; // T2, default ON
+  private Long userDId; // T1, INACTIVE
+  private Long userEId; // T1, stakeholder only
+
+  private Long taskA1;
+  private Long taskA2;
+  private Long taskAsg; // owner B, assignee A
+  private Long taskStake; // owner A, STAKEHOLDERS, stakeholder E
+  private Long taskDoneA;
+  private Long taskFutureA;
+  private Long taskB1;
+  private Long taskC1;
+  private Long taskD1;
+
+  @BeforeEach
+  void setUp() {
+    txTemplate.execute(
+        ignored -> {
+          var userA = new UserJpaEntity("sub-n-a", "n-a@example.com", "通知A", "ツウチエー", null);
+          var userB = new UserJpaEntity("sub-n-b", "n-b@example.com", "通知B", "ツウチビー", null);
+          var userC = new UserJpaEntity("sub-n-c", "n-c@example.com", "通知C", "ツウチシー", null);
+          var userD = new UserJpaEntity("sub-n-d", "n-d@example.com", "通知D", "ツウチディー", null);
+          var userE = new UserJpaEntity("sub-n-e", "n-e@example.com", "通知E", "ツウチイー", null);
+          em.persist(userA);
+          em.persist(userB);
+          em.persist(userC);
+          em.persist(userD);
+          em.persist(userE);
+          em.flush();
+          userAId = userA.getId();
+          userBId = userB.getId();
+          userCId = userC.getId();
+          userDId = userD.getId();
+          userEId = userE.getId();
+
+          SecurityContextHolder.getContext()
+              .setAuthentication(
+                  new TasksAuthenticationToken(
+                      new TasksPrincipal(
+                          userAId, "sub-n-a", "n-a@example.com", "通知A", "ツウチエー", null),
+                      List.of()));
+
+          var t1 = new TenantJpaEntity("N-1", "通知テナント1");
+          var t2 = new TenantJpaEntity("N-2", "通知テナント2");
+          em.persist(t1);
+          em.persist(t2);
+          em.flush();
+          tenant1Id = t1.getId();
+          tenant2Id = t2.getId();
+
+          // userD を INACTIVE 化
+          em.createNativeQuery("UPDATE users SET status = 'INACTIVE' WHERE id = ?")
+              .setParameter(1, userDId)
+              .executeUpdate();
+
+          // userB は email_due_today = FALSE(OFF)
+          em.createNativeQuery(
+                  "INSERT INTO user_notification_settings"
+                      + " (user_id, tenant_id, email_due_today, email_overdue, email_stakeholder, updated_at)"
+                      + " VALUES (?,?,?,?,?,?)")
+              .setParameter(1, userBId)
+              .setParameter(2, tenant1Id)
+              .setParameter(3, false)
+              .setParameter(4, true)
+              .setParameter(5, true)
+              .setParameter(6, LocalDateTime.of(2026, 1, 1, 0, 0))
+              .executeUpdate();
+
+          taskA1 =
+              persist(
+                  tenant1Id, userAId, null, "A1", TaskStatus.NOT_STARTED, Visibility.TENANT, TODAY);
+          taskA2 =
+              persist(
+                  tenant1Id, userAId, null, "A2", TaskStatus.IN_PROGRESS, Visibility.TENANT, TODAY);
+          taskAsg =
+              persist(
+                  tenant1Id,
+                  userBId,
+                  userAId,
+                  "Asg",
+                  TaskStatus.NOT_STARTED,
+                  Visibility.TENANT,
+                  TODAY);
+          taskStake =
+              persist(
+                  tenant1Id,
+                  userAId,
+                  null,
+                  "Stake",
+                  TaskStatus.NOT_STARTED,
+                  Visibility.STAKEHOLDERS,
+                  TODAY);
+          taskDoneA =
+              persist(tenant1Id, userAId, null, "DoneA", TaskStatus.DONE, Visibility.TENANT, TODAY);
+          taskFutureA =
+              persist(
+                  tenant1Id,
+                  userAId,
+                  null,
+                  "FutureA",
+                  TaskStatus.NOT_STARTED,
+                  Visibility.TENANT,
+                  TODAY.plusDays(1));
+          taskB1 =
+              persist(
+                  tenant1Id, userBId, null, "B1", TaskStatus.NOT_STARTED, Visibility.TENANT, TODAY);
+          taskC1 =
+              persist(
+                  tenant2Id, userCId, null, "C1", TaskStatus.NOT_STARTED, Visibility.TENANT, TODAY);
+          taskD1 =
+              persist(
+                  tenant1Id, userDId, null, "D1", TaskStatus.NOT_STARTED, Visibility.TENANT, TODAY);
+
+          // userE を taskStake の関係者として登録(所有者・担当者ではない)
+          em.createNativeQuery(
+                  "INSERT INTO task_stakeholders (task_id, user_id, tenant_id, added_by, added_at)"
+                      + " VALUES (?,?,?,?,?)")
+              .setParameter(1, taskStake)
+              .setParameter(2, userEId)
+              .setParameter(3, tenant1Id)
+              .setParameter(4, userAId)
+              .setParameter(5, LocalDateTime.of(2026, 1, 1, 0, 0))
+              .executeUpdate();
+
+          return null;
+        });
+    SecurityContextHolder.clearContext();
+  }
+
+  @AfterEach
+  void tearDown() {
+    SecurityContextHolder.clearContext();
+    if (tenant1Id == null) {
+      return;
+    }
+    txTemplate.execute(
+        ignored -> {
+          em.createNativeQuery("DELETE FROM task_stakeholders WHERE tenant_id IN (?,?)")
+              .setParameter(1, tenant1Id)
+              .setParameter(2, tenant2Id)
+              .executeUpdate();
+          em.createNativeQuery("DELETE FROM tasks WHERE tenant_id IN (?,?)")
+              .setParameter(1, tenant1Id)
+              .setParameter(2, tenant2Id)
+              .executeUpdate();
+          em.createNativeQuery("DELETE FROM user_notification_settings WHERE tenant_id IN (?,?)")
+              .setParameter(1, tenant1Id)
+              .setParameter(2, tenant2Id)
+              .executeUpdate();
+          em.createNativeQuery("DELETE FROM tenants WHERE id IN (?,?)")
+              .setParameter(1, tenant1Id)
+              .setParameter(2, tenant2Id)
+              .executeUpdate();
+          em.createNativeQuery("DELETE FROM users WHERE id IN (?,?,?,?,?)")
+              .setParameter(1, userAId)
+              .setParameter(2, userBId)
+              .setParameter(3, userCId)
+              .setParameter(4, userDId)
+              .setParameter(5, userEId)
+              .executeUpdate();
+          return null;
+        });
+  }
+
+  @Test
+  void extractsOwnerAndAssignee_excludesOff_done_future_stakeholder_inactive_andSeparatesTenants() {
+    List<DueTodayNotification> result = queryPort.findDueTodayRecipients(TODAY);
+
+    // 通知される受信者は A(T1)と C(T2)のみ
+    assertThat(result).hasSize(2);
+
+    DueTodayNotification a = findRecipient(result, userAId);
+    assertThat(a.tenantId()).isEqualTo(tenant1Id);
+    assertThat(a.email()).isEqualTo("n-a@example.com");
+    List<Long> aTaskIds = a.tasks().stream().map(DueTodayNotification.DueTask::taskId).toList();
+    // 所有(A1/A2/Stake)+ 担当(Asg)= 4 件。DONE / 未来日は除外。
+    assertThat(aTaskIds)
+        .containsExactlyInAnyOrder(taskA1, taskA2, taskStake, taskAsg)
+        .doesNotContain(taskDoneA, taskFutureA);
+
+    DueTodayNotification c = findRecipient(result, userCId);
+    assertThat(c.tenantId()).isEqualTo(tenant2Id);
+    assertThat(c.tasks()).hasSize(1);
+
+    // B(設定 OFF)・D(INACTIVE)・E(関係者のみ)は通知対象外
+    assertThat(result.stream().map(DueTodayNotification::userId))
+        .doesNotContain(userBId, userDId, userEId);
+  }
+
+  private static DueTodayNotification findRecipient(
+      List<DueTodayNotification> result, Long userId) {
+    Optional<DueTodayNotification> found =
+        result.stream().filter(n -> n.userId().equals(userId)).findFirst();
+    assertThat(found).as("受信者 userId=%s が存在する", userId).isPresent();
+    return found.orElseThrow();
+  }
+
+  private Long persist(
+      Long tenantId,
+      Long ownerId,
+      @org.jspecify.annotations.Nullable Long assigneeId,
+      String title,
+      TaskStatus status,
+      Visibility visibility,
+      LocalDate dueDate) {
+    var task =
+        new TaskJpaEntity(
+            tenantId,
+            ownerId,
+            title,
+            null,
+            status,
+            Priority.MEDIUM,
+            visibility,
+            assigneeId,
+            dueDate);
+    em.persist(task);
+    em.flush();
+    return task.getId();
+  }
+}

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/notification/infra/NotificationBatchSchedulerTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/notification/infra/NotificationBatchSchedulerTest.java
@@ -1,0 +1,36 @@
+package xyz.dgz48.tasks.webapi.notification.infra;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.slf4j.MDC;
+import xyz.dgz48.tasks.webapi.notification.usecase.SendDueTodayNotificationsUseCase;
+import xyz.dgz48.tasks.webapi.notification.usecase.SendDueTodayNotificationsUseCase.SendResult;
+
+class NotificationBatchSchedulerTest {
+
+  @Test
+  void runDueTodayNotification_delegatesToUseCase() {
+    SendDueTodayNotificationsUseCase useCase = mock(SendDueTodayNotificationsUseCase.class);
+    when(useCase.execute()).thenReturn(new SendResult(0, 0, 0));
+    NotificationBatchScheduler scheduler = new NotificationBatchScheduler(useCase);
+
+    scheduler.runDueTodayNotification();
+
+    verify(useCase).execute();
+  }
+
+  @Test
+  void runDueTodayNotification_clearsBatchIdFromMdcAfterRun() {
+    SendDueTodayNotificationsUseCase useCase = mock(SendDueTodayNotificationsUseCase.class);
+    when(useCase.execute()).thenReturn(new SendResult(0, 0, 0));
+    NotificationBatchScheduler scheduler = new NotificationBatchScheduler(useCase);
+
+    scheduler.runDueTodayNotification();
+
+    assertThat(MDC.get("batchId")).isNull();
+  }
+}

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/notification/usecase/SendDueTodayNotificationsUseCaseTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/notification/usecase/SendDueTodayNotificationsUseCaseTest.java
@@ -1,0 +1,106 @@
+package xyz.dgz48.tasks.webapi.notification.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import xyz.dgz48.tasks.webapi.notification.domain.DueTodayNotification;
+import xyz.dgz48.tasks.webapi.notification.domain.DueTodayNotification.DueTask;
+import xyz.dgz48.tasks.webapi.notification.usecase.EmailSenderPort.EmailSendException;
+
+class SendDueTodayNotificationsUseCaseTest {
+
+  private static final ZoneId JST = ZoneId.of("Asia/Tokyo");
+  private final Clock clock =
+      Clock.fixed(ZonedDateTime.of(2026, 1, 15, 19, 0, 0, 0, JST).toInstant(), JST);
+
+  private final DueTodayNotificationQueryPort queryPort = mock(DueTodayNotificationQueryPort.class);
+  private final EmailSenderPort emailSender = mock(EmailSenderPort.class);
+  private final SendDueTodayNotificationsUseCase useCase =
+      new SendDueTodayNotificationsUseCase(queryPort, emailSender, clock);
+
+  private static DueTodayNotification notification(long userId, String email, String... titles) {
+    List<DueTask> tasks = new java.util.ArrayList<>();
+    for (int i = 0; i < titles.length; i++) {
+      tasks.add(new DueTask((long) (i + 1), titles[i]));
+    }
+    return new DueTodayNotification(100L, userId, email, "氏名" + userId, tasks);
+  }
+
+  @Test
+  void execute_queriesWithJstToday_andSendsOnePerRecipient() {
+    when(queryPort.findDueTodayRecipients(eq(LocalDate.of(2026, 1, 15))))
+        .thenReturn(
+            List.of(
+                notification(1L, "a@example.com", "資料作成", "レビュー"),
+                notification(2L, "b@example.com", "打合せ")));
+    doNothing().when(emailSender).send(anyString(), anyString(), anyString());
+
+    SendDueTodayNotificationsUseCase.SendResult result = useCase.execute();
+
+    assertThat(result.recipientCount()).isEqualTo(2);
+    assertThat(result.sentCount()).isEqualTo(2);
+    assertThat(result.failedCount()).isZero();
+    verify(emailSender, times(2)).send(anyString(), anyString(), anyString());
+  }
+
+  @Test
+  void execute_buildsSubjectAndBodyFromTasks() {
+    when(queryPort.findDueTodayRecipients(any()))
+        .thenReturn(List.of(notification(1L, "a@example.com", "資料作成", "レビュー")));
+
+    useCase.execute();
+
+    ArgumentCaptor<String> to = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<String> subject = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<String> body = ArgumentCaptor.forClass(String.class);
+    verify(emailSender).send(to.capture(), subject.capture(), body.capture());
+    assertThat(to.getValue()).isEqualTo("a@example.com");
+    assertThat(subject.getValue()).contains("2 件");
+    assertThat(body.getValue()).contains("資料作成").contains("レビュー");
+  }
+
+  @Test
+  void execute_continuesAfterPerRecipientFailure() {
+    when(queryPort.findDueTodayRecipients(any()))
+        .thenReturn(
+            List.of(
+                notification(1L, "fail@example.com", "失敗"),
+                notification(2L, "ok@example.com", "成功")));
+    doThrow(new EmailSendException("boom", new RuntimeException()))
+        .when(emailSender)
+        .send(eq("fail@example.com"), anyString(), anyString());
+
+    SendDueTodayNotificationsUseCase.SendResult result = useCase.execute();
+
+    assertThat(result.recipientCount()).isEqualTo(2);
+    assertThat(result.sentCount()).isEqualTo(1);
+    assertThat(result.failedCount()).isEqualTo(1);
+    verify(emailSender).send(eq("ok@example.com"), anyString(), anyString());
+  }
+
+  @Test
+  void execute_noRecipients_sendsNothing() {
+    when(queryPort.findDueTodayRecipients(any())).thenReturn(List.of());
+
+    SendDueTodayNotificationsUseCase.SendResult result = useCase.execute();
+
+    assertThat(result.recipientCount()).isZero();
+    verify(emailSender, never()).send(anyString(), anyString(), anyString());
+  }
+}


### PR DESCRIPTION
## 概要

Issue #750 — B-01 期限当日通知メール(F-18)のスケジュールバッチを新規 `notification` feature(Spring Modulith / クリーンアーキ4層)として実装する。

毎日 09:00 JST、当日期限かつ未完了タスクの **所有者・担当者** へメール通知する(ADR-0005 §3.4 / 基本設計書 §8.1)。

## スコープ判断

ADR-0005 §3.4 が MVP 通知を **F-18(期限当日通知)のみ** に限定しているため、本 PR の対象は **B-01 のみ**。`email_overdue`(B-02)・`email_stakeholder` 等は後続スコープ。

## 設計判断(ADR-0037 を追加)

- **スケジュール + 排他**: `@Scheduled`(cron 09:00 / Asia/Tokyo)+ ShedLock `@SchedulerLock` + `JdbcTemplateLockProvider`(`usingDbTime()`、既存 `shedlock` テーブル)。複数 ECS Fargate タスクでも単一ノードのみ実行(設計規約 §7)。MDC `batchId=B-01`。
- **対象抽出**: バッチは `TenantContext` を持たず Hibernate Filter(ADR-0010)が適用されないため、全テナント横断の **単一 native クエリ** で抽出し `(tenant_id, user_id)` でグループ化してテナント分離を維持(設計規約 §3.3 native 許容(1))。`email_due_today` OFF / INACTIVE・匿名化ユーザー / DONE・未来日タスクは除外。関係者は対象外(ADR-0005 §3.4)。
- **送出**: AWS SDK SES v2。`notification.email.provider=ses` のときのみ SES を生成、既定 `log` はログフォールバック(PII マスク)。送出はトランザクション外で受信者単位に実行し、1 件の失敗が他をブロックしない。ログに PII(宛先・タイトル)を出力しない。

## 受け入れ条件

- [x] スケジュール実行で対象タスクを抽出し通知送出(`@Scheduled` + UseCase + SES/ログ送出)
- [x] 通知設定 OFF のユーザーには送らない(`email_due_today=false` を抽出クエリで除外、IT 検証)
- [x] ShedLock で単一ノード実行が担保される(`@SchedulerLock` + JDBC LockProvider)
- [x] 単体テストでカバレッジ 80% 以上(SES はモック。`jacocoTestCoverageVerification` 通過)

## 依存追加

- `net.javacrumbs.shedlock:shedlock-spring` / `shedlock-provider-jdbc-template` `6.10.0`
- `software.amazon.awssdk:sesv2`(既存 BOM 2.46.15)
- 新規マイグレーションなし(既存 `shedlock` / `user_notification_settings` テーブルを使用)。

## テスト

- `SendDueTodayNotificationsUseCaseTest`(送出・件名/本文生成・受信者単位の失敗継続・JST 当日解決)
- `DueTodayNotificationQueryIT`(Testcontainers): 所有者+担当者抽出 / 設定OFF・DONE・未来日・関係者・INACTIVE 除外 / テナント分離
- `NotificationBatchSchedulerTest`(委譲・MDC クリア)、`SesEmailSenderTest`、`LoggingEmailSenderTest`
- `processTestAot` / `compileAotTestJava` 成功(ShedLock / SES の AOT・native 互換確認、native build は CI で最終確認)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
