### PR TITLE
feat(audit): B-05 監査ログ ハッシュチェーン検証バッチ + アンカー (Closes #751)

### DIFF
--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/adapter/external/LoggingAuditChainAlertPort.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/adapter/external/LoggingAuditChainAlertPort.java
@@ -1,0 +1,28 @@
+package xyz.dgz48.tasks.webapi.audit.adapter.external;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import xyz.dgz48.tasks.webapi.audit.domain.AuditChainMismatch;
+import xyz.dgz48.tasks.webapi.audit.usecase.AuditChainAlertPort;
+
+/**
+ * 連鎖検証の不整合を構造化 ERROR ログで通知する {@link AuditChainAlertPort} 実装(ADR-0019 / ADR-0038 §3.7)。
+ *
+ * <p>ERROR ログが CloudWatch アラームの実体となる(ADR-0029)。出力は非 PII の連鎖メタデータ(chain_key / chain_seq /
+ * 不整合種別)のみで、監査行そのものは記録しない(fail-open のため例外は投げない)。
+ */
+@Component
+class LoggingAuditChainAlertPort implements AuditChainAlertPort {
+
+  private static final Logger log = LoggerFactory.getLogger(LoggingAuditChainAlertPort.class);
+
+  @Override
+  public void alert(AuditChainMismatch mismatch) {
+    log.error(
+        "監査ログ ハッシュチェーンの不整合を検知 chainKey={} atSeq={} reason={}",
+        mismatch.chainKey(),
+        mismatch.atSeq(),
+        mismatch.reason());
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/adapter/external/SsmHmacKeyProvider.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/adapter/external/SsmHmacKeyProvider.java
@@ -1,0 +1,54 @@
+package xyz.dgz48.tasks.webapi.audit.adapter.external;
+
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import software.amazon.awssdk.services.ssm.SsmClient;
+import software.amazon.awssdk.services.ssm.model.GetParameterRequest;
+import xyz.dgz48.tasks.webapi.audit.usecase.HmacKeyProvider;
+
+/**
+ * AWS Systems Manager Parameter Store(SecureString)から HMAC 鍵をロードする {@link
+ * HmacKeyProvider}(本番、ADR-0038 §3.3)。
+ *
+ * <p>パラメータ名は {@code <prefix>-<keyId>}(例 {@code /tasks/dev/app/audit-hash-key-v1})。鍵は不変のため鍵 ID
+ * 単位でキャッシュし、KMS 復号付きで一度だけ取得する。認証情報・リージョンは AWS SDK 標準プロバイダチェーン(ECS タスクロール)で解決する。
+ */
+public class SsmHmacKeyProvider implements HmacKeyProvider {
+
+  private static final String HMAC_ALGORITHM = "HmacSHA256";
+
+  private final SsmClient ssmClient;
+  private final String currentKeyId;
+  private final String parameterPrefix;
+  private final ConcurrentMap<String, SecretKey> cache = new ConcurrentHashMap<>();
+
+  public SsmHmacKeyProvider(SsmClient ssmClient, String currentKeyId, String parameterPrefix) {
+    this.ssmClient = ssmClient;
+    this.currentKeyId = currentKeyId;
+    this.parameterPrefix = parameterPrefix;
+  }
+
+  @Override
+  public String currentKeyId() {
+    return currentKeyId;
+  }
+
+  @Override
+  public SecretKey keyFor(String keyId) {
+    return cache.computeIfAbsent(keyId, this::loadKey);
+  }
+
+  private SecretKey loadKey(String keyId) {
+    String parameterName = parameterPrefix + "-" + keyId;
+    String secret =
+        ssmClient
+            .getParameter(
+                GetParameterRequest.builder().name(parameterName).withDecryption(true).build())
+            .parameter()
+            .value();
+    return new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), HMAC_ALGORITHM);
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/adapter/persistence/AuditAnchorJpaEntity.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/adapter/persistence/AuditAnchorJpaEntity.java
@@ -1,0 +1,57 @@
+package xyz.dgz48.tasks.webapi.audit.adapter.persistence;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * audit_anchors テーブルの JPA エンティティ(ADR-0038 §3.6)。
+ *
+ * <p>B-05 検証成功後に各 {@code chain_key} の連鎖頭を追記専用で固定する。B-03(保管削除)の対象外で prune しない。
+ */
+@Entity
+@Table(name = "audit_anchors")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SuppressWarnings("NullAway.Init")
+class AuditAnchorJpaEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(name = "chain_key", nullable = false)
+  private Long chainKey;
+
+  @Column(name = "seq_at_checkpoint", nullable = false)
+  private Long seqAtCheckpoint;
+
+  @Column(name = "head_hash", nullable = false, length = 64)
+  private String headHash;
+
+  @Column(name = "hash_key_id", nullable = false, length = 32)
+  private String hashKeyId;
+
+  @Column(name = "created_at", nullable = false)
+  private LocalDateTime createdAt;
+
+  AuditAnchorJpaEntity(
+      long chainKey,
+      long seqAtCheckpoint,
+      String headHash,
+      String hashKeyId,
+      LocalDateTime createdAt) {
+    this.chainKey = chainKey;
+    this.seqAtCheckpoint = seqAtCheckpoint;
+    this.headHash = headHash;
+    this.hashKeyId = hashKeyId;
+    this.createdAt = createdAt;
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/adapter/persistence/AuditAnchorJpaRepository.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/adapter/persistence/AuditAnchorJpaRepository.java
@@ -1,0 +1,12 @@
+package xyz.dgz48.tasks.webapi.audit.adapter.persistence;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+interface AuditAnchorJpaRepository extends JpaRepository<AuditAnchorJpaEntity, Long> {
+
+  /** 指定 seq 未満で最大の {@code seq_at_checkpoint} を持つアンカー(保管削除後の検証起点)。 */
+  Optional<AuditAnchorJpaEntity>
+      findFirstByChainKeyAndSeqAtCheckpointLessThanOrderBySeqAtCheckpointDesc(
+          long chainKey, long seqExclusive);
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/adapter/persistence/AuditChainQueryAdapter.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/adapter/persistence/AuditChainQueryAdapter.java
@@ -1,0 +1,99 @@
+package xyz.dgz48.tasks.webapi.audit.adapter.persistence;
+
+import io.micrometer.observation.annotation.Observed;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.stereotype.Component;
+import xyz.dgz48.tasks.webapi.audit.domain.AuditAnchor;
+import xyz.dgz48.tasks.webapi.audit.domain.AuditChainRow;
+import xyz.dgz48.tasks.webapi.audit.domain.CanonicalAuditRow;
+import xyz.dgz48.tasks.webapi.audit.domain.ChainHead;
+import xyz.dgz48.tasks.webapi.audit.usecase.AuditChainQueryPort;
+
+/**
+ * {@link AuditChainQueryPort} の JPA 実装(ADR-0038 §3.7)。
+ *
+ * <p>{@code chain_key} は {@code audit_logs} の列ではなく {@code tenant_id} から導出する(テナント行は {@code
+ * tenant_id}、横断行 = 予約値 {@code 0} は {@code tenant_id IS NULL})。生存行の取得は {@code idx_al_chain
+ * (tenant_id, chain_seq)} を用いる。
+ */
+@Observed(name = "audit.chainQuery")
+@Component
+class AuditChainQueryAdapter implements AuditChainQueryPort {
+
+  private static final long PLATFORM_CHAIN_KEY = 0L;
+
+  private final AuditLogJpaRepository auditLogRepository;
+  private final ChainHeadJpaRepository chainHeadRepository;
+  private final AuditAnchorJpaRepository anchorRepository;
+  private final Clock clock;
+
+  AuditChainQueryAdapter(
+      AuditLogJpaRepository auditLogRepository,
+      ChainHeadJpaRepository chainHeadRepository,
+      AuditAnchorJpaRepository anchorRepository,
+      Clock clock) {
+    this.auditLogRepository = auditLogRepository;
+    this.chainHeadRepository = chainHeadRepository;
+    this.anchorRepository = anchorRepository;
+    this.clock = clock;
+  }
+
+  @Override
+  public List<Long> findActiveChainKeys() {
+    return chainHeadRepository.findAllChainKeys();
+  }
+
+  @Override
+  public List<AuditChainRow> findRows(long chainKey) {
+    List<AuditLogJpaEntity> entities =
+        chainKey == PLATFORM_CHAIN_KEY
+            ? auditLogRepository.findByTenantIdIsNullOrderByChainSeqAsc()
+            : auditLogRepository.findByTenantIdOrderByChainSeqAsc(chainKey);
+    return entities.stream().map(e -> toChainRow(chainKey, e)).toList();
+  }
+
+  @Override
+  public Optional<ChainHead> findHead(long chainKey) {
+    return chainHeadRepository
+        .findById(chainKey)
+        .map(h -> new ChainHead(h.getChainKey(), h.getLastHash(), h.getLastSeq()));
+  }
+
+  @Override
+  public Optional<AuditAnchor> findLatestAnchorBelow(long chainKey, long seqExclusive) {
+    return anchorRepository
+        .findFirstByChainKeyAndSeqAtCheckpointLessThanOrderBySeqAtCheckpointDesc(
+            chainKey, seqExclusive)
+        .map(
+            a ->
+                new AuditAnchor(
+                    a.getChainKey(), a.getSeqAtCheckpoint(), a.getHeadHash(), a.getHashKeyId()));
+  }
+
+  @Override
+  public void appendAnchor(long chainKey, long seqAtCheckpoint, String headHash, String hashKeyId) {
+    LocalDateTime now = LocalDateTime.now(clock).truncatedTo(ChronoUnit.SECONDS);
+    anchorRepository.save(
+        new AuditAnchorJpaEntity(chainKey, seqAtCheckpoint, headHash, hashKeyId, now));
+  }
+
+  private static AuditChainRow toChainRow(long chainKey, AuditLogJpaEntity e) {
+    var canonical =
+        new CanonicalAuditRow(
+            chainKey,
+            e.getChainSeq(),
+            e.getUserId(),
+            e.getAction(),
+            e.getEntityType(),
+            e.getEntityId(),
+            e.getDetail() == null ? "{}" : e.getDetail(),
+            e.getIpAddress(),
+            e.getCreatedAt(),
+            e.getHashKeyId());
+    return new AuditChainRow(canonical, e.getHashChain());
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/adapter/persistence/AuditLogJpaRepository.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/adapter/persistence/AuditLogJpaRepository.java
@@ -1,5 +1,13 @@
 package xyz.dgz48.tasks.webapi.audit.adapter.persistence;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-interface AuditLogJpaRepository extends JpaRepository<AuditLogJpaEntity, Long> {}
+interface AuditLogJpaRepository extends JpaRepository<AuditLogJpaEntity, Long> {
+
+  /** テナント連鎖(chain_key = tenant_id)の生存行を chain_seq 昇順で返す(B-05 検証用)。 */
+  List<AuditLogJpaEntity> findByTenantIdOrderByChainSeqAsc(long tenantId);
+
+  /** プラットフォーム連鎖(chain_key = 0、tenant_id IS NULL)の生存行を chain_seq 昇順で返す(B-05 検証用)。 */
+  List<AuditLogJpaEntity> findByTenantIdIsNullOrderByChainSeqAsc();
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/adapter/persistence/ChainHeadJpaRepository.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/adapter/persistence/ChainHeadJpaRepository.java
@@ -2,6 +2,7 @@ package xyz.dgz48.tasks.webapi.audit.adapter.persistence;
 
 import jakarta.persistence.LockModeType;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
@@ -31,4 +32,8 @@ interface ChainHeadJpaRepository extends JpaRepository<ChainHeadJpaEntity, Long>
   @Lock(LockModeType.PESSIMISTIC_WRITE)
   @Query("select h from ChainHeadJpaEntity h where h.chainKey = :chainKey")
   Optional<ChainHeadJpaEntity> lockByChainKey(@Param("chainKey") long chainKey);
+
+  /** 連鎖が存在する全 {@code chain_key}(B-05 検証の対象集合)。 */
+  @Query("select h.chainKey from ChainHeadJpaEntity h")
+  List<Long> findAllChainKeys();
 }

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/domain/AuditAnchor.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/domain/AuditAnchor.java
@@ -1,0 +1,11 @@
+package xyz.dgz48.tasks.webapi.audit.domain;
+
+/**
+ * 検証チェックポイント({@code audit_anchors} の不変表現、ADR-0038 §3.6)。
+ *
+ * @param chainKey 連鎖キー(tenant_id、横断は 0)
+ * @param seqAtCheckpoint この時点の chain_seq
+ * @param headHash この時点の連鎖頭ハッシュ
+ * @param hashKeyId チェックポイント作成時の現行鍵 ID
+ */
+public record AuditAnchor(long chainKey, long seqAtCheckpoint, String headHash, String hashKeyId) {}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/domain/AuditChainMismatch.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/domain/AuditChainMismatch.java
@@ -1,0 +1,23 @@
+package xyz.dgz48.tasks.webapi.audit.domain;
+
+/**
+ * 連鎖検証で検出した不整合(ADR-0038 §3.7)。改ざん検知は fail-open であり、検出はアラートと構造化ログに用いる。
+ *
+ * @param chainKey 不整合が見つかった連鎖キー
+ * @param atSeq 不整合が見つかった chain_seq
+ * @param reason 不整合の種別
+ */
+public record AuditChainMismatch(long chainKey, long atSeq, Reason reason) {
+
+  /** 不整合の種別。 */
+  public enum Reason {
+    /** 連鎖順序の欠落・並べ替え(期待 chain_seq と不一致)。 */
+    SEQUENCE_BROKEN,
+    /** 行内容または格納ハッシュの改変(再計算ハッシュと不一致)。 */
+    HASH_MISMATCH,
+    /** 末尾の切り詰め(chain_heads の末尾と生存行の末尾が不一致)。 */
+    TAIL_MISMATCH,
+    /** 保管削除済み prefix の検証起点アンカーが見つからない。 */
+    MISSING_ANCHOR
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/domain/AuditChainRow.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/domain/AuditChainRow.java
@@ -1,0 +1,9 @@
+package xyz.dgz48.tasks.webapi.audit.domain;
+
+/**
+ * 検証対象の監査行(正準化入力 + 格納済みハッシュ)。
+ *
+ * @param canonical 正準化に用いる不変列
+ * @param storedHash {@code audit_logs.hash_chain} に格納されている値(再計算結果と突合する)
+ */
+public record AuditChainRow(CanonicalAuditRow canonical, String storedHash) {}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/domain/ChainHead.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/domain/ChainHead.java
@@ -1,0 +1,10 @@
+package xyz.dgz48.tasks.webapi.audit.domain;
+
+/**
+ * 連鎖末尾の状態({@code chain_heads} の不変表現)。
+ *
+ * @param chainKey 連鎖キー(tenant_id、横断は 0)
+ * @param lastHash 末尾行のハッシュ
+ * @param lastSeq 末尾の chain_seq
+ */
+public record ChainHead(long chainKey, String lastHash, long lastSeq) {}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/infra/AuditChainVerificationBatchScheduler.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/infra/AuditChainVerificationBatchScheduler.java
@@ -1,0 +1,45 @@
+package xyz.dgz48.tasks.webapi.audit.infra;
+
+import lombok.RequiredArgsConstructor;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.slf4j.MDC;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import xyz.dgz48.tasks.webapi.audit.usecase.VerifyAuditChainUseCase;
+
+/**
+ * B-05 監査ログ整合性検証バッチのスケジューラ(基本設計書 §8.1、毎日 02:00 JST、ADR-0038 §3.7)。
+ *
+ * <p>{@link SchedulerLock} により複数ノードでも単一ノードのみが実行する(設計規約 §7、ADR-0037)。実行時刻・タイムゾーン・有効化は {@code
+ * audit.verification.batch.*} で設定可能(既定: 02:00 / Asia/Tokyo / 有効)。MDC に {@code batchId} を設定する。
+ * 改ざん検知は fail-open であり、検証は監査書込をブロックしない。
+ */
+@Component
+@ConditionalOnProperty(
+    name = "audit.verification.batch.enabled",
+    havingValue = "true",
+    matchIfMissing = true)
+@RequiredArgsConstructor
+public class AuditChainVerificationBatchScheduler {
+
+  private static final String BATCH_ID = "B-05";
+
+  private final VerifyAuditChainUseCase verifyAuditChainUseCase;
+
+  @Scheduled(
+      cron = "${audit.verification.batch.cron:0 0 2 * * *}",
+      zone = "${audit.verification.batch.zone:Asia/Tokyo}")
+  @SchedulerLock(
+      name = "auditChainVerificationBatch",
+      lockAtLeastFor = "PT1M",
+      lockAtMostFor = "PT30M")
+  public void runAuditChainVerification() {
+    MDC.put("batchId", BATCH_ID);
+    try {
+      verifyAuditChainUseCase.execute();
+    } finally {
+      MDC.remove("batchId");
+    }
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/infra/AuditHashChainConfig.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/infra/AuditHashChainConfig.java
@@ -1,21 +1,40 @@
 package xyz.dgz48.tasks.webapi.audit.infra;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.services.ssm.SsmClient;
 import xyz.dgz48.tasks.webapi.audit.adapter.external.PropertyHmacKeyProvider;
+import xyz.dgz48.tasks.webapi.audit.adapter.external.SsmHmacKeyProvider;
 import xyz.dgz48.tasks.webapi.audit.usecase.HmacKeyProvider;
 
 /**
  * 監査ハッシュチェーンの HMAC 鍵プロバイダを構成する(ADR-0038 §3.3)。
  *
- * <p>既定は設定値由来の {@link PropertyHmacKeyProvider}(ローカル / テスト)。{@code source=ssm} の本番経路は別 PR で
- * {@code @ConditionalOnProperty} の SSM 実装を追加し、本フォールバックは {@link ConditionalOnMissingBean} で退避する。
+ * <p>{@code source=ssm}(本番)は Parameter Store から鍵をロードする {@link SsmHmacKeyProvider} を生成する。それ以外 (既定
+ * {@code property}、ローカル / テスト)は設定値由来の {@link PropertyHmacKeyProvider} をフォールバックとして使う ({@link
+ * ConditionalOnMissingBean} により ssm 経路が無いときだけ選択される)。
  */
 @Configuration(proxyBeanMethods = false)
 @EnableConfigurationProperties(AuditHashChainProperties.class)
 class AuditHashChainConfig {
+
+  @Bean
+  @ConditionalOnProperty(name = "audit.hash-chain.source", havingValue = "ssm")
+  SsmClient auditSsmClient() {
+    // リージョン・認証情報は AWS SDK の標準プロバイダチェーン(ECS タスクロール / 環境変数)から解決する。
+    return SsmClient.create();
+  }
+
+  @Bean
+  @ConditionalOnProperty(name = "audit.hash-chain.source", havingValue = "ssm")
+  HmacKeyProvider ssmHmacKeyProvider(
+      SsmClient auditSsmClient, AuditHashChainProperties properties) {
+    return new SsmHmacKeyProvider(
+        auditSsmClient, properties.keyId(), properties.ssmParameterPrefix());
+  }
 
   @Bean
   @ConditionalOnMissingBean(HmacKeyProvider.class)

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/usecase/AuditChainAlertPort.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/usecase/AuditChainAlertPort.java
@@ -1,0 +1,14 @@
+package xyz.dgz48.tasks.webapi.audit.usecase;
+
+import xyz.dgz48.tasks.webapi.audit.domain.AuditChainMismatch;
+
+/**
+ * 連鎖検証で検出した不整合を通知する Port(ADR-0038 §3.7)。
+ *
+ * <p>改ざん検知は fail-open(監査書込をブロックしない)。実装は構造化 ERROR ログ(ADR-0019、CloudWatch アラームの実体)を主経路とする。
+ */
+public interface AuditChainAlertPort {
+
+  /** 不整合を 1 件通知する。 */
+  void alert(AuditChainMismatch mismatch);
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/usecase/AuditChainQueryPort.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/usecase/AuditChainQueryPort.java
@@ -1,0 +1,31 @@
+package xyz.dgz48.tasks.webapi.audit.usecase;
+
+import java.util.List;
+import java.util.Optional;
+import xyz.dgz48.tasks.webapi.audit.domain.AuditAnchor;
+import xyz.dgz48.tasks.webapi.audit.domain.AuditChainRow;
+import xyz.dgz48.tasks.webapi.audit.domain.ChainHead;
+
+/** B-05 検証バッチが連鎖を読み出し・チェックポイントを追記するための Port(ADR-0038 §3.7)。 */
+public interface AuditChainQueryPort {
+
+  /** 連鎖が存在する全 {@code chain_key}(= {@code chain_heads} の全行)を返す。 */
+  List<Long> findActiveChainKeys();
+
+  /** 当該連鎖の生存行を {@code chain_seq} 昇順で返す。 */
+  List<AuditChainRow> findRows(long chainKey);
+
+  /** 当該連鎖の末尾状態を返す。 */
+  Optional<ChainHead> findHead(long chainKey);
+
+  /**
+   * 指定 {@code chain_seq} 未満で最大の {@code seq_at_checkpoint} を持つアンカーを返す(保管削除後の検証起点)。
+   *
+   * @param chainKey 連鎖キー
+   * @param seqExclusive これ未満の seq を持つ最新アンカーを探す
+   */
+  Optional<AuditAnchor> findLatestAnchorBelow(long chainKey, long seqExclusive);
+
+  /** 検証成功後に新しいチェックポイントを追記する。 */
+  void appendAnchor(long chainKey, long seqAtCheckpoint, String headHash, String hashKeyId);
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/usecase/AuditChainVerifier.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/usecase/AuditChainVerifier.java
@@ -1,0 +1,87 @@
+package xyz.dgz48.tasks.webapi.audit.usecase;
+
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import xyz.dgz48.tasks.webapi.audit.domain.AuditAnchor;
+import xyz.dgz48.tasks.webapi.audit.domain.AuditCanonicalizer;
+import xyz.dgz48.tasks.webapi.audit.domain.AuditChainHasher;
+import xyz.dgz48.tasks.webapi.audit.domain.AuditChainMismatch;
+import xyz.dgz48.tasks.webapi.audit.domain.AuditChainMismatch.Reason;
+import xyz.dgz48.tasks.webapi.audit.domain.AuditChainRow;
+import xyz.dgz48.tasks.webapi.audit.domain.ChainHead;
+
+/**
+ * 単一連鎖({@code chain_key})を検証し、整合していればチェックポイントを追記する(ADR-0038 §3.7)。
+ *
+ * <p>保管窓内の最古チェックポイント(無ければ GENESIS)を起点に末尾まで HMAC を再計算し、各行の格納ハッシュ・順序・末尾を突合する。 連鎖ごとに独立したトランザクションで実行し、1
+ * 連鎖の検証が他連鎖をブロックしないようにする(呼出側で fail-open に集約)。
+ */
+@Service
+@RequiredArgsConstructor
+class AuditChainVerifier {
+
+  private final AuditChainQueryPort queryPort;
+  private final HmacKeyProvider hmacKeyProvider;
+
+  /** 当該連鎖を検証する。整合していれば空リストを返し新チェックポイントを追記する。不整合は最初の 1 件を返す(検出は事後・fail-open)。 */
+  @Transactional
+  List<AuditChainMismatch> verify(long chainKey) {
+    List<AuditChainRow> rows = queryPort.findRows(chainKey);
+    if (rows.isEmpty()) {
+      return List.of();
+    }
+
+    long minSeq = rows.get(0).canonical().chainSeq();
+    long startSeq;
+    String prevHash;
+    if (minSeq == 1) {
+      startSeq = 0;
+      prevHash = AuditChainHasher.GENESIS_HASH;
+    } else {
+      // 保管削除(B-03)で prefix が消えている場合、検証起点は削除境界の retained アンカー。
+      Optional<AuditAnchor> anchor = queryPort.findLatestAnchorBelow(chainKey, minSeq);
+      if (anchor.isEmpty()) {
+        return List.of(new AuditChainMismatch(chainKey, minSeq, Reason.MISSING_ANCHOR));
+      }
+      startSeq = anchor.get().seqAtCheckpoint();
+      prevHash = anchor.get().headHash();
+    }
+
+    long expectedSeq = startSeq + 1;
+    String prev = prevHash;
+    for (AuditChainRow row : rows) {
+      long seq = row.canonical().chainSeq();
+      if (seq != expectedSeq) {
+        return List.of(new AuditChainMismatch(chainKey, expectedSeq, Reason.SEQUENCE_BROKEN));
+      }
+      String recomputed =
+          AuditChainHasher.hmacHex(
+              AuditCanonicalizer.canonicalBytes(row.canonical()),
+              prev,
+              hmacKeyProvider.keyFor(row.canonical().hashKeyId()));
+      if (!recomputed.equals(row.storedHash())) {
+        return List.of(new AuditChainMismatch(chainKey, seq, Reason.HASH_MISMATCH));
+      }
+      prev = row.storedHash();
+      expectedSeq++;
+    }
+
+    // 末尾切り詰め検出: 生存行の末尾と chain_heads の末尾(書込のたびに更新)を突合する。
+    ChainHead head =
+        queryPort
+            .findHead(chainKey)
+            .orElseThrow(() -> new IllegalStateException("chain_heads 行が見つかりません: " + chainKey));
+    AuditChainRow last = rows.get(rows.size() - 1);
+    if (head.lastSeq() != last.canonical().chainSeq()
+        || !head.lastHash().equals(last.storedHash())) {
+      return List.of(new AuditChainMismatch(chainKey, head.lastSeq(), Reason.TAIL_MISMATCH));
+    }
+
+    queryPort.appendAnchor(
+        chainKey, head.lastSeq(), head.lastHash(), hmacKeyProvider.currentKeyId());
+    return List.of();
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/usecase/VerifyAuditChainUseCase.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/usecase/VerifyAuditChainUseCase.java
@@ -1,0 +1,69 @@
+package xyz.dgz48.tasks.webapi.audit.usecase;
+
+import io.micrometer.observation.annotation.Observed;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import xyz.dgz48.tasks.webapi.audit.domain.AuditChainMismatch;
+
+/**
+ * B-05 監査ログ整合性検証ユースケース(ADR-0038 §3.7 / 基本設計書 §8.1)。
+ *
+ * <p>全 {@code chain_key} を {@link AuditChainVerifier} で個別に検証する。改ざん検知は <b>fail-open</b> であり、 1
+ * 連鎖の検証失敗が他連鎖を止めない(例外は捕捉してログのみ)。検出した不整合は {@link AuditChainAlertPort} で通知し、 戻り値の集計でも返す(バッチ・テストの観測用)。
+ */
+@Service
+@RequiredArgsConstructor
+public class VerifyAuditChainUseCase {
+
+  private static final Logger log = LoggerFactory.getLogger(VerifyAuditChainUseCase.class);
+
+  private final AuditChainQueryPort queryPort;
+  private final AuditChainVerifier verifier;
+  private final AuditChainAlertPort alertPort;
+
+  @Observed(name = "audit.chainVerification")
+  public AuditChainVerificationSummary execute() {
+    List<Long> chainKeys = queryPort.findActiveChainKeys();
+    List<AuditChainMismatch> mismatches = new ArrayList<>();
+    int clean = 0;
+    for (long chainKey : chainKeys) {
+      try {
+        List<AuditChainMismatch> chainMismatches = verifier.verify(chainKey);
+        if (chainMismatches.isEmpty()) {
+          clean++;
+        } else {
+          for (AuditChainMismatch mismatch : chainMismatches) {
+            alertPort.alert(mismatch);
+          }
+          mismatches.addAll(chainMismatches);
+        }
+      } catch (RuntimeException e) {
+        // fail-open: 1 連鎖の検証エラーが他連鎖の検証を止めないようにする。
+        log.error("監査連鎖の検証中にエラーが発生しました chainKey={}: {}", chainKey, e.getMessage(), e);
+      }
+    }
+
+    var summary =
+        new AuditChainVerificationSummary(chainKeys.size(), clean, List.copyOf(mismatches));
+    log.info(
+        "監査連鎖検証バッチ完了 chains={} clean={} mismatches={}",
+        summary.chainsChecked(),
+        summary.chainsClean(),
+        summary.mismatches().size());
+    return summary;
+  }
+
+  /**
+   * 検証結果の集計(ログ・監視・テスト用)。
+   *
+   * @param chainsChecked 検証対象の連鎖数
+   * @param chainsClean 整合していた連鎖数
+   * @param mismatches 検出した不整合
+   */
+  public record AuditChainVerificationSummary(
+      int chainsChecked, int chainsClean, List<AuditChainMismatch> mismatches) {}
+}

--- a/webapi/src/main/resources/application.yml
+++ b/webapi/src/main/resources/application.yml
@@ -80,6 +80,12 @@ audit:
     source: ${AUDIT_HASH_CHAIN_SOURCE:property}
     secret: ${AUDIT_HASH_CHAIN_SECRET:dev-insecure-audit-hmac-key-change-me}
     ssm-parameter-prefix: ${AUDIT_HASH_CHAIN_SSM_PREFIX:/tasks/dev/app/audit-hash-key}
+  # B-05 監査ログ整合性検証バッチ(毎日 02:00 JST、ShedLock 排他、ADR-0038 §3.7)。
+  verification:
+    batch:
+      enabled: ${AUDIT_VERIFICATION_BATCH_ENABLED:true}
+      cron: ${AUDIT_VERIFICATION_BATCH_CRON:0 0 2 * * *}
+      zone: ${AUDIT_VERIFICATION_BATCH_ZONE:Asia/Tokyo}
 
 # 通知バッチ(B-01 期限当日通知メール、設計規約 §7 / 基本設計書 §8.1)。
 # email.provider=ses のときのみ SES クライアントを生成。既定 log はローカル/テスト用のログフォールバック。

--- a/webapi/src/main/resources/db/migration/V1.0.0_04__audit_anchors.sql
+++ b/webapi/src/main/resources/db/migration/V1.0.0_04__audit_anchors.sql
@@ -1,0 +1,14 @@
+-- ADR-0038 §3.6: 監査ハッシュチェーンの検証チェックポイント(アンカー)。
+-- B-05 検証バッチが各 chain_key の検証成功後に連鎖頭を追記専用で固定する。
+-- audit_anchors は B-03(1 年保管削除)の対象外とし prune しない。保管削除後も
+-- retained アンカーを起点に連鎖検証を継続できる。
+CREATE TABLE audit_anchors (
+    id                BIGINT      NOT NULL AUTO_INCREMENT,
+    chain_key         BIGINT      NOT NULL COMMENT 'tenant_id、横断は予約値 0',
+    seq_at_checkpoint BIGINT      NOT NULL COMMENT 'この時点の chain_seq(連鎖頭)',
+    head_hash         CHAR(64)    NOT NULL COMMENT 'この時点の連鎖頭ハッシュ',
+    hash_key_id       VARCHAR(32) NOT NULL COMMENT 'チェックポイント作成時の現行鍵 ID',
+    created_at        DATETIME    NOT NULL COMMENT 'チェックポイント作成日時',
+    PRIMARY KEY (id),
+    KEY idx_anchor_chain (chain_key, seq_at_checkpoint)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/audit/AuditChainConcurrentInsertIT.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/audit/AuditChainConcurrentInsertIT.java
@@ -1,0 +1,106 @@
+package xyz.dgz48.tasks.webapi.audit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
+import xyz.dgz48.tasks.webapi.MockJwtDecoderConfiguration;
+import xyz.dgz48.tasks.webapi.TestcontainersConfiguration;
+import xyz.dgz48.tasks.webapi.audit.domain.AuditEventType;
+import xyz.dgz48.tasks.webapi.audit.usecase.AuditLogPort;
+import xyz.dgz48.tasks.webapi.audit.usecase.VerifyAuditChainUseCase;
+
+/**
+ * 同一連鎖への並行 INSERT が分岐しないことの統合テスト(ADR-0038 §3.4)。
+ *
+ * <p>{@code chain_heads} 行の {@code SELECT ... FOR UPDATE} による直列化を実 MySQL(Testcontainers)で検証する。
+ * 並行書込後に {@code chain_seq} が 1..N の連続値(ギャップ・重複なし)であり、検証が整合することを確認する。
+ */
+@SpringBootTest
+@Import({TestcontainersConfiguration.class, MockJwtDecoderConfiguration.class})
+class AuditChainConcurrentInsertIT {
+
+  private static final long TENANT = 9300L;
+  private static final int THREADS = 6;
+  private static final int PER_THREAD = 4;
+  private static final int TOTAL = THREADS * PER_THREAD;
+
+  @Autowired AuditLogPort auditLogPort;
+  @Autowired VerifyAuditChainUseCase verifyAuditChainUseCase;
+  @Autowired JdbcTemplate jdbcTemplate;
+
+  @BeforeEach
+  @AfterEach
+  void cleanChainTables() {
+    jdbcTemplate.execute("DELETE FROM audit_anchors");
+    jdbcTemplate.execute("DELETE FROM audit_logs");
+    jdbcTemplate.execute("DELETE FROM chain_heads");
+  }
+
+  @Test
+  void concurrentInserts_produceContiguousChainSeq_andVerifyClean() throws InterruptedException {
+    var startGate = new CountDownLatch(1);
+    var done = new CountDownLatch(THREADS);
+    var errors = new AtomicInteger();
+    ExecutorService pool = Executors.newFixedThreadPool(THREADS);
+    try {
+      for (int t = 0; t < THREADS; t++) {
+        var unused =
+            pool.submit(
+                () -> {
+                  try {
+                    startGate.await();
+                    for (int i = 0; i < PER_THREAD; i++) {
+                      // record() は REQUIRES 外呼び出しのためスレッドごとに独立 tx を開始する。
+                      auditLogPort.record(AuditEventType.TASK_UPDATED, TENANT, 1L, Map.of("x", i));
+                    }
+                  } catch (RuntimeException | InterruptedException e) {
+                    errors.incrementAndGet();
+                  } finally {
+                    done.countDown();
+                  }
+                });
+      }
+      startGate.countDown();
+      assertThat(done.await(60, TimeUnit.SECONDS)).isTrue();
+    } finally {
+      pool.shutdownNow();
+    }
+
+    assertThat(errors.get()).isZero();
+
+    Long count =
+        jdbcTemplate.queryForObject(
+            "SELECT COUNT(*) FROM audit_logs WHERE tenant_id = ?", Long.class, TENANT);
+    Long distinct =
+        jdbcTemplate.queryForObject(
+            "SELECT COUNT(DISTINCT chain_seq) FROM audit_logs WHERE tenant_id = ?",
+            Long.class,
+            TENANT);
+    Long maxSeq =
+        jdbcTemplate.queryForObject(
+            "SELECT MAX(chain_seq) FROM audit_logs WHERE tenant_id = ?", Long.class, TENANT);
+    Long minSeq =
+        jdbcTemplate.queryForObject(
+            "SELECT MIN(chain_seq) FROM audit_logs WHERE tenant_id = ?", Long.class, TENANT);
+
+    assertThat(count).isEqualTo((long) TOTAL);
+    assertThat(distinct).isEqualTo((long) TOTAL); // 重複なし
+    assertThat(minSeq).isEqualTo(1L);
+    assertThat(maxSeq).isEqualTo((long) TOTAL); // ギャップなし(連続)
+
+    // 直列化されていれば連鎖は整合する。
+    assertThat(verifyAuditChainUseCase.execute().mismatches()).isEmpty();
+  }
+}

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/audit/AuditChainVerificationIT.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/audit/AuditChainVerificationIT.java
@@ -1,0 +1,159 @@
+package xyz.dgz48.tasks.webapi.audit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
+import xyz.dgz48.tasks.webapi.MockJwtDecoderConfiguration;
+import xyz.dgz48.tasks.webapi.TestcontainersConfiguration;
+import xyz.dgz48.tasks.webapi.audit.domain.AuditChainMismatch;
+import xyz.dgz48.tasks.webapi.audit.domain.AuditChainMismatch.Reason;
+import xyz.dgz48.tasks.webapi.audit.domain.AuditEventType;
+import xyz.dgz48.tasks.webapi.audit.usecase.AuditLogPort;
+import xyz.dgz48.tasks.webapi.audit.usecase.VerifyAuditChainUseCase;
+import xyz.dgz48.tasks.webapi.audit.usecase.VerifyAuditChainUseCase.AuditChainVerificationSummary;
+
+/**
+ * B-05 監査ログ ハッシュチェーン検証(ADR-0038 §3.7)の統合テスト。
+ *
+ * <p>実テナント連鎖・プラットフォーム連鎖の連結と、改ざん注入(行改変 / 削除 / 並べ替え / 末尾切り詰め)の検出、保管削除後の チェックポイント起点検証を Testcontainers
+ * MySQL で検証する。{@code audit_logs} は FK を持たない(テナント・ユーザー削除後も保持)ため、 実際のテナント / ユーザーを作らず任意 ID で連鎖を構成できる。
+ */
+@SpringBootTest
+@Import({TestcontainersConfiguration.class, MockJwtDecoderConfiguration.class})
+class AuditChainVerificationIT {
+
+  private static final long TENANT_A = 9100L;
+  private static final long TENANT_B = 9200L;
+
+  @Autowired AuditLogPort auditLogPort;
+  @Autowired VerifyAuditChainUseCase verifyAuditChainUseCase;
+  @Autowired JdbcTemplate jdbcTemplate;
+
+  @BeforeEach
+  @AfterEach
+  void cleanChainTables() {
+    jdbcTemplate.execute("DELETE FROM audit_anchors");
+    jdbcTemplate.execute("DELETE FROM audit_logs");
+    jdbcTemplate.execute("DELETE FROM chain_heads");
+  }
+
+  /** record() は @Transactional(REQUIRED) のため tx 外から呼ぶと 1 件ごとに独立コミットされる。 */
+  private void writeRows(Long tenantId, int count) {
+    for (int i = 0; i < count; i++) {
+      auditLogPort.record(
+          AuditEventType.TASK_UPDATED, tenantId, 1L, Map.of("i", i, "note", "監査" + i));
+    }
+  }
+
+  @Test
+  void cleanChains_acrossTenantsAndPlatform_verifyCleanAndCheckpointAppended() {
+    writeRows(TENANT_A, 3);
+    writeRows(TENANT_B, 2);
+    writeRows(null, 2); // プラットフォーム連鎖(chain_key = 0)
+
+    AuditChainVerificationSummary summary = verifyAuditChainUseCase.execute();
+
+    assertThat(summary.chainsChecked()).isEqualTo(3);
+    assertThat(summary.chainsClean()).isEqualTo(3);
+    assertThat(summary.mismatches()).isEmpty();
+
+    // 各連鎖の末尾でチェックポイントが 1 件ずつ追記される。
+    List<Map<String, Object>> anchors =
+        jdbcTemplate.queryForList(
+            "SELECT chain_key, seq_at_checkpoint FROM audit_anchors ORDER BY chain_key");
+    assertThat(anchors).hasSize(3);
+    assertThat(anchors)
+        .extracting(r -> ((Number) r.get("chain_key")).longValue())
+        .containsExactly(0L, TENANT_A, TENANT_B);
+  }
+
+  @Test
+  void modifiedRow_isDetectedAsHashMismatch() {
+    writeRows(TENANT_A, 3);
+    // 2 件目の action を改変(canonical が変わり再計算ハッシュと不一致になる)。
+    jdbcTemplate.update(
+        "UPDATE audit_logs SET action = 'HACKED' WHERE tenant_id = ? AND chain_seq = 2", TENANT_A);
+
+    AuditChainVerificationSummary summary = verifyAuditChainUseCase.execute();
+
+    assertThat(summary.mismatches())
+        .containsExactly(new AuditChainMismatch(TENANT_A, 2L, Reason.HASH_MISMATCH));
+  }
+
+  @Test
+  void deletedMiddleRow_isDetectedAsSequenceBroken() {
+    writeRows(TENANT_A, 3);
+    jdbcTemplate.update("DELETE FROM audit_logs WHERE tenant_id = ? AND chain_seq = 2", TENANT_A);
+
+    AuditChainVerificationSummary summary = verifyAuditChainUseCase.execute();
+
+    // seq1 の次に seq2 を期待するが seq3 が来るため SEQUENCE_BROKEN。
+    assertThat(summary.mismatches())
+        .containsExactly(new AuditChainMismatch(TENANT_A, 2L, Reason.SEQUENCE_BROKEN));
+  }
+
+  @Test
+  void reorderedRows_areDetected() {
+    writeRows(TENANT_A, 3);
+    // seq2 と seq3 を入れ替える(chain_seq は一意制約を持たないため一時値経由で交換)。
+    jdbcTemplate.update(
+        "UPDATE audit_logs SET chain_seq = 999 WHERE tenant_id = ? AND chain_seq = 2", TENANT_A);
+    jdbcTemplate.update(
+        "UPDATE audit_logs SET chain_seq = 2 WHERE tenant_id = ? AND chain_seq = 3", TENANT_A);
+    jdbcTemplate.update(
+        "UPDATE audit_logs SET chain_seq = 3 WHERE tenant_id = ? AND chain_seq = 999", TENANT_A);
+
+    AuditChainVerificationSummary summary = verifyAuditChainUseCase.execute();
+
+    // 並べ替えで chain_seq=2 の行内容が変わり、HMAC 再計算が格納値と不一致になる。
+    assertThat(summary.mismatches()).hasSize(1);
+    assertThat(summary.mismatches().get(0).chainKey()).isEqualTo(TENANT_A);
+    assertThat(summary.mismatches().get(0).reason()).isEqualTo(Reason.HASH_MISMATCH);
+  }
+
+  @Test
+  void truncatedTail_isDetectedAgainstChainHead() {
+    writeRows(TENANT_A, 3);
+    // 末尾行(seq3)を削除。chain_heads は更新されないため末尾不整合として検出される。
+    jdbcTemplate.update("DELETE FROM audit_logs WHERE tenant_id = ? AND chain_seq = 3", TENANT_A);
+
+    AuditChainVerificationSummary summary = verifyAuditChainUseCase.execute();
+
+    assertThat(summary.mismatches())
+        .containsExactly(new AuditChainMismatch(TENANT_A, 3L, Reason.TAIL_MISMATCH));
+  }
+
+  @Test
+  void retainedAnchor_allowsVerificationAfterPrefixDeletion() {
+    // 1) 5 件書込 → 検証(チェックポイント seq5 追記)。
+    writeRows(TENANT_A, 5);
+    assertThat(verifyAuditChainUseCase.execute().mismatches()).isEmpty();
+
+    // 2) さらに 5 件書込(seq 6..10)。
+    writeRows(TENANT_A, 5);
+
+    // 3) B-03 を模擬: アンカー seq5 までの prefix を削除(seq <= 5)。
+    jdbcTemplate.update("DELETE FROM audit_logs WHERE tenant_id = ? AND chain_seq <= 5", TENANT_A);
+
+    // 4) 再検証: retained アンカー seq5 を起点に seq6..10 を検証 → 整合。
+    AuditChainVerificationSummary summary = verifyAuditChainUseCase.execute();
+    assertThat(summary.mismatches()).isEmpty();
+    assertThat(summary.chainsClean()).isEqualTo(1);
+
+    // 末尾 seq10 の新チェックポイントが追記される。
+    Long maxAnchorSeq =
+        jdbcTemplate.queryForObject(
+            "SELECT MAX(seq_at_checkpoint) FROM audit_anchors WHERE chain_key = ?",
+            Long.class,
+            TENANT_A);
+    assertThat(maxAnchorSeq).isEqualTo(10L);
+  }
+}

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/audit/adapter/external/SsmHmacKeyProviderTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/audit/adapter/external/SsmHmacKeyProviderTest.java
@@ -1,0 +1,67 @@
+package xyz.dgz48.tasks.webapi.audit.adapter.external;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.services.ssm.SsmClient;
+import software.amazon.awssdk.services.ssm.model.GetParameterRequest;
+import software.amazon.awssdk.services.ssm.model.GetParameterResponse;
+import software.amazon.awssdk.services.ssm.model.Parameter;
+
+/** {@link SsmHmacKeyProvider} のユニットテスト。 */
+@ExtendWith(MockitoExtension.class)
+class SsmHmacKeyProviderTest {
+
+  @Mock SsmClient ssmClient;
+
+  private void stubSecret(String value) {
+    when(ssmClient.getParameter(any(GetParameterRequest.class)))
+        .thenReturn(
+            GetParameterResponse.builder()
+                .parameter(Parameter.builder().value(value).build())
+                .build());
+  }
+
+  @Test
+  void keyFor_loadsSecureStringWithDecryption_byPrefixAndKeyId() {
+    stubSecret("ssm-secret");
+    var provider = new SsmHmacKeyProvider(ssmClient, "v1", "/tasks/dev/app/audit-hash-key");
+
+    var key = provider.keyFor("v1");
+
+    assertThat(key.getAlgorithm()).isEqualTo("HmacSHA256");
+    assertThat(key.getEncoded()).isEqualTo("ssm-secret".getBytes(StandardCharsets.UTF_8));
+
+    ArgumentCaptor<GetParameterRequest> captor = ArgumentCaptor.forClass(GetParameterRequest.class);
+    verify(ssmClient).getParameter(captor.capture());
+    assertThat(captor.getValue().name()).isEqualTo("/tasks/dev/app/audit-hash-key-v1");
+    assertThat(captor.getValue().withDecryption()).isTrue();
+  }
+
+  @Test
+  void keyFor_cachesPerKeyId() {
+    stubSecret("ssm-secret");
+    var provider = new SsmHmacKeyProvider(ssmClient, "v1", "/tasks/dev/app/audit-hash-key");
+
+    provider.keyFor("v1");
+    provider.keyFor("v1");
+
+    // 鍵は不変のため SSM 取得は 1 回のみ。
+    verify(ssmClient, times(1)).getParameter(any(GetParameterRequest.class));
+  }
+
+  @Test
+  void currentKeyId_returnsConfiguredId() {
+    var provider = new SsmHmacKeyProvider(ssmClient, "v1", "/tasks/dev/app/audit-hash-key");
+    assertThat(provider.currentKeyId()).isEqualTo("v1");
+  }
+}

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/audit/infra/AuditChainVerificationBatchSchedulerTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/audit/infra/AuditChainVerificationBatchSchedulerTest.java
@@ -1,0 +1,34 @@
+package xyz.dgz48.tasks.webapi.audit.infra;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.MDC;
+import xyz.dgz48.tasks.webapi.audit.usecase.VerifyAuditChainUseCase;
+import xyz.dgz48.tasks.webapi.audit.usecase.VerifyAuditChainUseCase.AuditChainVerificationSummary;
+
+/** {@link AuditChainVerificationBatchScheduler} のユニットテスト。 */
+@ExtendWith(MockitoExtension.class)
+class AuditChainVerificationBatchSchedulerTest {
+
+  @Mock VerifyAuditChainUseCase verifyAuditChainUseCase;
+
+  @Test
+  void runAuditChainVerification_delegatesToUseCase_andClearsMdc() {
+    when(verifyAuditChainUseCase.execute())
+        .thenReturn(new AuditChainVerificationSummary(0, 0, List.of()));
+    var scheduler = new AuditChainVerificationBatchScheduler(verifyAuditChainUseCase);
+
+    scheduler.runAuditChainVerification();
+
+    verify(verifyAuditChainUseCase).execute();
+    // MDC の batchId は実行後に必ず除去される。
+    assertThat(MDC.get("batchId")).isNull();
+  }
+}

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/audit/usecase/VerifyAuditChainUseCaseTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/audit/usecase/VerifyAuditChainUseCaseTest.java
@@ -1,0 +1,57 @@
+package xyz.dgz48.tasks.webapi.audit.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import xyz.dgz48.tasks.webapi.audit.domain.AuditChainMismatch;
+import xyz.dgz48.tasks.webapi.audit.domain.AuditChainMismatch.Reason;
+import xyz.dgz48.tasks.webapi.audit.usecase.VerifyAuditChainUseCase.AuditChainVerificationSummary;
+
+/** {@link VerifyAuditChainUseCase} のユニットテスト(集約・fail-open のオーケストレーション)。 */
+@ExtendWith(MockitoExtension.class)
+class VerifyAuditChainUseCaseTest {
+
+  @Mock AuditChainQueryPort queryPort;
+  @Mock AuditChainVerifier verifier;
+  @Mock AuditChainAlertPort alertPort;
+
+  private VerifyAuditChainUseCase useCase() {
+    return new VerifyAuditChainUseCase(queryPort, verifier, alertPort);
+  }
+
+  @Test
+  void execute_aggregatesCleanAndMismatchedChains_andAlertsEachMismatch() {
+    var mismatch = new AuditChainMismatch(2L, 3L, Reason.HASH_MISMATCH);
+    when(queryPort.findActiveChainKeys()).thenReturn(List.of(1L, 2L));
+    when(verifier.verify(1L)).thenReturn(List.of());
+    when(verifier.verify(2L)).thenReturn(List.of(mismatch));
+
+    AuditChainVerificationSummary summary = useCase().execute();
+
+    assertThat(summary.chainsChecked()).isEqualTo(2);
+    assertThat(summary.chainsClean()).isEqualTo(1);
+    assertThat(summary.mismatches()).containsExactly(mismatch);
+    verify(alertPort).alert(mismatch);
+  }
+
+  @Test
+  void execute_isFailOpen_whenOneChainThrows() {
+    when(queryPort.findActiveChainKeys()).thenReturn(List.of(3L));
+    when(verifier.verify(3L)).thenThrow(new RuntimeException("DB error"));
+
+    AuditChainVerificationSummary summary = useCase().execute();
+
+    // 例外は捕捉され、バッチは完了する(他連鎖をブロックしない)。
+    assertThat(summary.chainsChecked()).isEqualTo(1);
+    assertThat(summary.chainsClean()).isZero();
+    assertThat(summary.mismatches()).isEmpty();
+    verify(alertPort, never()).alert(org.mockito.ArgumentMatchers.any());
+  }
+}

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/shared/adapter/persistence/HibernateFilterEntityAuditTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/shared/adapter/persistence/HibernateFilterEntityAuditTest.java
@@ -37,7 +37,8 @@ class HibernateFilterEntityAuditTest {
           "UserTenantJpaEntity", // user_tenants: TenantContext 確立前にクロステナント参照が必要
           "AppAdminUserJpaEntity", // app_admin_users: SaaS Admin ユーザー管理、tenant_id 列なし
           "AuditLogJpaEntity", // audit_logs: tenant_id が nullable、テナント範囲を超えた参照が必要
-          "ChainHeadJpaEntity" // chain_heads: chain_key(=tenant_id/0)が PK、横断連鎖も持つ補助表(ADR-0038)
+          "ChainHeadJpaEntity", // chain_heads: chain_key(=tenant_id/0)が PK、横断連鎖も持つ補助表(ADR-0038)
+          "AuditAnchorJpaEntity" // audit_anchors: chain_key 単位の検証チェックポイント、横断連鎖も持つ(ADR-0038)
           );
 
   @Autowired EntityManagerFactory emf;


### PR DESCRIPTION
## 概要

Issue #751 / ADR-0038 の改ざん検知のうち **検証経路** を実装し、#751 を完了する。書込経路は先行 PR #763(merged)。

`Closes #751`。

## 変更内容

### スキーマ(Flyway `V1.0.0_04`)
- `audit_anchors` 新設(検証チェックポイント)。B-03(1 年保管削除)対象外で prune しない

### 検証ロジック
- **`VerifyAuditChainUseCase`**(B-05): 全 `chain_key` を個別検証して集約。改ざん検知は **fail-open**(1 連鎖の失敗が他を止めない、例外は捕捉してログのみ)。検出は `AuditChainAlertPort` で通知し、戻り値の集計でも返す(観測・テスト用)
- **`AuditChainVerifier`**: 連鎖ごと独立トランザクション。保管窓内の最古 retained アンカー(無ければ GENESIS)を起点に末尾まで HMAC 再計算し、各行の格納ハッシュ・`chain_seq` 順序・末尾(`chain_heads`)を突合。整合なら新チェックポイントを追記。検出種別: 改変 / 順序欠落・並べ替え / 末尾切詰 / アンカー欠落
- **`AuditChainQueryAdapter`**: `chain_key` は `tenant_id` から導出(横断 = 0 = `tenant_id IS NULL`)、`idx_al_chain` で生存行取得

### バッチ・アラート・鍵
- **`AuditChainVerificationBatchScheduler`**: 毎日 02:00 JST、`@SchedulerLock`、MDC `batchId=B-05`(`NotificationBatchScheduler` / ADR-0037 と同構成)。`audit.verification.batch.*` で設定可
- **`LoggingAuditChainAlertPort`**: 不整合を構造化 ERROR ログで通知(ADR-0019、CloudWatch アラームの実体)。非 PII
- **`SsmHmacKeyProvider`**: `source=ssm` の本番経路(Parameter Store SecureString + KMS 復号 + 鍵 ID 単位キャッシュ)。property フォールバックは `@ConditionalOnMissingBean` で退避

## テスト
- `AuditChainVerificationIT`(Testcontainers): 連鎖連結(2 テナント + 横断 `chain_key=0`)の write→verify round-trip(MySQL JSON 正規化を跨いで byte 一致を実証)、改ざん注入 4 種(改変 / 削除 / 並べ替え / 末尾切詰)検出、**保管削除後の retained アンカー起点検証**
- `AuditChainConcurrentInsertIT`: 同一連鎖への並行 INSERT が `chain_seq` 連続(ギャップ・重複なし)= 実 MySQL `FOR UPDATE` 直列化の実証
- unit: `VerifyAuditChainUseCaseTest`(fail-open / アラート集約)、`SsmHmacKeyProviderTest`(鍵キャッシュ・復号要求)、`AuditChainVerificationBatchSchedulerTest`(委譲 / MDC)

## 受け入れ条件(#751)
- [x] 連鎖方式の確定(ADR-0038、#758)
- [x] Flyway で `chain_seq` / `hash_key_id` 追加 + `chain_heads` / `audit_anchors` 新設(#763 + 本 PR)
- [x] 追記時に `chain_key` 単位で連鎖が正しく連結(並行 INSERT で分岐しない)
- [x] 改ざん行(改変・削除・並べ替え・末尾)を検出できる B-05 検証 + テスト、カバレッジ 80% 以上
- [x] `audit_anchors` チェックポイントで保管削除(B-03)後も検証可能

## 検証
`./gradlew :webapi:check` 緑(spotlessCheck / 505 tests / JaCoCo 80% ゲート)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)