### PR TITLE
fix(quality): IDE 警告解消(merge の unboxing nullness + 未使用テストフィールド)

### DIFF
--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/dashboard/adapter/persistence/DashboardQueryAdapter.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/dashboard/adapter/persistence/DashboardQueryAdapter.java
@@ -80,8 +80,8 @@ class DashboardQueryAdapter implements DashboardQueryPort {
         myOpenCount++;
       }
       // ステータス別・優先度別(認可フィルタ通過タスク全体)
-      statusBreakdown.merge(row.status(), 1L, Long::sum);
-      priorityBreakdown.merge(row.priority(), 1L, Long::sum);
+      statusBreakdown.merge(row.status(), 1L, (a, b) -> a + b);
+      priorityBreakdown.merge(row.priority(), 1L, (a, b) -> a + b);
     }
 
     return new DashboardSummary(

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/dashboard/adapter/web/DashboardIT.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/dashboard/adapter/web/DashboardIT.java
@@ -77,9 +77,6 @@ class DashboardIT {
   private Long t8CompletedYesterday;
   private Long t9UpcomingAssignedToA;
   private Long t10FutureBeyondWindowOwnedByA;
-  // 集計漏れ検証用(A から参照不可)
-  private Long t4PrivateOwnedByB;
-  private Long t6StakeholderNotRegistered;
 
   @BeforeEach
   void setUp() {
@@ -140,15 +137,15 @@ class DashboardIT {
                   Priority.MEDIUM,
                   Visibility.TENANT,
                   TODAY);
-          t4PrivateOwnedByB =
-              persistTask(
-                  userBId,
-                  null,
-                  "T4",
-                  TaskStatus.NOT_STARTED,
-                  Priority.MEDIUM,
-                  Visibility.PRIVATE,
-                  TODAY);
+          // T4: 他者(B)の PRIVATE。当日期限だが A の集計に漏れない検証用(集計漏れ検証)。
+          persistTask(
+              userBId,
+              null,
+              "T4",
+              TaskStatus.NOT_STARTED,
+              Priority.MEDIUM,
+              Visibility.PRIVATE,
+              TODAY);
           t5StakeholderUpcoming =
               persistTask(
                   userBId,
@@ -158,15 +155,15 @@ class DashboardIT {
                   Priority.HIGH,
                   Visibility.STAKEHOLDERS,
                   TODAY.plusDays(1));
-          t6StakeholderNotRegistered =
-              persistTask(
-                  userBId,
-                  null,
-                  "T6",
-                  TaskStatus.NOT_STARTED,
-                  Priority.MEDIUM,
-                  Visibility.STAKEHOLDERS,
-                  TODAY);
+          // T6: A が非関係者の STAKEHOLDERS。当日期限だが A の集計に漏れない検証用(集計漏れ検証)。
+          persistTask(
+              userBId,
+              null,
+              "T6",
+              TaskStatus.NOT_STARTED,
+              Priority.MEDIUM,
+              Visibility.STAKEHOLDERS,
+              TODAY);
           t7CompletedTodayOwnedByA =
               persistTask(
                   userAId,

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/notification/adapter/persistence/DueTodayNotificationQueryIT.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/notification/adapter/persistence/DueTodayNotificationQueryIT.java
@@ -57,9 +57,6 @@ class DueTodayNotificationQueryIT {
   private Long taskStake; // owner A, STAKEHOLDERS, stakeholder E
   private Long taskDoneA;
   private Long taskFutureA;
-  private Long taskB1;
-  private Long taskC1;
-  private Long taskD1;
 
   @BeforeEach
   void setUp() {
@@ -150,15 +147,12 @@ class DueTodayNotificationQueryIT {
                   TaskStatus.NOT_STARTED,
                   Visibility.TENANT,
                   TODAY.plusDays(1));
-          taskB1 =
-              persist(
-                  tenant1Id, userBId, null, "B1", TaskStatus.NOT_STARTED, Visibility.TENANT, TODAY);
-          taskC1 =
-              persist(
-                  tenant2Id, userCId, null, "C1", TaskStatus.NOT_STARTED, Visibility.TENANT, TODAY);
-          taskD1 =
-              persist(
-                  tenant1Id, userDId, null, "D1", TaskStatus.NOT_STARTED, Visibility.TENANT, TODAY);
+          // B1: 所有者 B は email_due_today=OFF のため通知対象外(設定 OFF 除外の検証用)。
+          persist(tenant1Id, userBId, null, "B1", TaskStatus.NOT_STARTED, Visibility.TENANT, TODAY);
+          // C1: 別テナント(tenant2)の C。テナント単位グループ化の検証用。
+          persist(tenant2Id, userCId, null, "C1", TaskStatus.NOT_STARTED, Visibility.TENANT, TODAY);
+          // D1: 所有者 D は INACTIVE のため通知対象外(INACTIVE 除外の検証用)。
+          persist(tenant1Id, userDId, null, "D1", TaskStatus.NOT_STARTED, Visibility.TENANT, TODAY);
 
           // userE を taskStake の関係者として登録(所有者・担当者ではない)
           em.createNativeQuery(


### PR DESCRIPTION
## 概要

IDE(Eclipse ecj)が報告していた警告を解消する。挙動・アサーションは不変。

## 変更内容

### `DashboardQueryAdapter`(本体)
- summary 集計の `statusBreakdown.merge(..., Long::sum)` / `priorityBreakdown.merge(..., Long::sum)` を `(a, b) -> a + b` に置換。
- `Long::sum` メソッド参照は nullable な `Long` ディスクリプタ引数を primitive `long` にバインドするため、Eclipse null 解析が unchecked unboxing 警告を出していた。ラムダは非 null の `Long` を明示的に unbox し、機能的に等価。

### `DashboardIT` / `DueTodayNotificationQueryIT`(テスト)
- write-only(代入のみ・参照なし)の負例フィクスチャフィールドを削除:
  - `DashboardIT`: `t4PrivateOwnedByB` / `t6StakeholderNotRegistered`(他者 PRIVATE・非関係者 STAKEHOLDERS — 集計に漏れないことの検証用。id 参照はなく `todayDueCount` でアサート)
  - `DueTodayNotificationQueryIT`: `taskB1` / `taskC1` / `taskD1`(設定 OFF / INACTIVE 除外・テナント分離の検証用)
- いずれも DB 副作用のための `persist` 呼び出しのみ残し、意図をコメントで明示。

## 検証

- `./gradlew :webapi:spotlessApply :webapi:compileJava :webapi:compileTestJava` 通過。
- 変更はデッドなフィールド書き込みの除去と等価ラムダ置換のみで、クエリロジック・テストアサーションには触れていない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)