### PR TITLE
feat(audit): 監査ログ自レコード HMAC ハッシュチェーン書込経路 (Refs #751)

### DIFF
--- a/infra/environments/dev/parameter-store.tf
+++ b/infra/environments/dev/parameter-store.tf
@@ -8,6 +8,7 @@ module "parameter_store" {
   keycloak_admin_password      = var.keycloak_admin_password
   keycloak_oauth_client_secret = var.keycloak_oauth_client_secret
   keycloak_smtp_password       = var.keycloak_smtp_password
+  audit_hmac_key_v1            = var.audit_hmac_key_v1
   jwt_issuer                   = var.jwt_issuer
   tenant_default_id            = var.tenant_default_id
 }

--- a/infra/environments/dev/terraform.tfvars
+++ b/infra/environments/dev/terraform.tfvars
@@ -14,6 +14,7 @@ keycloak_spi_read_password   = "CHANGE_ME"
 keycloak_admin_password      = "CHANGE_ME"
 keycloak_oauth_client_secret = "CHANGE_ME"
 keycloak_smtp_password       = "CHANGE_ME"
+audit_hmac_key_v1            = "CHANGE_ME"
 
 # String config values
 jwt_issuer        = "https://auth-dev.dgz48.xyz/realms/tasks"

--- a/infra/environments/dev/variables.tf
+++ b/infra/environments/dev/variables.tf
@@ -58,6 +58,13 @@ variable "keycloak_smtp_password" {
   description = "SES SMTP password placeholder for Keycloak email sending"
 }
 
+variable "audit_hmac_key_v1" {
+  type        = string
+  sensitive   = true
+  default     = "CHANGE_ME"
+  description = "Audit hash-chain HMAC key (id v1) placeholder; set actual value in SSM after apply (ADR-0038)"
+}
+
 # ---------------------------------------------------------------------------
 # Parameter Store — String values
 # ---------------------------------------------------------------------------

--- a/infra/modules/parameter_store/main.tf
+++ b/infra/modules/parameter_store/main.tf
@@ -86,6 +86,23 @@ resource "aws_ssm_parameter" "keycloak_smtp_password" {
   }
 }
 
+# Audit hash-chain HMAC key (ADR-0038). Stored under app/* so the existing webapi
+# task-role policy (ssm:GetParameter* on parameter/tasks/<env>/app/* + kms:Decrypt)
+# already grants read; no IAM change required.
+resource "aws_ssm_parameter" "audit_hmac_key_v1" {
+  name  = "/tasks/${var.env}/app/audit-hash-key-v1"
+  type  = "SecureString"
+  value = var.audit_hmac_key_v1
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+
+  tags = {
+    Name = "tasks-${var.env}-app-audit-hash-key-v1"
+  }
+}
+
 # ---------------------------------------------------------------------------
 # String parameters — config values fully managed by Terraform
 # ---------------------------------------------------------------------------

--- a/infra/modules/parameter_store/variables.tf
+++ b/infra/modules/parameter_store/variables.tf
@@ -39,6 +39,12 @@ variable "keycloak_smtp_password" {
   description = "SES SMTP interface password for Keycloak email sending (generated from IAM access key)"
 }
 
+variable "audit_hmac_key_v1" {
+  type        = string
+  sensitive   = true
+  description = "HMAC-SHA256 key (id v1) for audit_logs hash-chain tamper evidence (ADR-0038); webapi reads it via ssm:GetParameter"
+}
+
 variable "jwt_issuer" {
   type        = string
   description = "OAuth2 JWT issuer URI (e.g. https://auth-dev.dgz48.xyz/realms/tasks)"

--- a/webapi/build.gradle
+++ b/webapi/build.gradle
@@ -74,9 +74,11 @@ dependencies {
     }
 
     // AWS SDK v2 — RDS IAM auth token generation (ECS Fargate runtime identity) + SES v2 (通知メール送出)
+    //   + SSM Parameter Store (監査ハッシュチェーンの HMAC 鍵ロード、ADR-0038 §3.3)
     implementation platform('software.amazon.awssdk:bom:2.46.15')
     implementation 'software.amazon.awssdk:rds'
     implementation 'software.amazon.awssdk:sesv2'
+    implementation 'software.amazon.awssdk:ssm'
 
     // ShedLock — スケジュールバッチの多重起動排他制御(設計規約 §7、shedlock テーブル使用)
     implementation 'net.javacrumbs.shedlock:shedlock-spring:6.10.0'

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/adapter/external/PropertyHmacKeyProvider.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/adapter/external/PropertyHmacKeyProvider.java
@@ -1,0 +1,38 @@
+package xyz.dgz48.tasks.webapi.audit.adapter.external;
+
+import java.nio.charset.StandardCharsets;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import xyz.dgz48.tasks.webapi.audit.usecase.HmacKeyProvider;
+
+/**
+ * 設定値({@code audit.hash-chain.secret})を HMAC 鍵に用いる {@link HmacKeyProvider} 実装。
+ *
+ * <p>ローカル / テスト用のフォールバック。本番は {@code source=ssm} で Parameter Store から鍵をロードする実装に切り替える。鍵は不変のため {@link
+ * SecretKeySpec} を一度だけ構築して保持する。
+ */
+public class PropertyHmacKeyProvider implements HmacKeyProvider {
+
+  private static final String HMAC_ALGORITHM = "HmacSHA256";
+
+  private final String keyId;
+  private final SecretKey key;
+
+  public PropertyHmacKeyProvider(String keyId, String secret) {
+    this.keyId = keyId;
+    this.key = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), HMAC_ALGORITHM);
+  }
+
+  @Override
+  public String currentKeyId() {
+    return keyId;
+  }
+
+  @Override
+  public SecretKey keyFor(String keyId) {
+    if (!this.keyId.equals(keyId)) {
+      throw new IllegalArgumentException("未知の鍵識別子です: " + keyId);
+    }
+    return key;
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/adapter/external/package-info.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/adapter/external/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package xyz.dgz48.tasks.webapi.audit.adapter.external;
+
+import org.jspecify.annotations.NullMarked;

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/adapter/persistence/AuditLogJpaEntity.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/adapter/persistence/AuditLogJpaEntity.java
@@ -59,6 +59,12 @@ class AuditLogJpaEntity {
   @Column(name = "hash_chain", nullable = false, length = 64)
   private String hashChain;
 
+  @Column(name = "chain_seq", nullable = false)
+  private Long chainSeq;
+
+  @Column(name = "hash_key_id", nullable = false, length = 32)
+  private String hashKeyId;
+
   @Column(name = "created_at", nullable = false)
   private LocalDateTime createdAt;
 
@@ -67,13 +73,17 @@ class AuditLogJpaEntity {
       @Nullable Long userId,
       String action,
       @Nullable String detail,
-      LocalDateTime createdAt,
-      String hashChain) {
+      long chainSeq,
+      String hashChain,
+      String hashKeyId,
+      LocalDateTime createdAt) {
     this.tenantId = tenantId;
     this.userId = userId;
     this.action = action;
     this.detail = detail;
-    this.createdAt = createdAt;
+    this.chainSeq = chainSeq;
     this.hashChain = hashChain;
+    this.hashKeyId = hashKeyId;
+    this.createdAt = createdAt;
   }
 }

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/adapter/persistence/AuditLogJpaRepository.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/adapter/persistence/AuditLogJpaRepository.java
@@ -1,9 +1,5 @@
 package xyz.dgz48.tasks.webapi.audit.adapter.persistence;
 
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-interface AuditLogJpaRepository extends JpaRepository<AuditLogJpaEntity, Long> {
-
-  Optional<AuditLogJpaEntity> findFirstByOrderByIdDesc();
-}
+interface AuditLogJpaRepository extends JpaRepository<AuditLogJpaEntity, Long> {}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/adapter/persistence/AuditLogPersistenceAdapter.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/adapter/persistence/AuditLogPersistenceAdapter.java
@@ -1,46 +1,102 @@
 package xyz.dgz48.tasks.webapi.audit.adapter.persistence;
 
 import io.micrometer.observation.annotation.Observed;
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.time.Clock;
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import org.jspecify.annotations.Nullable;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 import tools.jackson.core.JacksonException;
 import tools.jackson.databind.json.JsonMapper;
+import xyz.dgz48.tasks.webapi.audit.domain.AuditCanonicalizer;
+import xyz.dgz48.tasks.webapi.audit.domain.AuditChainHasher;
 import xyz.dgz48.tasks.webapi.audit.domain.AuditEventType;
+import xyz.dgz48.tasks.webapi.audit.domain.CanonicalAuditRow;
 import xyz.dgz48.tasks.webapi.audit.usecase.AuditLogPort;
+import xyz.dgz48.tasks.webapi.audit.usecase.HmacKeyProvider;
 
+/**
+ * 監査ログを {@code audit_logs} に追記する {@link AuditLogPort} 実装(ADR-0038)。
+ *
+ * <p>各行に自レコードハッシュ {@code HMAC(canonical(自行) ‖ 前ハッシュ)} を格納する。並行 INSERT が連鎖を分岐させないよう、{@code
+ * chain_key}(テナント行は {@code tenant_id}、横断行は予約値 {@code 0})単位で {@code chain_heads} 行を悲観ロックして直列化する。
+ * {@code chain_heads} の upsert・{@code FOR UPDATE}・{@code audit_logs} INSERT・末尾更新は単一トランザクションで原子的に
+ * 行う必要があるため {@link Propagation#REQUIRED} とする(呼出側に tx があれば join、無ければ本メソッドが境界となる)。これにより
+ * ロックは末尾更新まで保持され、直列化が成立する。{@code MANDATORY} にしない理由は、{@code LOGIN_FAILED} のように tx 外の
+ * セキュリティ経路から直接呼ばれる正当な呼出元が存在するためである。
+ */
 @Observed(name = "audit.repository")
 @Component
 class AuditLogPersistenceAdapter implements AuditLogPort {
 
-  static final String GENESIS_HASH = "0".repeat(64);
+  /** 横断行(tenant_id IS NULL)を 1 本のプラットフォーム連鎖にまとめる予約 chain_key。 */
+  private static final long PLATFORM_CHAIN_KEY = 0L;
 
   private final AuditLogJpaRepository repository;
+  private final ChainHeadJpaRepository chainHeadRepository;
   private final Clock clock;
   private final JsonMapper jsonMapper;
+  private final HmacKeyProvider hmacKeyProvider;
 
-  AuditLogPersistenceAdapter(AuditLogJpaRepository repository, Clock clock, JsonMapper jsonMapper) {
+  AuditLogPersistenceAdapter(
+      AuditLogJpaRepository repository,
+      ChainHeadJpaRepository chainHeadRepository,
+      Clock clock,
+      JsonMapper jsonMapper,
+      HmacKeyProvider hmacKeyProvider) {
     this.repository = repository;
+    this.chainHeadRepository = chainHeadRepository;
     this.clock = clock;
     this.jsonMapper = jsonMapper;
+    this.hmacKeyProvider = hmacKeyProvider;
   }
 
   @Override
+  @Transactional(propagation = Propagation.REQUIRED)
   public void record(
       AuditEventType eventType,
       @Nullable Long tenantId,
       @Nullable Long userId,
       @Nullable Object detail) {
-    LocalDateTime createdAt = LocalDateTime.now(clock);
-    String hashChain = computeChainHash(repository.findFirstByOrderByIdDesc().orElse(null));
+    long chainKey = tenantId != null ? tenantId : PLATFORM_CHAIN_KEY;
+    // DATETIME 列は秒精度のため、書込・正準化・再読込の三者が一致するよう秒精度に正規化する。
+    LocalDateTime createdAt = LocalDateTime.now(clock).truncatedTo(ChronoUnit.SECONDS);
     String detailJson = serializeDetail(detail);
-    var entity =
-        new AuditLogJpaEntity(tenantId, userId, eventType.name(), detailJson, createdAt, hashChain);
-    repository.save(entity);
+    String keyId = hmacKeyProvider.currentKeyId();
+
+    // chain_heads 行の存在を保証(初回はジェネシス相当)してから FOR UPDATE で末尾を掴み直列化する。
+    chainHeadRepository.ensureExists(chainKey, AuditChainHasher.GENESIS_HASH, createdAt);
+    ChainHeadJpaEntity head =
+        chainHeadRepository
+            .lockByChainKey(chainKey)
+            .orElseThrow(() -> new IllegalStateException("chain_heads 行の取得に失敗しました: " + chainKey));
+
+    long chainSeq = head.getLastSeq() + 1;
+    var canonicalRow =
+        new CanonicalAuditRow(
+            chainKey,
+            chainSeq,
+            userId,
+            eventType.name(),
+            null,
+            null,
+            detailJson,
+            null,
+            createdAt,
+            keyId);
+    String hashChain =
+        AuditChainHasher.hmacHex(
+            AuditCanonicalizer.canonicalBytes(canonicalRow),
+            head.getLastHash(),
+            hmacKeyProvider.keyFor(keyId));
+
+    repository.save(
+        new AuditLogJpaEntity(
+            tenantId, userId, eventType.name(), detailJson, chainSeq, hashChain, keyId, createdAt));
+    head.update(hashChain, chainSeq, createdAt);
+    chainHeadRepository.save(head);
   }
 
   /** シリアライズ失敗は {@link JacksonException}(unchecked)をそのまま伝播させ fail-closed とする。 */
@@ -50,24 +106,6 @@ class AuditLogPersistenceAdapter implements AuditLogPort {
       return jsonMapper.writeValueAsString(detail);
     } catch (JacksonException e) {
       throw new IllegalStateException("監査 detail のシリアライズに失敗しました", e);
-    }
-  }
-
-  static String computeChainHash(@Nullable AuditLogJpaEntity prev) {
-    if (prev == null) {
-      return GENESIS_HASH;
-    }
-    String input = prev.getId() + "|" + prev.getDetail() + "|" + prev.getCreatedAt();
-    try {
-      MessageDigest digest = MessageDigest.getInstance("SHA-256");
-      byte[] hashBytes = digest.digest(input.getBytes(StandardCharsets.UTF_8));
-      StringBuilder hex = new StringBuilder(64);
-      for (byte b : hashBytes) {
-        hex.append(String.format("%02x", b));
-      }
-      return hex.toString();
-    } catch (NoSuchAlgorithmException e) {
-      throw new IllegalStateException("SHA-256 not available", e);
     }
   }
 }

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/adapter/persistence/ChainHeadJpaEntity.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/adapter/persistence/ChainHeadJpaEntity.java
@@ -1,0 +1,43 @@
+package xyz.dgz48.tasks.webapi.audit.adapter.persistence;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * chain_heads テーブルの JPA エンティティ(ADR-0038 §3.4)。
+ *
+ * <p>{@code chain_key} 単位の連鎖末尾(末尾ハッシュ・最大 chain_seq)を保持する。監査 INSERT 時に該当行を悲観ロックで取得して 並行 INSERT
+ * を直列化する。{@code chain_key} はテナント行は {@code tenant_id}、横断行は予約値 {@code 0}。
+ */
+@Entity
+@Table(name = "chain_heads")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SuppressWarnings("NullAway.Init")
+class ChainHeadJpaEntity {
+
+  @Id
+  @Column(name = "chain_key")
+  private Long chainKey;
+
+  @Column(name = "last_hash", nullable = false, length = 64)
+  private String lastHash;
+
+  @Column(name = "last_seq", nullable = false)
+  private Long lastSeq;
+
+  @Column(name = "updated_at", nullable = false)
+  private LocalDateTime updatedAt;
+
+  void update(String lastHash, long lastSeq, LocalDateTime updatedAt) {
+    this.lastHash = lastHash;
+    this.lastSeq = lastSeq;
+    this.updatedAt = updatedAt;
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/adapter/persistence/ChainHeadJpaRepository.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/adapter/persistence/ChainHeadJpaRepository.java
@@ -1,0 +1,34 @@
+package xyz.dgz48.tasks.webapi.audit.adapter.persistence;
+
+import jakarta.persistence.LockModeType;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+interface ChainHeadJpaRepository extends JpaRepository<ChainHeadJpaEntity, Long> {
+
+  /**
+   * 当該 {@code chain_key} の行が無ければジェネシス相当(末尾 seq=0)で生成する。存在する場合は no-op (上書きしない)。直後の {@link
+   * #lockByChainKey} による {@code FOR UPDATE} が必ず行を掴めるよう、行の存在を保証する(ADR-0038 §3.4)。
+   */
+  @Modifying
+  @Query(
+      value =
+          "INSERT INTO chain_heads (chain_key, last_hash, last_seq, updated_at)"
+              + " VALUES (:chainKey, :genesisHash, 0, :now)"
+              + " ON DUPLICATE KEY UPDATE chain_key = chain_key",
+      nativeQuery = true)
+  void ensureExists(
+      @Param("chainKey") long chainKey,
+      @Param("genesisHash") String genesisHash,
+      @Param("now") LocalDateTime now);
+
+  /** 当該 {@code chain_key} の末尾行を悲観ロック({@code SELECT ... FOR UPDATE})で取得する。 */
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @Query("select h from ChainHeadJpaEntity h where h.chainKey = :chainKey")
+  Optional<ChainHeadJpaEntity> lockByChainKey(@Param("chainKey") long chainKey);
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/domain/AuditCanonicalizer.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/domain/AuditCanonicalizer.java
@@ -1,0 +1,52 @@
+package xyz.dgz48.tasks.webapi.audit.domain;
+
+import java.nio.charset.StandardCharsets;
+import java.time.format.DateTimeFormatter;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import tools.jackson.databind.SerializationFeature;
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * 監査行を決定的な正準 JSON バイト列へ変換する(ADR-0038 §3.2)。
+ *
+ * <p>書込側・検証側の双方がこの 1 関数だけを通すことで HMAC 入力の byte 一致を保証する。決定性のため、リクエスト経路の {@code JsonMapper}
+ * には依存せず、本クラス専用に <b>マップキーをキー順整列</b>({@link SerializationFeature#ORDER_MAP_ENTRIES_BY_KEYS})した
+ * {@code JsonMapper} を構築する。これによりトップレベル列もネストした {@code detail} オブジェクトのキー順も、書込時の挿入順に依存せず一意に定まる。
+ *
+ * <p>{@code created_at} は Jackson の自動シリアライズに任せず、秒精度の固定フォーマットで文字列化する({@code DATETIME}
+ * 列の精度と一致させ、再読込時の差異を防ぐ)。{@code detail} は格納済み JSON 文字列をツリーに復元してネスト object として埋め込み、文字列として再エスケープしない。
+ */
+public final class AuditCanonicalizer {
+
+  /** {@code created_at} の正準フォーマット(JST 壁時計・秒精度。ADR-0009)。 */
+  private static final DateTimeFormatter CREATED_AT_FORMAT =
+      DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
+
+  /** キー順整列を有効にした正準化専用 mapper(マップは全階層でキー昇順に整列される)。 */
+  private static final JsonMapper CANONICAL_MAPPER =
+      JsonMapper.builder().enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS).build();
+
+  private AuditCanonicalizer() {}
+
+  /**
+   * 監査行を正準 JSON の UTF-8 バイト列へ変換する。
+   *
+   * @param row 監査行(不変列)
+   * @return HMAC 入力に用いる正準バイト列
+   */
+  public static byte[] canonicalBytes(CanonicalAuditRow row) {
+    Map<String, Object> canonical = new LinkedHashMap<>();
+    canonical.put("chain_key", row.chainKey());
+    canonical.put("chain_seq", row.chainSeq());
+    canonical.put("user_id", row.userId());
+    canonical.put("action", row.action());
+    canonical.put("entity_type", row.entityType());
+    canonical.put("entity_id", row.entityId());
+    canonical.put("detail", CANONICAL_MAPPER.readValue(row.detailJson(), Object.class));
+    canonical.put("ip_address", row.ipAddress());
+    canonical.put("created_at", row.createdAt().format(CREATED_AT_FORMAT));
+    canonical.put("hash_key_id", row.hashKeyId());
+    return CANONICAL_MAPPER.writeValueAsString(canonical).getBytes(StandardCharsets.UTF_8);
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/domain/AuditChainHasher.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/domain/AuditChainHasher.java
@@ -1,0 +1,54 @@
+package xyz.dgz48.tasks.webapi.audit.domain;
+
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import javax.crypto.Mac;
+import javax.crypto.SecretKey;
+
+/**
+ * 監査ハッシュチェーンの 1 リンクを計算する(ADR-0038 §3.2 / §3.3)。
+ *
+ * <pre>hash_n = HMAC_SHA256( key , canonical(row_n) ‖ hash_{n-1}_hex )</pre>
+ *
+ * <p>前ハッシュは hex 文字列(64 桁小文字)の UTF-8 バイト列として正準バイト列の後ろに連結する。各連鎖の先頭行は前ハッシュとして {@link #GENESIS_HASH}
+ * を用いる。HMAC 鍵を用いるため、DB 単独を侵害した攻撃者(鍵を持たない)は連鎖を偽造できない(NIST AU-9 / AU-10)。
+ */
+public final class AuditChainHasher {
+
+  /** 各連鎖の先頭行が前ハッシュとして用いるジェネシスハッシュ(64 桁のゼロ)。 */
+  public static final String GENESIS_HASH = "0".repeat(64);
+
+  private static final String HMAC_ALGORITHM = "HmacSHA256";
+
+  private AuditChainHasher() {}
+
+  /**
+   * 自レコードハッシュを計算し 64 桁小文字 hex で返す。
+   *
+   * @param canonicalBytes {@link AuditCanonicalizer#canonicalBytes} の出力
+   * @param prevHashHex 直前行のハッシュ hex(連鎖先頭は {@link #GENESIS_HASH})
+   * @param key この行の {@code hash_key_id} に対応する HMAC 鍵
+   * @return 自レコードハッシュ(64 桁小文字 hex)
+   */
+  public static String hmacHex(byte[] canonicalBytes, String prevHashHex, SecretKey key) {
+    try {
+      Mac mac = Mac.getInstance(HMAC_ALGORITHM);
+      mac.init(key);
+      mac.update(canonicalBytes);
+      byte[] digest = mac.doFinal(prevHashHex.getBytes(StandardCharsets.UTF_8));
+      return toHex(digest);
+    } catch (NoSuchAlgorithmException | InvalidKeyException e) {
+      throw new IllegalStateException("HMAC-SHA256 の初期化に失敗しました", e);
+    }
+  }
+
+  private static String toHex(byte[] bytes) {
+    StringBuilder hex = new StringBuilder(bytes.length * 2);
+    for (byte b : bytes) {
+      hex.append(Character.forDigit((b >> 4) & 0xF, 16));
+      hex.append(Character.forDigit(b & 0xF, 16));
+    }
+    return hex.toString();
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/domain/CanonicalAuditRow.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/domain/CanonicalAuditRow.java
@@ -1,0 +1,34 @@
+package xyz.dgz48.tasks.webapi.audit.domain;
+
+import java.time.LocalDateTime;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * ハッシュチェーン計算の入力となる監査行の不変表現(ADR-0038 §3.2)。
+ *
+ * <p>書込側(adapter)と検証側(B-05 バッチ)が同一の {@link AuditCanonicalizer} を通すことで、再計算結果が byte
+ * 単位で一致することを保証する。{@code chainKey} は解決済みの値(テナント行は {@code tenant_id}、横断行は予約値 {@code 0})であり、{@code
+ * audit_logs.tenant_id} 列の値(横断行は {@code NULL})とは異なる点に注意する。
+ *
+ * @param chainKey 連鎖キー(tenant_id、横断は 0)
+ * @param chainSeq 連鎖内の順序(1 始まり)
+ * @param userId 操作ユーザー ID(不明な場合は {@code null})
+ * @param action イベント種別({@code AuditEventType.name()})
+ * @param entityType 対象エンティティ種別({@code null} 可)
+ * @param entityId 対象 ID({@code null} 可)
+ * @param detailJson detail 列に格納する JSON 文字列(空は {@code "{}"})。canonical ではネスト object として埋め込む
+ * @param ipAddress 送信元 IP({@code null} 可)
+ * @param createdAt 発生日時(JST、秒精度に正規化済み)
+ * @param hashKeyId この行の HMAC 計算に用いる鍵識別子
+ */
+public record CanonicalAuditRow(
+    long chainKey,
+    long chainSeq,
+    @Nullable Long userId,
+    String action,
+    @Nullable String entityType,
+    @Nullable Long entityId,
+    String detailJson,
+    @Nullable String ipAddress,
+    LocalDateTime createdAt,
+    String hashKeyId) {}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/infra/AuditHashChainConfig.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/infra/AuditHashChainConfig.java
@@ -1,0 +1,25 @@
+package xyz.dgz48.tasks.webapi.audit.infra;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import xyz.dgz48.tasks.webapi.audit.adapter.external.PropertyHmacKeyProvider;
+import xyz.dgz48.tasks.webapi.audit.usecase.HmacKeyProvider;
+
+/**
+ * 監査ハッシュチェーンの HMAC 鍵プロバイダを構成する(ADR-0038 §3.3)。
+ *
+ * <p>既定は設定値由来の {@link PropertyHmacKeyProvider}(ローカル / テスト)。{@code source=ssm} の本番経路は別 PR で
+ * {@code @ConditionalOnProperty} の SSM 実装を追加し、本フォールバックは {@link ConditionalOnMissingBean} で退避する。
+ */
+@Configuration(proxyBeanMethods = false)
+@EnableConfigurationProperties(AuditHashChainProperties.class)
+class AuditHashChainConfig {
+
+  @Bean
+  @ConditionalOnMissingBean(HmacKeyProvider.class)
+  HmacKeyProvider propertyHmacKeyProvider(AuditHashChainProperties properties) {
+    return new PropertyHmacKeyProvider(properties.keyId(), properties.secret());
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/infra/AuditHashChainProperties.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/infra/AuditHashChainProperties.java
@@ -1,0 +1,22 @@
+package xyz.dgz48.tasks.webapi.audit.infra;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.bind.DefaultValue;
+
+/**
+ * 監査ハッシュチェーンの設定(application.yml の {@code audit.hash-chain.*}、ADR-0038 §3.3)。
+ *
+ * <p>{@code source=property}(既定)は {@code secret} の値を HMAC 鍵に用いる(ローカル / テスト用)。{@code source=ssm} は
+ * Parameter Store SecureString から鍵をロードする(本番)。{@code keyId} は新規書込の {@code hash_key_id} となる。
+ *
+ * @param keyId 現行の鍵識別子({@code hash_key_id})
+ * @param source 鍵の取得元({@code property} | {@code ssm})
+ * @param secret {@code source=property} 時の HMAC 鍵(本番では使わない)
+ * @param ssmParameterPrefix {@code source=ssm} 時の鍵パラメータ名の接頭辞(実名は {@code <prefix>-<keyId>})
+ */
+@ConfigurationProperties("audit.hash-chain")
+public record AuditHashChainProperties(
+    @DefaultValue("v1") String keyId,
+    @DefaultValue("property") String source,
+    @DefaultValue("dev-insecure-audit-hmac-key-change-me") String secret,
+    @DefaultValue("/tasks/dev/app/audit-hash-key") String ssmParameterPrefix) {}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/infra/package-info.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/infra/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package xyz.dgz48.tasks.webapi.audit.infra;
+
+import org.jspecify.annotations.NullMarked;

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/usecase/HmacKeyProvider.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/usecase/HmacKeyProvider.java
@@ -1,0 +1,28 @@
+package xyz.dgz48.tasks.webapi.audit.usecase;
+
+import javax.crypto.SecretKey;
+
+/**
+ * 監査ハッシュチェーンの HMAC 鍵を解決する Port(ADR-0038 §3.3)。
+ *
+ * <p>鍵は DB 外(Parameter Store / KMS)で管理する(設計規約 §5.4)。各監査行は計算に用いた鍵を {@code hash_key_id} で記録し、検証時は
+ * その識別子で鍵を解決する。ローテーション後の新規行は新しい鍵 ID を用い、既存行は元の鍵 ID で検証するため、連鎖は鍵に依存せず途切れない。
+ */
+public interface HmacKeyProvider {
+
+  /**
+   * 新規書込で用いる現行の鍵識別子を返す。
+   *
+   * @return 現行の {@code hash_key_id}
+   */
+  String currentKeyId();
+
+  /**
+   * 指定された鍵識別子に対応する HMAC-SHA256 鍵を返す。
+   *
+   * @param keyId 鍵識別子({@code hash_key_id})
+   * @return HMAC 鍵
+   * @throws IllegalArgumentException 未知の鍵識別子の場合
+   */
+  SecretKey keyFor(String keyId);
+}

--- a/webapi/src/main/resources/application.yml
+++ b/webapi/src/main/resources/application.yml
@@ -71,6 +71,16 @@ rds:
     enabled: ${RDS_IAM_AUTH_ENABLED:false}
     region: ${AWS_DEFAULT_REGION:ap-northeast-1}
 
+# 監査ログ ハッシュチェーン改ざん検知(ADR-0038)。HMAC 鍵の取得元を切り替える。
+#   source=property(既定): secret 値を鍵に用いる(ローカル/テスト)。
+#   source=ssm(本番)     : Parameter Store SecureString から <ssm-parameter-prefix>-<key-id> をロード。
+audit:
+  hash-chain:
+    key-id: ${AUDIT_HASH_CHAIN_KEY_ID:v1}
+    source: ${AUDIT_HASH_CHAIN_SOURCE:property}
+    secret: ${AUDIT_HASH_CHAIN_SECRET:dev-insecure-audit-hmac-key-change-me}
+    ssm-parameter-prefix: ${AUDIT_HASH_CHAIN_SSM_PREFIX:/tasks/dev/app/audit-hash-key}
+
 # 通知バッチ(B-01 期限当日通知メール、設計規約 §7 / 基本設計書 §8.1)。
 # email.provider=ses のときのみ SES クライアントを生成。既定 log はローカル/テスト用のログフォールバック。
 notification:

--- a/webapi/src/main/resources/db/migration/V1.0.0_03__audit_hash_chain.sql
+++ b/webapi/src/main/resources/db/migration/V1.0.0_03__audit_hash_chain.sql
@@ -1,0 +1,34 @@
+-- ADR-0038: 監査ログ ハッシュチェーン改ざん検知(テナント単位連鎖・自レコード HMAC)。
+-- Sprint 3 の弱い hash_chain(前レコード SHA-256 / 再帰なし)を、真の連鎖
+-- (hash_n = HMAC_SHA256(key, canonical(自行) ‖ hash_{n-1}))へ作り直す書込経路スキーマ。
+--
+-- プレ本番(本番データなし)のため後方互換移行は設けず、旧セマンティクスで記録された
+-- 既存行は破棄する(ADR-0038 §6 実装メモ)。
+
+-- 旧セマンティクスの行を破棄(新 NOT NULL 列 chain_seq / hash_key_id を満たせないため)。
+TRUNCATE TABLE audit_logs;
+
+-- 自レコードハッシュ化に必要な列を追加。
+--   chain_seq   : 連鎖内の順序の正本。グローバル id 昇順は chain_key 横断で順序が崩れ、
+--                 created_at(DATETIME 秒精度)は高負荷時に同秒衝突するため決定的順序を持つ。
+--   hash_key_id : HMAC 鍵識別子(ローテーション対応。canonical(row) 入力にも含める)。
+ALTER TABLE audit_logs
+    ADD COLUMN chain_seq   BIGINT      NOT NULL COMMENT '連鎖内の順序の正本(chain_key 単位、1 始まり)' AFTER hash_chain,
+    ADD COLUMN hash_key_id VARCHAR(32) NOT NULL COMMENT 'この行の HMAC 計算に用いた鍵の識別子' AFTER chain_seq,
+    ADD KEY idx_al_chain (tenant_id, chain_seq);
+
+-- hash_chain の意味を「前レコードの SHA-256」→「自レコードの HMAC(前ハッシュ込み)」へ変更。
+-- 列名・型は維持し、コメントのみ改訂(ADR-0038 §3.5)。
+ALTER TABLE audit_logs
+    MODIFY COLUMN hash_chain CHAR(64) NOT NULL COMMENT '自レコードの HMAC-SHA256(canonical(自行) ‖ 前ハッシュ)。改ざん検知用(ADR-0038)';
+
+-- 連鎖末尾の状態を chain_key 単位で保持し、行ロックで並行 INSERT を直列化する(ADR-0038 §3.4)。
+-- chain_key = tenant_id、tenant_id IS NULL(プラットフォーム横断)は予約値 0。
+-- 行は初回書込時に upsert で生成するため seed しない。
+CREATE TABLE chain_heads (
+    chain_key  BIGINT     NOT NULL COMMENT 'tenant_id、横断は予約値 0',
+    last_hash  CHAR(64)   NOT NULL COMMENT 'この連鎖の末尾行ハッシュ',
+    last_seq   BIGINT     NOT NULL COMMENT 'この連鎖の最大 chain_seq',
+    updated_at DATETIME   NOT NULL COMMENT '末尾更新日時',
+    PRIMARY KEY (chain_key)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/audit/AuthorizationDeniedAuditIT.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/audit/AuthorizationDeniedAuditIT.java
@@ -290,10 +290,15 @@ class AuthorizationDeniedAuditIT {
         ignored -> {
           @SuppressWarnings("unchecked")
           List<String> hashes =
-              em.createNativeQuery("SELECT hash_chain FROM audit_logs ORDER BY id").getResultList();
+              em.createNativeQuery("SELECT hash_chain FROM audit_logs ORDER BY chain_seq")
+                  .getResultList();
           assertThat(hashes).hasSize(2);
-          assertThat(hashes.get(0)).isEqualTo("0".repeat(64));
-          assertThat(hashes.get(1)).isNotEqualTo("0".repeat(64)).matches("[0-9a-f]{64}");
+          // ADR-0038: 各行は自レコードハッシュを格納する。先頭行もジェネシスではなく自己ハッシュ。
+          assertThat(hashes.get(0)).isNotEqualTo("0".repeat(64)).matches("[0-9a-f]{64}");
+          assertThat(hashes.get(1))
+              .isNotEqualTo("0".repeat(64))
+              .matches("[0-9a-f]{64}")
+              .isNotEqualTo(hashes.get(0));
           return null;
         });
   }

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/audit/CrossTenantViolationDetectionIT.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/audit/CrossTenantViolationDetectionIT.java
@@ -113,7 +113,9 @@ class CrossTenantViolationDetectionIT {
   }
 
   @Test
-  void hashChain_firstRecordUsesGenesisHash_secondRecordHasNonGenesisHash() {
+  void hashChain_eachRecordStoresOwnHmac_andChainSeqIncrements() {
+    // ADR-0038: 各行は自レコードハッシュ(HMAC(canonical(自行) ‖ 前ハッシュ))を格納する。
+    // 先頭行も前ハッシュ=ジェネシスで計算した自己ハッシュであり、ジェネシスそのものではない。
     // 1件目の違反を記録
     taskRepository.findById(Long.MAX_VALUE);
     // 2件目の違反を記録
@@ -121,16 +123,21 @@ class CrossTenantViolationDetectionIT {
 
     List<Map<String, Object>> rows =
         jdbcTemplate.queryForList(
-            "SELECT hash_chain FROM audit_logs" + " WHERE action = 'TENANT_CROSSED' ORDER BY id");
+            "SELECT hash_chain, chain_seq, hash_key_id FROM audit_logs"
+                + " WHERE action = 'TENANT_CROSSED' ORDER BY chain_seq");
     assertThat(rows).hasSize(2);
 
-    // 1件目はジェネシスハッシュ(前レコードなし)
-    assertThat(rows.get(0).get("hash_chain")).isEqualTo("0".repeat(64));
-
-    // 2件目は前レコードを参照したチェーンハッシュ(ジェネシスハッシュではなく 64 桁の hex)
+    String first = (String) rows.get(0).get("hash_chain");
     String second = (String) rows.get(1).get("hash_chain");
-    assertThat(second).isNotEqualTo("0".repeat(64));
-    assertThat(second).matches("[0-9a-f]{64}");
+
+    // 双方とも 64 桁 hex の自己ハッシュ(ジェネシスではない)で、相異なる。
+    assertThat(first).matches("[0-9a-f]{64}").isNotEqualTo("0".repeat(64));
+    assertThat(second).matches("[0-9a-f]{64}").isNotEqualTo("0".repeat(64)).isNotEqualTo(first);
+
+    // chain_seq は同一連鎖(横断 = chain_key 0)で 1, 2 と採番される。
+    assertThat(((Number) rows.get(0).get("chain_seq")).longValue()).isEqualTo(1L);
+    assertThat(((Number) rows.get(1).get("chain_seq")).longValue()).isEqualTo(2L);
+    assertThat(rows.get(0).get("hash_key_id")).isEqualTo("v1");
   }
 
   private void setUpSaasAdmin() {

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/audit/adapter/external/PropertyHmacKeyProviderTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/audit/adapter/external/PropertyHmacKeyProviderTest.java
@@ -1,0 +1,32 @@
+package xyz.dgz48.tasks.webapi.audit.adapter.external;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+/** {@link PropertyHmacKeyProvider} のユニットテスト。 */
+class PropertyHmacKeyProviderTest {
+
+  private final PropertyHmacKeyProvider provider = new PropertyHmacKeyProvider("v1", "test-secret");
+
+  @Test
+  void currentKeyId_returnsConfiguredId() {
+    assertThat(provider.currentKeyId()).isEqualTo("v1");
+  }
+
+  @Test
+  void keyFor_currentId_returnsHmacSha256Key() {
+    var key = provider.keyFor("v1");
+    assertThat(key.getAlgorithm()).isEqualTo("HmacSHA256");
+    assertThat(key.getEncoded())
+        .isEqualTo("test-secret".getBytes(java.nio.charset.StandardCharsets.UTF_8));
+  }
+
+  @Test
+  void keyFor_unknownId_throws() {
+    assertThatThrownBy(() -> provider.keyFor("v2"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("v2");
+  }
+}

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/audit/adapter/persistence/AuditLogPersistenceAdapterTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/audit/adapter/persistence/AuditLogPersistenceAdapterTest.java
@@ -2,46 +2,25 @@ package xyz.dgz48.tasks.webapi.audit.adapter.persistence;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.json.JsonMapper;
 import xyz.dgz48.tasks.webapi.audit.usecase.AuditFieldChange;
 
-/** {@link AuditLogPersistenceAdapter} のユニットテスト。 */
+/**
+ * {@link AuditLogPersistenceAdapter} の {@code serializeDetail} のユニットテスト。
+ *
+ * <p>連鎖計算({@code canonical} / HMAC)は {@code AuditCanonicalizerTest} / {@code AuditChainHasherTest}
+ * で、 連鎖の連結・直列化は Testcontainers IT で検証する。
+ */
 class AuditLogPersistenceAdapterTest {
 
   private static JsonMapper defaultJsonMapper() {
     // Jackson 3.x では DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS がデフォルト false のため
     // LocalDate は設定なしで "2026-08-01" のような ISO 文字列にシリアライズされる
     return JsonMapper.builder().build();
-  }
-
-  @Test
-  void computeChainHash_whenNoPreviousRecord_returnsGenesisHash() {
-    String hash = AuditLogPersistenceAdapter.computeChainHash(null);
-    assertThat(hash).isEqualTo("0".repeat(64));
-  }
-
-  @Test
-  void computeChainHash_withPreviousRecord_computesSha256OfIdDetailCreatedAt() {
-    LocalDateTime createdAt = LocalDateTime.of(2026, 6, 6, 11, 0, 0);
-    String detail = "{\"table\":\"tasks\",\"sqlType\":\"SELECT\"}";
-    var prev =
-        new AuditLogJpaEntity(null, null, "TENANT_CROSSED", detail, createdAt, "0".repeat(64));
-
-    String hash = AuditLogPersistenceAdapter.computeChainHash(prev);
-
-    // prev.getId() は null(未永続化エンティティ) — same behavior as null|detail|createdAt input
-    String expectedInput = prev.getId() + "|" + prev.getDetail() + "|" + prev.getCreatedAt();
-    assertThat(hash).isEqualTo(sha256Hex(expectedInput));
-    assertThat(hash).matches("[0-9a-f]{64}");
-    assertThat(hash).isNotEqualTo("0".repeat(64));
   }
 
   @Test
@@ -85,20 +64,7 @@ class AuditLogPersistenceAdapterTest {
   }
 
   private static AuditLogPersistenceAdapter newAdapter() {
-    return new AuditLogPersistenceAdapter(null, null, defaultJsonMapper());
-  }
-
-  private static String sha256Hex(String input) {
-    try {
-      MessageDigest digest = MessageDigest.getInstance("SHA-256");
-      byte[] hashBytes = digest.digest(input.getBytes(StandardCharsets.UTF_8));
-      StringBuilder hex = new StringBuilder(64);
-      for (byte b : hashBytes) {
-        hex.append(String.format("%02x", b));
-      }
-      return hex.toString();
-    } catch (NoSuchAlgorithmException e) {
-      throw new IllegalStateException("SHA-256 not available", e);
-    }
+    // serializeDetail は jsonMapper のみを使うため、他の協調オブジェクトは不要。
+    return new AuditLogPersistenceAdapter(null, null, null, defaultJsonMapper(), null);
   }
 }

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/audit/domain/AuditCanonicalizerTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/audit/domain/AuditCanonicalizerTest.java
@@ -1,0 +1,97 @@
+package xyz.dgz48.tasks.webapi.audit.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@link AuditCanonicalizer} のユニットテスト。
+ *
+ * <p>正準バイト列がプロセス間で決定的(キー順固定・detail のキー順非依存・created_at の固定フォーマット・null の JSON null
+ * 表現)であることを検証する。これは書込側と検証側で HMAC 入力が byte 一致することの回帰ロックである(ADR-0038 §3.2)。
+ */
+class AuditCanonicalizerTest {
+
+  private static String canonical(CanonicalAuditRow row) {
+    return new String(AuditCanonicalizer.canonicalBytes(row), StandardCharsets.UTF_8);
+  }
+
+  @Test
+  void canonicalBytes_producesFixedKeyOrderJson_withNestedDetail() {
+    var row =
+        new CanonicalAuditRow(
+            5L,
+            3L,
+            42L,
+            "TASK_UPDATED",
+            "tasks",
+            100L,
+            "{\"b\":2,\"a\":1}",
+            "192.0.2.1",
+            LocalDateTime.of(2026, 1, 15, 10, 30, 45),
+            "v1");
+
+    assertThat(canonical(row))
+        .isEqualTo(
+            "{\"action\":\"TASK_UPDATED\",\"chain_key\":5,\"chain_seq\":3,"
+                + "\"created_at\":\"2026-01-15T10:30:45\",\"detail\":{\"a\":1,\"b\":2},"
+                + "\"entity_id\":100,\"entity_type\":\"tasks\",\"hash_key_id\":\"v1\","
+                + "\"ip_address\":\"192.0.2.1\",\"user_id\":42}");
+  }
+
+  @Test
+  void canonicalBytes_representsNullColumnsAsJsonNull_andEmptyDetailAsEmptyObject() {
+    var row =
+        new CanonicalAuditRow(
+            0L,
+            1L,
+            null,
+            "TENANT_CROSSED",
+            null,
+            null,
+            "{}",
+            null,
+            LocalDateTime.of(2026, 1, 15, 0, 0, 0),
+            "v1");
+
+    assertThat(canonical(row))
+        .isEqualTo(
+            "{\"action\":\"TENANT_CROSSED\",\"chain_key\":0,\"chain_seq\":1,"
+                + "\"created_at\":\"2026-01-15T00:00:00\",\"detail\":{},"
+                + "\"entity_id\":null,\"entity_type\":null,\"hash_key_id\":\"v1\","
+                + "\"ip_address\":null,\"user_id\":null}");
+  }
+
+  @Test
+  void canonicalBytes_isIndependentOfDetailKeyInsertionOrder() {
+    var createdAt = LocalDateTime.of(2026, 1, 15, 10, 0, 0);
+    var rowA =
+        new CanonicalAuditRow(
+            1L, 1L, 7L, "TASK_UPDATED", null, null, "{\"x\":1,\"y\":2}", null, createdAt, "v1");
+    var rowB =
+        new CanonicalAuditRow(
+            1L, 1L, 7L, "TASK_UPDATED", null, null, "{\"y\":2,\"x\":1}", null, createdAt, "v1");
+
+    assertThat(canonical(rowA)).isEqualTo(canonical(rowB));
+  }
+
+  @Test
+  void canonicalBytes_truncatesNothingButFormatsSecondsPrecision() {
+    var row =
+        new CanonicalAuditRow(
+            1L,
+            1L,
+            null,
+            "LOGIN",
+            null,
+            null,
+            "{}",
+            null,
+            LocalDateTime.of(2026, 12, 31, 23, 59, 59),
+            "v1");
+
+    assertThat(canonical(row)).contains("\"created_at\":\"2026-12-31T23:59:59\"");
+  }
+}

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/audit/domain/AuditChainHasherTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/audit/domain/AuditChainHasherTest.java
@@ -1,0 +1,57 @@
+package xyz.dgz48.tasks.webapi.audit.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import javax.crypto.spec.SecretKeySpec;
+import org.junit.jupiter.api.Test;
+
+/** {@link AuditChainHasher} のユニットテスト。 */
+class AuditChainHasherTest {
+
+  private static SecretKeySpec key(byte[] bytes) {
+    return new SecretKeySpec(bytes, "HmacSHA256");
+  }
+
+  @Test
+  void genesisHash_is64Zeros() {
+    assertThat(AuditChainHasher.GENESIS_HASH).isEqualTo("0".repeat(64)).hasSize(64);
+  }
+
+  @Test
+  void hmacHex_matchesRfc4231TestCase1() {
+    // RFC 4231 §4.2 Test Case 1: key = 0x0b×20, data = "Hi There"。
+    // hmacHex は canonicalBytes ‖ prevHashHex を HMAC するため、prevHashHex="" として
+    // 実効メッセージを "Hi There" に一致させる。
+    byte[] keyBytes = new byte[20];
+    Arrays.fill(keyBytes, (byte) 0x0b);
+
+    String hash =
+        AuditChainHasher.hmacHex("Hi There".getBytes(StandardCharsets.UTF_8), "", key(keyBytes));
+
+    assertThat(hash).isEqualTo("b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7");
+  }
+
+  @Test
+  void hmacHex_isDeterministic_and64LowercaseHex() {
+    var k = key("secret-key".getBytes(StandardCharsets.UTF_8));
+    byte[] canonical = "{\"a\":1}".getBytes(StandardCharsets.UTF_8);
+
+    String first = AuditChainHasher.hmacHex(canonical, AuditChainHasher.GENESIS_HASH, k);
+    String second = AuditChainHasher.hmacHex(canonical, AuditChainHasher.GENESIS_HASH, k);
+
+    assertThat(first).isEqualTo(second).matches("[0-9a-f]{64}");
+  }
+
+  @Test
+  void hmacHex_changesWhenPreviousHashChanges() {
+    var k = key("secret-key".getBytes(StandardCharsets.UTF_8));
+    byte[] canonical = "{\"a\":1}".getBytes(StandardCharsets.UTF_8);
+
+    String fromGenesis = AuditChainHasher.hmacHex(canonical, AuditChainHasher.GENESIS_HASH, k);
+    String fromOther = AuditChainHasher.hmacHex(canonical, "a".repeat(64), k);
+
+    assertThat(fromGenesis).isNotEqualTo(fromOther);
+  }
+}

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/shared/adapter/persistence/HibernateFilterEntityAuditTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/shared/adapter/persistence/HibernateFilterEntityAuditTest.java
@@ -36,7 +36,8 @@ class HibernateFilterEntityAuditTest {
           "UserJpaEntity", // users: プラットフォーム横断ユーザー、tenant_id 列なし
           "UserTenantJpaEntity", // user_tenants: TenantContext 確立前にクロステナント参照が必要
           "AppAdminUserJpaEntity", // app_admin_users: SaaS Admin ユーザー管理、tenant_id 列なし
-          "AuditLogJpaEntity" // audit_logs: tenant_id が nullable、テナント範囲を超えた参照が必要
+          "AuditLogJpaEntity", // audit_logs: tenant_id が nullable、テナント範囲を超えた参照が必要
+          "ChainHeadJpaEntity" // chain_heads: chain_key(=tenant_id/0)が PK、横断連鎖も持つ補助表(ADR-0038)
           );
 
   @Autowired EntityManagerFactory emf;


### PR DESCRIPTION
## 概要

Issue #751 / ADR-0038 の改ざん検知(tamper-evidence)のうち **書込経路** を実装する。Sprint 3 で landing 済の `computeChainHash` は真の連鎖でない(前ハッシュを入力に含めず再帰しない / 保護列 3 列 / 前行ハッシュ格納で末尾無保護)ため、自レコード HMAC へ作り直す。

検証経路(B-05 バッチ + `audit_anchors` + 改ざん検出 IT)は後続 PR(`Closes #751`)。本 PR は `Refs #751`。

## 方式(ADR-0038)

```
hash_n = HMAC_SHA256( key , canonical(自行の全不変列) ‖ hash_{n-1}_hex )
chain_key = tenant_id(横断は予約値 0)/ GENESIS = "0"×64
```

## 変更内容

### スキーマ(Flyway `V1.0.0_03`)
- `audit_logs` に `chain_seq` / `hash_key_id`(NOT NULL)を追加、`hash_chain` の意味を改訂、`idx_al_chain (tenant_id, chain_seq)` 追加
- `chain_heads` 新設(連鎖末尾の行ロック直列化)
- プレ本番のため `audit_logs` を truncate(後方互換 backfill なし、ADR-0038 §6)

### 連鎖計算
- **`AuditCanonicalizer`**: 専用 mapper(`ORDER_MAP_ENTRIES_BY_KEYS`)で決定的な正準 JSON を生成。`created_at` は秒精度固定フォーマット(`DATETIME` 列と一致)、`detail` はネスト object として埋め込み再 stringify しない。書込側・検証側が同一関数を通すことで **byte 一致を保証**(golden 文字列テストで回帰ロック)
- **`AuditChainHasher`**: HMAC-SHA256。RFC 4231 テストベクタで検証
- **`chain_heads` 直列化**: `chain_key` 単位で upsert(`ON DUPLICATE KEY UPDATE` no-op)→ `SELECT ... FOR UPDATE` → `chain_seq` 採番 → INSERT → 末尾更新。全表スキャン `findFirstByOrderByIdDesc` 廃止
- **`AuditLogPersistenceAdapter.record`** を `@Transactional(REQUIRED)` 化(4 文を単一 tx で原子化。`LOGIN_FAILED` 等 tx 外の正当呼出元があるため `MANDATORY` は不可)

### 鍵管理
- `HmacKeyProvider`(port)+ `PropertyHmacKeyProvider`(既定、dev/test)。`source=ssm` の本番経路は次 PR
- Terraform: `app/*` 配下に `audit-hash-key-v1` SecureString 新設。既存 `webapi_ssm`(`ssm:GetParameter*` + `kms:Decrypt`)で読み取り充足 → **iam.tf 変更不要**
- `software.amazon.awssdk:ssm` 依存追加

### テスト
- 新規 unit: `AuditCanonicalizerTest`(golden / null→json null / detail キー順非依存 / created_at 形式)、`AuditChainHasherTest`(RFC 4231)、`PropertyHmacKeyProviderTest`
- 既存 IT のセマンティクス反転: 先頭行もジェネシスではなく自己ハッシュ(`CrossTenantViolationDetectionIT` / `AuthorizationDeniedAuditIT`)
- `HibernateFilterEntityAuditTest` の除外リストに `ChainHeadJpaEntity` を追加

## 補足
- 設計規約 §4.3 / 基本設計書 §6.8・§4.2.6・§8.1 の改訂は ADR-0038 PR(#759)で landing 済のため本 PR では doc 変更なし
- `entity_type` / `entity_id` / `ip_address` は現状常に null(既存挙動)。canonical には null として入り決定的

## 検証
`./gradlew :webapi:check` 緑(spotlessCheck / 492 tests / JaCoCo 80% ゲート)。並行 INSERT 非分岐・改ざん検出の網羅 IT は B-05 を含む後続 PR で追加。

🤖 Generated with [Claude Code](https://claude.com/claude-code)