### PR TITLE
feat(tenant): セルフサインアップ POST /api/tenants + テナント作成画面 (S-11) (Closes #775)

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -35,6 +35,9 @@
           <div class="card-body">
             <p class="card-title fw-semibold">ユーザー情報</p>
             <pre id="user-info" class="bg-light p-3 rounded small"></pre>
+            <a id="link-create-tenant" href="tenants-new.html" class="btn btn-primary d-none">
+              テナントを作成
+            </a>
           </div>
         </div>
       </div>

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -78,6 +78,25 @@
  */
 
 /**
+ * @typedef {object} Tenant
+ * @property {number} id
+ * @property {string} code
+ * @property {string} name
+ * @property {'FREE'|'STANDARD'|'ENTERPRISE'} plan
+ * @property {'ACTIVE'|'SUSPENDED'|'DELETED'} status
+ * @property {string} createdAt
+ * @property {string} updatedAt
+ * @property {number} userCount
+ * @property {number} taskCount
+ */
+
+/**
+ * @typedef {object} TenantCreatedResponse
+ * @property {Tenant} tenant
+ * @property {TenantUser} initialAdmin
+ */
+
+/**
  * @typedef {object} TenantRef
  * @property {number} id
  * @property {string} name
@@ -242,6 +261,19 @@ const Api = (() => {
   }
 
   /**
+   * POST /api/tenants — セルフサインアップ(A-05、createTenant)。認証済み・テナント未所属でも作成可。
+   * 呼び出しユーザーは初代 TENANT_ADMIN として登録される。
+   *
+   * 注意: X-Tenant-Id は送らないこと。TenantContextFilter は免除パス判定を「ヘッダ無し」のときだけ行うため、
+   * 非メンバーテナントの X-Tenant-Id を送ると 403 になる。呼び出し前に setTenantId(null) でクリアする想定。
+   * @param {{name: string}} body
+   * @returns {Promise<TenantCreatedResponse>}
+   */
+  function createTenant(body) {
+    return request('/api/tenants', { method: 'POST', body: JSON.stringify(body) });
+  }
+
+  /**
    * GET /api/tasks — タスク一覧取得(A-1、listTasks)。
    * @param {Object} [params]
    * @param {string}  [params.targetDate]     - 表示対象日 (YYYY-MM-DD)
@@ -402,6 +434,7 @@ const Api = (() => {
     requestRaw,
     getMe,
     selectTenant,
+    createTenant,
     listTasks,
     getTask,
     createTask,

--- a/web/js/index.js
+++ b/web/js/index.js
@@ -26,9 +26,15 @@ async function main() {
       return;
     }
 
-    // テナント未選択: テナント選択 UI を表示
+    // テナント未選択: テナント選択 UI と「テナント作成」導線を表示
     /** @type {HTMLElement} */ (mustQuery(document, '#user-info')).textContent =
-      'テナントを選択してタスク一覧を開いてください。';
+      me.tenants.length === 0
+        ? '所属テナントがありません。新しいテナントを作成してください。'
+        : 'テナントを選択してタスク一覧を開いてください。';
+
+    /** @type {HTMLElement} */ (mustQuery(document, '#link-create-tenant')).classList.remove(
+      'd-none',
+    );
 
     /** @type {AppTenantSwitcherElement} */ (mustQuery(document, '#tenant-switcher')).setData(
       me.tenants,

--- a/web/js/tenants-new.js
+++ b/web/js/tenants-new.js
@@ -1,0 +1,76 @@
+// @ts-check
+
+/** @type {HTMLElement} */ (mustQuery(document, '#btn-logout')).addEventListener('click', () =>
+  Auth.logout(),
+);
+
+/**
+ * フォームエラーを表示する。
+ * @param {string} message
+ */
+function showError(message) {
+  const el = /** @type {HTMLElement} */ (mustQuery(document, '#form-error'));
+  el.textContent = message;
+  el.classList.remove('d-none');
+}
+
+function hideError() {
+  /** @type {HTMLElement} */ (mustQuery(document, '#form-error')).classList.add('d-none');
+}
+
+/**
+ * @param {SubmitEvent} event
+ */
+async function onSubmit(event) {
+  event.preventDefault();
+  hideError();
+
+  const input = /** @type {HTMLInputElement} */ (mustQuery(document, '#tenant-name'));
+  const name = input.value.trim();
+  if (name === '') {
+    showError('テナント名を入力してください。');
+    return;
+  }
+
+  const button = /** @type {HTMLButtonElement} */ (mustQuery(document, '#btn-create'));
+  button.disabled = true;
+
+  try {
+    // 非メンバーテナントの X-Tenant-Id が残っていると 403 になるためクリアする。
+    Api.setTenantId(null);
+    const result = await Api.createTenant({ name });
+    Api.setTenantId(String(result.tenant.id));
+    window.location.replace('tasks.html');
+  } catch (err) {
+    const e = /** @type {{ status?: number, message?: string }} */ (err);
+    if (e.status === 400) {
+      showError('テナント名が不正です(1〜255 文字で入力してください)。');
+    } else if (e.status === 409) {
+      showError('同名のテナントが既に存在します。別の名前でお試しください。');
+    } else {
+      showError(`テナント作成に失敗しました: ${e.message ?? '不明なエラー'}`);
+    }
+    button.disabled = false;
+  }
+}
+
+async function main() {
+  const authenticated = await Auth.init();
+  /** @type {HTMLElement} */ (mustQuery(document, '#loading')).classList.add('d-none');
+
+  if (!authenticated) {
+    return;
+  }
+
+  const user = Auth.getUser();
+  /** @type {HTMLElement} */ (mustQuery(document, '#nav-username')).textContent =
+    user?.name || user?.preferred_username || '';
+  /** @type {HTMLElement} */ (mustQuery(document, '#nav-username')).classList.remove('d-none');
+  /** @type {HTMLElement} */ (mustQuery(document, '#btn-logout')).classList.remove('d-none');
+
+  const form = /** @type {HTMLFormElement} */ (mustQuery(document, '#signup-form'));
+  form.classList.remove('d-none');
+  form.addEventListener('submit', onSubmit);
+}
+
+main();

--- a/web/package.json
+++ b/web/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "copy-vendor": "node scripts/copy-vendor.js",
-    "html-validate": "html-validate index.html tasks.html",
+    "html-validate": "html-validate index.html tasks.html tenants-new.html",
     "serve": "node serve.mjs"
   },
   "engines": {

--- a/web/tenants-new.html
+++ b/web/tenants-new.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>テナント作成 — Tasks</title>
+    <link rel="icon" type="image/svg+xml" href="favicon.svg">
+    <link rel="stylesheet" href="vendor/bootstrap/css/bootstrap.min.css">
+    <link rel="stylesheet" href="vendor/bootstrap-icons/bootstrap-icons.min.css">
+    <link rel="stylesheet" href="css/app.css">
+  </head>
+  <body>
+    <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
+      <div class="container">
+        <a class="navbar-brand" href="index.html">Tasks</a>
+        <div class="ms-auto d-flex align-items-center">
+          <span id="nav-username" class="navbar-text text-white me-3 d-none"></span>
+          <button id="btn-logout" type="button" class="btn btn-outline-light btn-sm d-none">
+            ログアウト
+          </button>
+        </div>
+      </div>
+    </nav>
+
+    <main class="container mt-4">
+      <div id="loading" class="text-center py-5">
+        <div class="spinner-border text-primary" role="status">
+          <span class="visually-hidden">Loading...</span>
+        </div>
+        <p class="mt-2 text-muted">認証状態を確認中...</p>
+      </div>
+
+      <div class="row justify-content-center">
+        <div class="col-12 col-md-8 col-lg-6">
+          <form id="signup-form" class="card d-none" novalidate>
+            <div class="card-body">
+              <h1 class="h5 card-title mb-3">テナントを作成</h1>
+              <p class="text-muted small">
+                テナント名を入力して作成すると、あなたが初代テナント管理者として登録されます。
+              </p>
+
+              <div id="form-error" class="alert alert-danger d-none" role="alert"></div>
+
+              <div class="mb-3">
+                <label for="tenant-name" class="form-label">テナント名</label>
+                <input
+                  id="tenant-name"
+                  type="text"
+                  class="form-control"
+                  maxlength="255"
+                  required
+                  autocomplete="off"
+                  placeholder="例: 営業部"
+                >
+              </div>
+
+              <button id="btn-create" type="submit" class="btn btn-primary">
+                作成
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </main>
+
+    <script src="vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
+    <script src="vendor/keycloak-js/keycloak.min.js"></script>
+    <script src="js/dom.js"></script>
+    <script src="js/auth.js"></script>
+    <script src="js/api.js"></script>
+    <script src="js/tenants-new.js"></script>
+  </body>
+</html>

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/adapter/persistence/AdminTenantPersistenceAdapter.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/adapter/persistence/AdminTenantPersistenceAdapter.java
@@ -12,6 +12,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 import xyz.dgz48.tasks.webapi.tenant.domain.Tenant;
+import xyz.dgz48.tasks.webapi.tenant.domain.TenantPlan;
 import xyz.dgz48.tasks.webapi.tenant.domain.TenantStatus;
 import xyz.dgz48.tasks.webapi.tenant.usecase.AdminTenantRepository;
 
@@ -22,6 +23,31 @@ import xyz.dgz48.tasks.webapi.tenant.usecase.AdminTenantRepository;
 class AdminTenantPersistenceAdapter implements AdminTenantRepository {
 
   private final TenantJpaRepository tenantJpaRepository;
+
+  @Override
+  @Transactional
+  public Tenant createTenant(String code, String name) {
+    TenantJpaEntity saved =
+        tenantJpaRepository.save(new TenantJpaEntity(code, name, TenantPlan.FREE));
+    // 新規作成直後はメンバー未登録 → COUNT クエリ(特に tasks)を発行しない。
+    // userCount は呼び出し側 UseCase が初代 admin 登録後に 1 へ補正する。
+    return new Tenant(
+        saved.getId(),
+        saved.getCode(),
+        saved.getName(),
+        saved.getPlan(),
+        saved.getStatus(),
+        saved.getCreatedAt(),
+        saved.getUpdatedAt(),
+        0L,
+        0L);
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public boolean existsByCode(String code) {
+    return tenantJpaRepository.existsByCode(code);
+  }
 
   @Override
   @Transactional(readOnly = true)

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/adapter/persistence/TenantJpaEntity.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/adapter/persistence/TenantJpaEntity.java
@@ -54,9 +54,13 @@ public class TenantJpaEntity {
   private LocalDateTime updatedAt;
 
   public TenantJpaEntity(String code, String name) {
+    this(code, name, TenantPlan.STANDARD);
+  }
+
+  public TenantJpaEntity(String code, String name, TenantPlan plan) {
     this.code = code;
     this.name = name;
-    this.plan = TenantPlan.STANDARD;
+    this.plan = plan;
     this.status = TenantStatus.ACTIVE;
   }
 

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/adapter/persistence/TenantJpaRepository.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/adapter/persistence/TenantJpaRepository.java
@@ -12,6 +12,8 @@ import xyz.dgz48.tasks.webapi.tenant.domain.TenantStatus;
 
 interface TenantJpaRepository extends JpaRepository<TenantJpaEntity, Long> {
 
+  boolean existsByCode(String code);
+
   @Query(
       """
       SELECT t FROM TenantJpaEntity t

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/adapter/web/TenantSignupController.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/adapter/web/TenantSignupController.java
@@ -1,0 +1,48 @@
+package xyz.dgz48.tasks.webapi.tenant.adapter.web;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.Nullable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import xyz.dgz48.tasks.webapi.tenant.adapter.web.dto.TenantCreateRequest;
+import xyz.dgz48.tasks.webapi.tenant.adapter.web.dto.TenantCreatedResponse;
+import xyz.dgz48.tasks.webapi.tenant.adapter.web.dto.TenantResponse;
+import xyz.dgz48.tasks.webapi.tenant.adapter.web.dto.TenantUserResponse;
+import xyz.dgz48.tasks.webapi.tenant.usecase.CreateTenantCommand;
+import xyz.dgz48.tasks.webapi.tenant.usecase.CreateTenantResult;
+import xyz.dgz48.tasks.webapi.tenant.usecase.CreateTenantUseCase;
+
+/**
+ * セルフサインアップ(A-05)用 Controller。{@code POST /api/tenants} は認証済みであれば(テナント未所属でも)実行でき、{@code
+ * X-Tenant-Id} ヘッダは不要({@code TenantContextFilter} の免除パス)。SaaS Admin 専用の他テナント操作({@link
+ * TenantAdminController})とは認可要件が異なるため別 Controller として分離する。
+ */
+@RestController
+@RequiredArgsConstructor
+public class TenantSignupController {
+
+  private final CreateTenantUseCase createTenantUseCase;
+
+  @PostMapping("/api/tenants")
+  public ResponseEntity<TenantCreatedResponse> createTenant(
+      @Valid @RequestBody TenantCreateRequest request,
+      @AuthenticationPrincipal(expression = "id") Long callerId,
+      @AuthenticationPrincipal(expression = "email") String callerEmail,
+      @AuthenticationPrincipal(expression = "fullName") String callerFullName,
+      @AuthenticationPrincipal(expression = "departmentName")
+          @Nullable String callerDepartmentName) {
+    CreateTenantResult result =
+        createTenantUseCase.execute(
+            new CreateTenantCommand(
+                callerId, callerEmail, callerFullName, callerDepartmentName, request.name()));
+    TenantCreatedResponse body =
+        new TenantCreatedResponse(
+            TenantResponse.from(result.tenant()), TenantUserResponse.from(result.initialAdmin()));
+    return ResponseEntity.status(HttpStatus.CREATED).body(body);
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/adapter/web/TenantSignupExceptionHandler.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/adapter/web/TenantSignupExceptionHandler.java
@@ -1,0 +1,52 @@
+package xyz.dgz48.tasks.webapi.tenant.adapter.web;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.time.OffsetDateTime;
+import java.util.Objects;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import xyz.dgz48.tasks.webapi.shared.infra.AppZones;
+import xyz.dgz48.tasks.webapi.shared.web.ErrorCode;
+import xyz.dgz48.tasks.webapi.shared.web.ErrorResponse;
+import xyz.dgz48.tasks.webapi.tenant.domain.TenantCodeConflictException;
+
+/**
+ * {@link TenantSignupController} 専用の例外ハンドラ。テナント {@code code} 一意化失敗({@link
+ * TenantCodeConflictException})および並行作成による一意制約違反({@link DataIntegrityViolationException})を 409 /
+ * E_CONFLICT にマップする。スコープを Controller に限定し、他経路の {@code DataIntegrityViolationException} 解釈に影響しない。
+ */
+@RestControllerAdvice(assignableTypes = TenantSignupController.class)
+public class TenantSignupExceptionHandler {
+
+  @ExceptionHandler(TenantCodeConflictException.class)
+  @ResponseStatus(HttpStatus.CONFLICT)
+  public ErrorResponse handleCodeConflict(
+      TenantCodeConflictException ex, HttpServletRequest request) {
+    return error(
+        HttpStatus.CONFLICT,
+        ErrorCode.E_CONFLICT,
+        Objects.requireNonNullElse(ex.getMessage(), "テナントコードの一意化に失敗しました"),
+        request);
+  }
+
+  @ExceptionHandler(DataIntegrityViolationException.class)
+  @ResponseStatus(HttpStatus.CONFLICT)
+  public ErrorResponse handleDataIntegrity(
+      DataIntegrityViolationException ex, HttpServletRequest request) {
+    return error(HttpStatus.CONFLICT, ErrorCode.E_CONFLICT, "同名テナントが既に存在します", request);
+  }
+
+  private static ErrorResponse error(
+      HttpStatus status, ErrorCode code, String message, HttpServletRequest request) {
+    return new ErrorResponse(
+        OffsetDateTime.now(AppZones.JST),
+        status.value(),
+        status.getReasonPhrase(),
+        code,
+        message,
+        request.getRequestURI());
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/adapter/web/dto/TenantCreateRequest.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/adapter/web/dto/TenantCreateRequest.java
@@ -1,0 +1,10 @@
+package xyz.dgz48.tasks.webapi.tenant.adapter.web.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/**
+ * テナント新規作成リクエスト(OpenAPI TenantCreateRequest)。{@code code} はサーバ側で {@code name} の slug
+ * から自動生成するため受け取らない。
+ */
+public record TenantCreateRequest(@NotBlank @Size(min = 1, max = 255) String name) {}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/adapter/web/dto/TenantCreatedResponse.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/adapter/web/dto/TenantCreatedResponse.java
@@ -1,0 +1,7 @@
+package xyz.dgz48.tasks.webapi.tenant.adapter.web.dto;
+
+/**
+ * テナント新規作成レスポンス(OpenAPI TenantCreatedResponse)。作成テナントと、初代 Tenant Admin として登録された {@code
+ * user_tenants} 概要を含む。
+ */
+public record TenantCreatedResponse(TenantResponse tenant, TenantUserResponse initialAdmin) {}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/domain/TenantCodeConflictException.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/domain/TenantCodeConflictException.java
@@ -1,0 +1,12 @@
+package xyz.dgz48.tasks.webapi.tenant.domain;
+
+/**
+ * テナント表示名から生成した {@code code} の一意化が、サフィックスリトライ上限を超えても解消できなかった場合の例外(409 /
+ * E_CONFLICT)。同名テナントが多数存在するレアケース。
+ */
+public class TenantCodeConflictException extends RuntimeException {
+
+  public TenantCodeConflictException(String baseCode) {
+    super("テナントコード '" + baseCode + "' の一意化に失敗しました(同名テナントが多すぎます)");
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/domain/TenantCodeGenerator.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/domain/TenantCodeGenerator.java
@@ -1,0 +1,58 @@
+package xyz.dgz48.tasks.webapi.tenant.domain;
+
+import java.util.Locale;
+
+/**
+ * テナント表示名から URL slug 用の {@code code} を生成するドメインサービス(Spring 非依存)。
+ *
+ * <p>生成ルール(基本設計書 §5.1 / OpenAPI {@code Tenant.code}): 小文字化・{@code [a-z0-9]} 以外をハイフンに置換・連続ハイフンを 1
+ * つに圧縮・先頭末尾のハイフンを除去・最大 {@value #MAX_LENGTH} 文字。日本語など {@code [a-z0-9]} を一切含まない名前では slug が空になるため、
+ * フォールスルー値 {@value #FALLBACK} を用いる(一意化のサフィックスは呼び出し側が付与する)。生成結果は必ず正規表現 {@code ^[a-z0-9-]+$} を満たす。
+ */
+public final class TenantCodeGenerator {
+
+  /** {@code tenants.code} の最大長(OpenAPI / DDL と一致)。 */
+  public static final int MAX_LENGTH = 50;
+
+  /** slug 化で有効文字が残らなかった場合の基底コード。 */
+  public static final String FALLBACK = "tenant";
+
+  /**
+   * 表示名から基底 slug を生成する(サフィックス未付与)。
+   *
+   * @param name テナント表示名(空白のみは呼び出し前に検証済みである前提)
+   * @return {@code ^[a-z0-9-]+$} を満たす 1〜{@value #MAX_LENGTH} 文字の slug
+   */
+  public String toBaseCode(String name) {
+    String slug =
+        name.toLowerCase(Locale.ROOT)
+            .replaceAll("[^a-z0-9]+", "-") // 非英数字(空白・記号・非ASCII)をハイフンに
+            .replaceAll("-{2,}", "-") // 連続ハイフンを 1 つに圧縮
+            .replaceAll("^-+|-+$", ""); // 先頭末尾のハイフンを除去
+    if (slug.isEmpty()) {
+      slug = FALLBACK;
+    }
+    return truncate(slug, MAX_LENGTH);
+  }
+
+  /**
+   * 基底 slug に一意化サフィックス {@code -n} を付与する({@value #MAX_LENGTH} 文字に収まるよう基底側を切り詰める)。
+   *
+   * @param baseCode {@link #toBaseCode(String)} の戻り値
+   * @param suffix 2 以上の連番
+   * @return {@code <base>-<suffix>} 形式で {@value #MAX_LENGTH} 文字以内のコード
+   */
+  public String withSuffix(String baseCode, int suffix) {
+    String tail = "-" + suffix;
+    String head = truncate(baseCode, MAX_LENGTH - tail.length());
+    head = head.replaceAll("-+$", "");
+    if (head.isEmpty()) {
+      head = FALLBACK;
+    }
+    return head + tail;
+  }
+
+  private static String truncate(String s, int max) {
+    return s.length() <= max ? s : s.substring(0, max);
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/infra/TenantInfraConfig.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/infra/TenantInfraConfig.java
@@ -3,6 +3,7 @@ package xyz.dgz48.tasks.webapi.tenant.infra;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import xyz.dgz48.tasks.webapi.tenant.domain.TenantAuditDiffDomainService;
+import xyz.dgz48.tasks.webapi.tenant.domain.TenantCodeGenerator;
 
 @Configuration
 class TenantInfraConfig {
@@ -10,5 +11,10 @@ class TenantInfraConfig {
   @Bean
   TenantAuditDiffDomainService tenantAuditDiffDomainService() {
     return new TenantAuditDiffDomainService();
+  }
+
+  @Bean
+  TenantCodeGenerator tenantCodeGenerator() {
+    return new TenantCodeGenerator();
   }
 }

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/usecase/AdminTenantRepository.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/usecase/AdminTenantRepository.java
@@ -15,6 +15,21 @@ import xyz.dgz48.tasks.webapi.tenant.domain.TenantStatus;
  */
 public interface AdminTenantRepository {
 
+  /**
+   * テナントを新規作成する({@code plan} は本フェーズ固定の {@code FREE}、{@code status} は {@code ACTIVE})。
+   *
+   * <p>セルフサインアップ(A-05)経路で呼ばれる。作成直後はメンバー未登録のため、返却する {@link Tenant} の {@code userCount} / {@code
+   * taskCount} は 0(COUNT クエリは発行しない — {@code X-Tenant-Id} 未指定経路で {@code tasks} を読むと越境検知に当たるため)。
+   *
+   * @param code 一意な slug コード(呼び出し側が一意性を担保済み)
+   * @param name テナント表示名
+   * @return 作成された Tenant(userCount/taskCount = 0)
+   */
+  Tenant createTenant(String code, String name);
+
+  /** 指定 code のテナントが既に存在するか(slug 一意化リトライ用)。 */
+  boolean existsByCode(String code);
+
   /** テナントを ID で検索する(フィルタなし)。存在しない場合は空。 */
   Optional<Tenant> findById(Long id);
 

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/usecase/CreateTenantCommand.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/usecase/CreateTenantCommand.java
@@ -1,0 +1,19 @@
+package xyz.dgz48.tasks.webapi.tenant.usecase;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * セルフサインアップ(A-05)入力。呼び出しユーザーのプロフィール(初代 admin レスポンス組み立て用)とテナント表示名を運ぶ。
+ *
+ * @param callerId 呼び出しユーザー ID(初代 TENANT_ADMIN になる)
+ * @param callerEmail 呼び出しユーザーのメール
+ * @param callerFullName 呼び出しユーザーの氏名
+ * @param callerDepartmentName 部署名(無ければ null)
+ * @param name 作成するテナントの表示名
+ */
+public record CreateTenantCommand(
+    Long callerId,
+    String callerEmail,
+    String callerFullName,
+    @Nullable String callerDepartmentName,
+    String name) {}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/usecase/CreateTenantResult.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/usecase/CreateTenantResult.java
@@ -1,0 +1,7 @@
+package xyz.dgz48.tasks.webapi.tenant.usecase;
+
+import xyz.dgz48.tasks.webapi.tenant.domain.Tenant;
+import xyz.dgz48.tasks.webapi.tenant.domain.TenantUserInfo;
+
+/** セルフサインアップ(A-05)結果。作成テナントと、初代 TENANT_ADMIN として登録されたユーザー情報を運ぶ(OpenAPI TenantCreatedResponse)。 */
+public record CreateTenantResult(Tenant tenant, TenantUserInfo initialAdmin) {}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/usecase/CreateTenantUseCase.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/usecase/CreateTenantUseCase.java
@@ -1,0 +1,96 @@
+package xyz.dgz48.tasks.webapi.tenant.usecase;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import xyz.dgz48.tasks.webapi.audit.domain.AuditEventType;
+import xyz.dgz48.tasks.webapi.audit.usecase.AuditLogPort;
+import xyz.dgz48.tasks.webapi.tenant.domain.Tenant;
+import xyz.dgz48.tasks.webapi.tenant.domain.TenantCodeConflictException;
+import xyz.dgz48.tasks.webapi.tenant.domain.TenantCodeGenerator;
+import xyz.dgz48.tasks.webapi.tenant.domain.TenantRole;
+import xyz.dgz48.tasks.webapi.tenant.domain.TenantUserInfo;
+import xyz.dgz48.tasks.webapi.tenant.domain.UserTenantStatus;
+
+/**
+ * セルフサインアップ(A-05、モデル B): 認証済み・テナント未所属でも可のユーザーが自分でテナントを作成し、初代 {@code TENANT_ADMIN} として登録される。
+ *
+ * <p>{@code code} は表示名の slug から自動生成し、既存と衝突する場合は {@code -2}, {@code -3} … のサフィックスを付与してリトライする (上限超過は
+ * {@link TenantCodeConflictException} → 409)。並行作成による稀な一意制約違反は {@code
+ * DataIntegrityViolationException} として伝播し、Controller 層の例外ハンドラで 409 にマップされる。
+ *
+ * <p>{@code tenants} / {@code user_tenants} は Hibernate Filter 非適用テーブルのため {@code X-Tenant-Id}
+ * 未指定(TenantContext 未設定)でも安全に書き込める。新規テナントの集計値(userCount/taskCount)は自明(1 / 0)であり、COUNT クエリ(特に {@code
+ * tasks})は発行しない。
+ */
+@Service
+@RequiredArgsConstructor
+public class CreateTenantUseCase {
+
+  /** slug サフィックスリトライの上限(超過時は 409)。 */
+  private static final int MAX_CODE_ATTEMPTS = 50;
+
+  private final AdminTenantRepository adminTenantRepository;
+  private final UserTenantManagementPort userTenantManagementPort;
+  private final TenantCodeGenerator tenantCodeGenerator;
+  private final AuditLogPort auditLogPort;
+  private final Clock clock;
+
+  @Transactional
+  public CreateTenantResult execute(CreateTenantCommand cmd) {
+    String code = resolveUniqueCode(cmd.name());
+    Tenant created = adminTenantRepository.createTenant(code, cmd.name());
+    Long tenantId = created.getId();
+
+    userTenantManagementPort.addMember(cmd.callerId(), tenantId, TenantRole.TENANT_ADMIN);
+    LocalDateTime joinedAt = LocalDateTime.now(clock);
+
+    auditLogPort.record(
+        AuditEventType.TENANT_CREATED,
+        tenantId,
+        cmd.callerId(),
+        Map.of("code", created.getCode(), "name", created.getName()));
+
+    // 初代 admin 登録後の集計値に補正(userCount = 1、taskCount = 0)。
+    Tenant tenant =
+        new Tenant(
+            tenantId,
+            created.getCode(),
+            created.getName(),
+            created.getPlan(),
+            created.getStatus(),
+            created.getCreatedAt(),
+            created.getUpdatedAt(),
+            1L,
+            0L);
+
+    TenantUserInfo initialAdmin =
+        new TenantUserInfo(
+            cmd.callerId(),
+            cmd.callerEmail(),
+            cmd.callerFullName(),
+            cmd.callerDepartmentName(),
+            TenantRole.TENANT_ADMIN,
+            UserTenantStatus.ACTIVE,
+            joinedAt);
+
+    return new CreateTenantResult(tenant, initialAdmin);
+  }
+
+  private String resolveUniqueCode(String name) {
+    String base = tenantCodeGenerator.toBaseCode(name);
+    if (!adminTenantRepository.existsByCode(base)) {
+      return base;
+    }
+    for (int suffix = 2; suffix <= MAX_CODE_ATTEMPTS; suffix++) {
+      String candidate = tenantCodeGenerator.withSuffix(base, suffix);
+      if (!adminTenantRepository.existsByCode(candidate)) {
+        return candidate;
+      }
+    }
+    throw new TenantCodeConflictException(base);
+  }
+}

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/SecurityConfigTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/SecurityConfigTest.java
@@ -54,6 +54,7 @@ import xyz.dgz48.tasks.webapi.tenant.domain.TenantMembership;
 import xyz.dgz48.tasks.webapi.tenant.domain.TenantRole;
 import xyz.dgz48.tasks.webapi.tenant.usecase.AddMemberUseCase;
 import xyz.dgz48.tasks.webapi.tenant.usecase.ChangeMemberRoleUseCase;
+import xyz.dgz48.tasks.webapi.tenant.usecase.CreateTenantUseCase;
 import xyz.dgz48.tasks.webapi.tenant.usecase.GetPlatformMetricsUseCase;
 import xyz.dgz48.tasks.webapi.tenant.usecase.GetTenantUseCase;
 import xyz.dgz48.tasks.webapi.tenant.usecase.ListTenantUsersUseCase;
@@ -107,6 +108,7 @@ class SecurityConfigTest {
   @MockitoBean ListTenantUsersUseCase listTenantUsersUseCase;
   @MockitoBean GetDashboardTasksUseCase getDashboardTasksUseCase;
   @MockitoBean GetDashboardSummaryUseCase getDashboardSummaryUseCase;
+  @MockitoBean CreateTenantUseCase createTenantUseCase;
 
   @Autowired MockMvc mockMvc;
 

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/TenantContextFilterTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/TenantContextFilterTest.java
@@ -43,6 +43,7 @@ import xyz.dgz48.tasks.webapi.tenant.domain.TenantMembership;
 import xyz.dgz48.tasks.webapi.tenant.domain.TenantRole;
 import xyz.dgz48.tasks.webapi.tenant.usecase.AddMemberUseCase;
 import xyz.dgz48.tasks.webapi.tenant.usecase.ChangeMemberRoleUseCase;
+import xyz.dgz48.tasks.webapi.tenant.usecase.CreateTenantUseCase;
 import xyz.dgz48.tasks.webapi.tenant.usecase.GetPlatformMetricsUseCase;
 import xyz.dgz48.tasks.webapi.tenant.usecase.GetTenantUseCase;
 import xyz.dgz48.tasks.webapi.tenant.usecase.ListTenantUsersUseCase;
@@ -122,6 +123,7 @@ class TenantContextFilterTest {
   @MockitoBean ListTenantUsersUseCase listTenantUsersUseCase;
   @MockitoBean GetDashboardTasksUseCase getDashboardTasksUseCase;
   @MockitoBean GetDashboardSummaryUseCase getDashboardSummaryUseCase;
+  @MockitoBean CreateTenantUseCase createTenantUseCase;
 
   @Autowired MockMvc mockMvc;
 

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/tenant/adapter/web/TenantSignupIT.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/tenant/adapter/web/TenantSignupIT.java
@@ -1,0 +1,192 @@
+package xyz.dgz48.tasks.webapi.tenant.adapter.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.jayway.jsonpath.JsonPath;
+import jakarta.persistence.EntityManager;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.support.TransactionTemplate;
+import xyz.dgz48.tasks.webapi.FixedClockConfiguration;
+import xyz.dgz48.tasks.webapi.MockJwtDecoderConfiguration;
+import xyz.dgz48.tasks.webapi.TestcontainersConfiguration;
+import xyz.dgz48.tasks.webapi.security.adapter.web.TasksAuthenticationToken;
+import xyz.dgz48.tasks.webapi.security.domain.TasksPrincipal;
+import xyz.dgz48.tasks.webapi.user.adapter.persistence.UserJpaEntity;
+
+/**
+ * セルフサインアップ(A-05)POST /api/tenants の統合 IT(Testcontainers MySQL 8.4)。
+ *
+ * <p>認証済み・テナント未所属ユーザーが {@code X-Tenant-Id} なしでテナントを作成し、初代 TENANT_ADMIN として登録されることを検証する。
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@Import({
+  TestcontainersConfiguration.class,
+  MockJwtDecoderConfiguration.class,
+  FixedClockConfiguration.class
+})
+class TenantSignupIT {
+
+  @Autowired MockMvc mockMvc;
+  @Autowired EntityManager em;
+  @Autowired TransactionTemplate txTemplate;
+
+  private Long userId;
+  private TasksAuthenticationToken authToken;
+  private final List<Long> createdTenantIds = new ArrayList<>();
+
+  @BeforeEach
+  void setUp() {
+    createdTenantIds.clear();
+    txTemplate.execute(
+        ignored -> {
+          var user =
+              new UserJpaEntity("sub-signup", "signup@example.com", "サインアップ太郎", "サインアップタロウ", "開発部");
+          em.persist(user);
+          em.flush();
+          userId = user.getId();
+          return null;
+        });
+    var principal =
+        new TasksPrincipal(
+            userId, "sub-signup", "signup@example.com", "サインアップ太郎", "サインアップタロウ", "開発部");
+    authToken = new TasksAuthenticationToken(principal, List.of());
+  }
+
+  @AfterEach
+  void tearDown() {
+    SecurityContextHolder.clearContext();
+    if (userId == null) {
+      return;
+    }
+    txTemplate.execute(
+        ignored -> {
+          for (Long tenantId : createdTenantIds) {
+            em.createNativeQuery("DELETE FROM audit_logs WHERE tenant_id = ?")
+                .setParameter(1, tenantId)
+                .executeUpdate();
+            em.createNativeQuery("DELETE FROM chain_heads WHERE chain_key = ?")
+                .setParameter(1, tenantId)
+                .executeUpdate();
+          }
+          em.createNativeQuery("DELETE FROM user_tenants WHERE user_id = ?")
+              .setParameter(1, userId)
+              .executeUpdate();
+          for (Long tenantId : createdTenantIds) {
+            em.createNativeQuery("DELETE FROM tenants WHERE id = ?")
+                .setParameter(1, tenantId)
+                .executeUpdate();
+          }
+          em.createNativeQuery("DELETE FROM users WHERE id = ?")
+              .setParameter(1, userId)
+              .executeUpdate();
+          return null;
+        });
+  }
+
+  @Test
+  void createTenant_returns201_andRegistersCallerAsTenantAdmin() throws Exception {
+    String response =
+        mockMvc
+            .perform(
+                post("/api/tenants")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("{\"name\":\"My Team\"}")
+                    .with(authentication(authToken)))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.tenant.name").value("My Team"))
+            .andExpect(jsonPath("$.tenant.code").value("my-team"))
+            .andExpect(jsonPath("$.tenant.plan").value("FREE"))
+            .andExpect(jsonPath("$.tenant.status").value("ACTIVE"))
+            .andExpect(jsonPath("$.tenant.userCount").value(1))
+            .andExpect(jsonPath("$.tenant.taskCount").value(0))
+            .andExpect(jsonPath("$.initialAdmin.userId").value(userId))
+            .andExpect(jsonPath("$.initialAdmin.email").value("signup@example.com"))
+            .andExpect(jsonPath("$.initialAdmin.role").value("TENANT_ADMIN"))
+            .andExpect(jsonPath("$.initialAdmin.status").value("ACTIVE"))
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+    Long tenantId = ((Number) JsonPath.read(response, "$.tenant.id")).longValue();
+    createdTenantIds.add(tenantId);
+
+    Object[] row =
+        (Object[])
+            em.createNativeQuery(
+                    "SELECT role, status FROM user_tenants WHERE user_id = ? AND tenant_id = ?")
+                .setParameter(1, userId)
+                .setParameter(2, tenantId)
+                .getSingleResult();
+    assertThat(row[0]).isEqualTo("TENANT_ADMIN");
+    assertThat(row[1]).isEqualTo("ACTIVE");
+  }
+
+  @Test
+  void createTenant_sameName_generatesSuffixedCode() throws Exception {
+    String first =
+        mockMvc
+            .perform(
+                post("/api/tenants")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("{\"name\":\"Dup Team\"}")
+                    .with(authentication(authToken)))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.tenant.code").value("dup-team"))
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+    createdTenantIds.add(((Number) JsonPath.read(first, "$.tenant.id")).longValue());
+
+    String second =
+        mockMvc
+            .perform(
+                post("/api/tenants")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("{\"name\":\"Dup Team\"}")
+                    .with(authentication(authToken)))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.tenant.code").value("dup-team-2"))
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+    createdTenantIds.add(((Number) JsonPath.read(second, "$.tenant.id")).longValue());
+  }
+
+  @Test
+  void createTenant_blankName_returns400() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/tenants")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"name\":\"   \"}")
+                .with(authentication(authToken)))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("E_VALIDATION"));
+  }
+
+  @Test
+  void createTenant_unauthenticated_returns401() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/tenants")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"name\":\"No Auth\"}"))
+        .andExpect(status().isUnauthorized());
+  }
+}

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/tenant/domain/TenantCodeGeneratorTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/tenant/domain/TenantCodeGeneratorTest.java
@@ -1,0 +1,77 @@
+package xyz.dgz48.tasks.webapi.tenant.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/** {@link TenantCodeGenerator} の slug 生成・サフィックス付与の単体テスト。 */
+class TenantCodeGeneratorTest {
+
+  private final TenantCodeGenerator generator = new TenantCodeGenerator();
+
+  @Nested
+  class ToBaseCode {
+
+    @Test
+    void asciiNameBecomesLowerKebab() {
+      assertThat(generator.toBaseCode("Sales Team")).isEqualTo("sales-team");
+    }
+
+    @Test
+    void symbolsAndSpacesCollapseToSingleHyphen() {
+      assertThat(generator.toBaseCode("  Hello,  World!!  ")).isEqualTo("hello-world");
+    }
+
+    @Test
+    void leadingAndTrailingHyphensAreTrimmed() {
+      assertThat(generator.toBaseCode("---ACME---")).isEqualTo("acme");
+    }
+
+    @Test
+    void japaneseOnlyNameFallsBackToTenant() {
+      assertThat(generator.toBaseCode("営業部テナント")).isEqualTo(TenantCodeGenerator.FALLBACK);
+    }
+
+    @Test
+    void symbolOnlyNameFallsBackToTenant() {
+      assertThat(generator.toBaseCode("!!!")).isEqualTo(TenantCodeGenerator.FALLBACK);
+    }
+
+    @Test
+    void resultIsTruncatedToMaxLength() {
+      String longName = "a".repeat(80);
+      assertThat(generator.toBaseCode(longName)).hasSize(TenantCodeGenerator.MAX_LENGTH);
+    }
+
+    @Test
+    void resultAlwaysMatchesCodePattern() {
+      assertThat(generator.toBaseCode("Café Münchën 2024")).matches("^[a-z0-9-]+$");
+    }
+  }
+
+  @Nested
+  class WithSuffix {
+
+    @Test
+    void appendsHyphenSuffix() {
+      assertThat(generator.withSuffix("sales-team", 2)).isEqualTo("sales-team-2");
+    }
+
+    @Test
+    void truncatesHeadToFitMaxLength() {
+      String base = "a".repeat(TenantCodeGenerator.MAX_LENGTH);
+      String result = generator.withSuffix(base, 10);
+      assertThat(result).hasSizeLessThanOrEqualTo(TenantCodeGenerator.MAX_LENGTH).endsWith("-10");
+      assertThat(result).matches("^[a-z0-9-]+$");
+    }
+
+    @Test
+    void doesNotProduceDoubleHyphenWhenHeadEndsWithHyphenAfterTruncation() {
+      // 切り詰め長(MAX_LENGTH-2=48)の境界がハイフンに当たるケースでも "--" を作らない。
+      String base = "a".repeat(TenantCodeGenerator.MAX_LENGTH - 3) + "-extra";
+      String result = generator.withSuffix(base, 3);
+      assertThat(result).doesNotContain("--").endsWith("-3").matches("^[a-z0-9-]+$");
+    }
+  }
+}

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/tenant/usecase/CreateTenantUseCaseTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/tenant/usecase/CreateTenantUseCaseTest.java
@@ -1,0 +1,113 @@
+package xyz.dgz48.tasks.webapi.tenant.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import xyz.dgz48.tasks.webapi.audit.domain.AuditEventType;
+import xyz.dgz48.tasks.webapi.audit.usecase.AuditLogPort;
+import xyz.dgz48.tasks.webapi.tenant.domain.Tenant;
+import xyz.dgz48.tasks.webapi.tenant.domain.TenantCodeConflictException;
+import xyz.dgz48.tasks.webapi.tenant.domain.TenantCodeGenerator;
+import xyz.dgz48.tasks.webapi.tenant.domain.TenantPlan;
+import xyz.dgz48.tasks.webapi.tenant.domain.TenantRole;
+import xyz.dgz48.tasks.webapi.tenant.domain.TenantStatus;
+import xyz.dgz48.tasks.webapi.tenant.domain.UserTenant;
+import xyz.dgz48.tasks.webapi.tenant.domain.UserTenantStatus;
+
+/** {@link CreateTenantUseCase} の単体テスト(code 一意化リトライ・初代 admin 登録・監査記録)。 */
+@ExtendWith(MockitoExtension.class)
+class CreateTenantUseCaseTest {
+
+  private static final Long CALLER_ID = 42L;
+  private static final Clock FIXED_CLOCK =
+      Clock.fixed(Instant.parse("2026-06-26T01:00:00Z"), ZoneOffset.UTC);
+
+  @Mock private AdminTenantRepository adminTenantRepository;
+  @Mock private UserTenantManagementPort userTenantManagementPort;
+  @Mock private AuditLogPort auditLogPort;
+
+  private CreateTenantUseCase useCase() {
+    return new CreateTenantUseCase(
+        adminTenantRepository,
+        userTenantManagementPort,
+        new TenantCodeGenerator(),
+        auditLogPort,
+        FIXED_CLOCK);
+  }
+
+  private Tenant createdTenant(Long id, String code, String name) {
+    LocalDateTime ts = LocalDateTime.of(2026, 6, 26, 10, 0);
+    return new Tenant(id, code, name, TenantPlan.FREE, TenantStatus.ACTIVE, ts, ts, 0L, 0L);
+  }
+
+  private CreateTenantCommand command(String name) {
+    return new CreateTenantCommand(CALLER_ID, "owner@example.com", "所有者", "開発部", name);
+  }
+
+  @Test
+  void createsTenantAndRegistersCallerAsTenantAdmin() {
+    given(adminTenantRepository.existsByCode("sales-team")).willReturn(false);
+    given(adminTenantRepository.createTenant("sales-team", "Sales Team"))
+        .willReturn(createdTenant(7L, "sales-team", "Sales Team"));
+    given(userTenantManagementPort.addMember(CALLER_ID, 7L, TenantRole.TENANT_ADMIN))
+        .willReturn(new UserTenant(CALLER_ID, 7L, TenantRole.TENANT_ADMIN));
+
+    CreateTenantResult result = useCase().execute(command("Sales Team"));
+
+    assertThat(result.tenant().getId()).isEqualTo(7L);
+    assertThat(result.tenant().getCode()).isEqualTo("sales-team");
+    assertThat(result.tenant().getPlan()).isEqualTo(TenantPlan.FREE);
+    assertThat(result.tenant().getUserCount()).isEqualTo(1L);
+    assertThat(result.tenant().getTaskCount()).isZero();
+
+    assertThat(result.initialAdmin().userId()).isEqualTo(CALLER_ID);
+    assertThat(result.initialAdmin().email()).isEqualTo("owner@example.com");
+    assertThat(result.initialAdmin().role()).isEqualTo(TenantRole.TENANT_ADMIN);
+    assertThat(result.initialAdmin().status()).isEqualTo(UserTenantStatus.ACTIVE);
+    // joinedAt は固定 Clock(01:00 UTC)由来
+    assertThat(result.initialAdmin().joinedAt())
+        .isEqualTo(LocalDateTime.ofInstant(FIXED_CLOCK.instant(), ZoneOffset.UTC));
+
+    verify(userTenantManagementPort).addMember(CALLER_ID, 7L, TenantRole.TENANT_ADMIN);
+    verify(auditLogPort).record(eq(AuditEventType.TENANT_CREATED), eq(7L), eq(CALLER_ID), any());
+  }
+
+  @Test
+  void retriesWithSuffixWhenBaseCodeCollides() {
+    given(adminTenantRepository.existsByCode("sales-team")).willReturn(true);
+    given(adminTenantRepository.existsByCode("sales-team-2")).willReturn(false);
+    given(adminTenantRepository.createTenant("sales-team-2", "Sales Team"))
+        .willReturn(createdTenant(8L, "sales-team-2", "Sales Team"));
+    given(userTenantManagementPort.addMember(CALLER_ID, 8L, TenantRole.TENANT_ADMIN))
+        .willReturn(new UserTenant(CALLER_ID, 8L, TenantRole.TENANT_ADMIN));
+
+    CreateTenantResult result = useCase().execute(command("Sales Team"));
+
+    assertThat(result.tenant().getCode()).isEqualTo("sales-team-2");
+    verify(adminTenantRepository).createTenant("sales-team-2", "Sales Team");
+  }
+
+  @Test
+  void throwsConflictWhenAllSuffixesExhausted() {
+    given(adminTenantRepository.existsByCode(any())).willReturn(true);
+
+    assertThatThrownBy(() -> useCase().execute(command("Sales Team")))
+        .isInstanceOf(TenantCodeConflictException.class);
+
+    verify(adminTenantRepository, never()).createTenant(any(), any());
+    verify(userTenantManagementPort, never()).addMember(any(), any(), any());
+  }
+}


### PR DESCRIPTION
## 概要

A-05 セルフサインアップ API (`POST /api/tenants`) と S-11 テナント作成画面を実装する。認証済みユーザーが新規テナントを作成し、自身が初代テナント管理者として登録される。トラッカー #780 の最初の課題。

Closes #775

## 実装内容

### バックエンド (A-05)
- **`CreateTenantUseCase`** — テナント名から slug(`code`)を生成し、`existsByCode` で一意化リトライ(衝突は最大 50 回、枯渇時 `TenantCodeConflictException` → 409)。呼び出し元を初代 `TENANT_ADMIN` / `ACTIVE` で `user_tenants` に登録し、`TENANT_CREATED` を監査記録。`Clock` 由来の `joinedAt` を返す。
- **`TenantCodeGenerator`**(domain) — `toLowerCase` → 非英数を `-` に畳み込み → トリム/連結圧縮、50 文字上限。日本語等で空になる場合は `tenant` にフォールバックし、常に `^[a-z0-9-]+$` を満たす。
- **`TenantSignupController`** — 認証済みであれば(テナント未所属でも)実行可能。`X-Tenant-Id` 不要(`TenantContextFilter` の免除パス)。caller 情報は `@AuthenticationPrincipal(expression=...)` で取得し、security feature への静的依存を作らない(Spring Modulith のサイクル回避)。
- **`TenantSignupExceptionHandler`** — 当 Controller スコープ限定で `TenantCodeConflictException` / `DataIntegrityViolationException`(並行作成レース)を 409 にマップ。

### フロントエンド (S-11)
- `index.html` / `index.js` — テナント未所属時に「テナントを作成」導線を表示。
- `tenants-new.html` / `tenants-new.js` — 作成フォーム。送信前に stale な `X-Tenant-Id` をクリアし、成功後に新テナントを選択して `tasks.html` へ遷移。400/409 を画面メッセージに変換。

## テスト
- `TenantCodeGeneratorTest`(slug 生成・フォールバック・suffix 付与・パターン保証)
- `CreateTenantUseCaseTest`(happy path / suffix リトライ / 衝突枯渇、固定 Clock)
- `TenantSignupIT`(Testcontainers): 201 + TENANT_ADMIN/ACTIVE 登録を SQL で検証、同名→suffix 付き code、blank→400、未認証→401
- `SecurityConfigTest` / `TenantContextFilterTest` に `CreateTenantUseCase` モックを追加(`@WebMvcTest` の全 Controller スキャン対応)

`./gradlew :webapi:check`(spotless / JaCoCo 0.80 / 全 IT)green、`web/` の biome・html-validate・tsc も green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
