### PR TITLE
feat(dashboard): 運営者ダッシュボード集計 GET /api/tenant/dashboard/summary + S-15 (Closes #776)

### DIFF
--- a/web/js/api.js
+++ b/web/js/api.js
@@ -109,6 +109,17 @@
  * @property {TenantRef[]} tenants
  */
 
+/**
+ * @typedef {object} TenantDashboardSummary
+ * @property {number} totalTaskCount
+ * @property {number} todayDueCount
+ * @property {number} overdueCount
+ * @property {number} completedTodayCount
+ * @property {Record<string, number>} statusBreakdown
+ * @property {Record<string, number>} priorityBreakdown
+ * @property {number} memberCount
+ */
+
 const Api = (() => {
   const _envMatch = window.location.hostname.match(/^tasks(?:-(\w+))?\.dgz48\.xyz$/);
   const BASE_URL = _envMatch
@@ -344,6 +355,14 @@ const Api = (() => {
   }
 
   /**
+   * GET /api/tenant/dashboard/summary — テナント運営者向けダッシュボード集計(A-28、S-15、Tenant Admin)。
+   * @returns {Promise<TenantDashboardSummary>}
+   */
+  function getTenantDashboardSummary() {
+    return request('/api/tenant/dashboard/summary');
+  }
+
+  /**
    * GET /api/tasks/{id} — タスク詳細取得(A-12)。ETag も返す。
    * @param {number} id
    * @returns {Promise<{task: TaskDetail, etag: string|null}>}
@@ -443,6 +462,7 @@ const Api = (() => {
     changeStatus,
     changeVisibility,
     listTenantUsers,
+    getTenantDashboardSummary,
     listStakeholders,
     addStakeholder,
     removeStakeholder,

--- a/web/js/tenant-dashboard.js
+++ b/web/js/tenant-dashboard.js
@@ -1,0 +1,121 @@
+// @ts-check
+
+/** @type {HTMLElement} */ (mustQuery(document, '#btn-logout')).addEventListener('click', () =>
+  Auth.logout(),
+);
+
+/**
+ * エラーメッセージを表示し、ローディングを止める。
+ * @param {string} message
+ */
+function showError(message) {
+  /** @type {HTMLElement} */ (mustQuery(document, '#loading')).classList.add('d-none');
+  const el = /** @type {HTMLElement} */ (mustQuery(document, '#error-alert'));
+  el.textContent = message;
+  el.classList.remove('d-none');
+}
+
+/**
+ * 数値カードへ件数を反映する。
+ * @param {string} id
+ * @param {number} value
+ */
+function setCard(id, value) {
+  /** @type {HTMLElement} */ (mustQuery(document, id)).textContent = String(value);
+}
+
+/**
+ * ブレークダウン表(ラベル + 件数)を描画する。0 件キーも明示する。
+ * @param {string} tbodyId
+ * @param {Array<{v: string, l: string}>} options 表示順 + ラベル
+ * @param {Record<string, number>} counts
+ */
+function renderBreakdown(tbodyId, options, counts) {
+  const tbody = /** @type {HTMLElement} */ (mustQuery(document, tbodyId));
+  tbody.replaceChildren();
+  for (const { v, l } of options) {
+    const tr = document.createElement('tr');
+    const th = document.createElement('th');
+    th.scope = 'row';
+    th.className = 'fw-normal';
+    th.textContent = l;
+    const td = document.createElement('td');
+    td.className = 'text-end fw-semibold';
+    td.textContent = String(counts?.[v] ?? 0);
+    tr.append(th, td);
+    tbody.append(tr);
+  }
+}
+
+/**
+ * @param {TenantDashboardSummary} summary
+ */
+function render(summary) {
+  setCard('#card-total', summary.totalTaskCount);
+  setCard('#card-today-due', summary.todayDueCount);
+  setCard('#card-overdue', summary.overdueCount);
+  setCard('#card-completed-today', summary.completedTodayCount);
+  setCard('#card-members', summary.memberCount);
+
+  renderBreakdown('#status-breakdown', TaskMeta.STATUS_OPTIONS, summary.statusBreakdown);
+  renderBreakdown('#priority-breakdown', TaskMeta.PRIORITY_OPTIONS, summary.priorityBreakdown);
+
+  /** @type {HTMLElement} */ (mustQuery(document, '#loading')).classList.add('d-none');
+  /** @type {HTMLElement} */ (mustQuery(document, '#summary')).classList.remove('d-none');
+}
+
+async function main() {
+  const authenticated = await Auth.init();
+  if (!authenticated) {
+    return;
+  }
+
+  const user = Auth.getUser();
+  const displayName = user?.name || user?.preferred_username || '';
+  /** @type {HTMLElement} */ (mustQuery(document, '#nav-username')).textContent = displayName;
+  /** @type {HTMLElement} */ (mustQuery(document, '#user-avatar')).textContent =
+    displayName.slice(0, 1) || '?';
+
+  /** @type {MeResponse} */
+  let me;
+  try {
+    me = await Api.getMe();
+  } catch (err) {
+    showError(`ユーザー情報の取得に失敗しました: ${/** @type {any} */ (err).message}`);
+    return;
+  }
+
+  const activeTenantId = Api.resolveActiveTenant(me.tenants);
+  if (activeTenantId === null) {
+    window.location.replace('index.html');
+    return;
+  }
+
+  /** @type {AppTenantSwitcherElement} */ (mustQuery(document, '#tenant-switcher')).setData(
+    me.tenants,
+    activeTenantId,
+  );
+
+  const activeTenant = me.tenants?.find((t) => t.id === activeTenantId);
+  if (activeTenant?.role === 'TENANT_ADMIN') {
+    document.body.classList.add('role-admin');
+  } else {
+    // Tenant Admin 以外はこのダッシュボードを参照できない(API は 403)。
+    showError('このページはテナント管理者のみ閲覧できます。');
+    return;
+  }
+
+  try {
+    const summary = await Api.getTenantDashboardSummary();
+    render(summary);
+  } catch (err) {
+    const e = /** @type {{ status?: number, message?: string }} */ (err);
+    if (e.status === 403) {
+      showError('このページはテナント管理者のみ閲覧できます。');
+    } else {
+      showError(`集計の取得に失敗しました: ${e.message ?? '不明なエラー'}`);
+    }
+  }
+}
+
+main();

--- a/web/package.json
+++ b/web/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "copy-vendor": "node scripts/copy-vendor.js",
-    "html-validate": "html-validate index.html tasks.html tenants-new.html",
+    "html-validate": "html-validate index.html tasks.html tenants-new.html tenant-dashboard.html",
     "serve": "node serve.mjs"
   },
   "engines": {

--- a/web/tasks.html
+++ b/web/tasks.html
@@ -45,7 +45,7 @@
     </a>
     <div class="admin-only">
       <div class="nav-group-label" aria-hidden="true">テナント運営</div>
-      <a class="side-link" href="#">
+      <a class="side-link" href="tenant-dashboard.html">
         <i class="bi bi-graph-up-arrow" aria-hidden="true"></i>運営者ダッシュボード
       </a>
       <a class="side-link" href="#">

--- a/web/tenant-dashboard.html
+++ b/web/tenant-dashboard.html
@@ -1,0 +1,160 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>運営者ダッシュボード — Tasks</title>
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+  <link rel="stylesheet" href="vendor/bootstrap/css/bootstrap.min.css">
+  <link rel="stylesheet" href="vendor/bootstrap-icons/bootstrap-icons.min.css">
+  <link rel="stylesheet" href="css/app.css">
+</head>
+<body>
+<a href="#main-content" class="visually-hidden-focusable position-absolute p-2 m-2 bg-primary text-white rounded">
+  メインコンテンツへスキップ
+</a>
+
+<!-- ===== Top navbar ===== -->
+<nav class="app-navbar d-flex align-items-center px-3 gap-3 sticky-top" aria-label="グローバルナビゲーション">
+  <a class="app-brand d-flex align-items-center gap-2" href="index.html">
+    <i class="bi bi-check2-square fs-5" aria-hidden="true"></i><span>Tasks</span>
+  </a>
+  <app-tenant-switcher id="tenant-switcher" class="d-none"></app-tenant-switcher>
+  <div class="ms-auto d-flex align-items-center gap-3">
+    <div class="d-flex align-items-center gap-2">
+      <div id="user-avatar"
+        class="rounded-circle bg-primary-subtle text-primary d-grid"
+        aria-hidden="true">?</div>
+      <span id="nav-username" class="small d-none d-lg-inline"></span>
+    </div>
+    <button id="btn-logout" type="button" class="btn btn-outline-secondary btn-sm">
+      <i class="bi bi-box-arrow-right me-1" aria-hidden="true"></i>ログアウト
+    </button>
+  </div>
+</nav>
+
+<div class="app-layout">
+  <!-- ===== Sidebar ===== -->
+  <aside class="app-sidebar d-none d-lg-block" aria-label="サイドナビゲーション">
+    <div class="nav-group-label" aria-hidden="true">メイン</div>
+    <a class="side-link" href="index.html">
+      <i class="bi bi-speedometer2" aria-hidden="true"></i>ダッシュボード
+    </a>
+    <a class="side-link" href="tasks.html">
+      <i class="bi bi-list-check" aria-hidden="true"></i>タスク一覧
+    </a>
+    <div class="admin-only">
+      <div class="nav-group-label" aria-hidden="true">テナント運営</div>
+      <a class="side-link active" href="tenant-dashboard.html" aria-current="page">
+        <i class="bi bi-graph-up-arrow" aria-hidden="true"></i>運営者ダッシュボード
+      </a>
+      <a class="side-link" href="#">
+        <i class="bi bi-people" aria-hidden="true"></i>ユーザー管理
+      </a>
+    </div>
+    <div class="nav-group-label" aria-hidden="true">アカウント</div>
+    <a class="side-link" href="#"><i class="bi bi-person-circle" aria-hidden="true"></i>プロフィール</a>
+    <a class="side-link" href="#"><i class="bi bi-bell" aria-hidden="true"></i>通知設定</a>
+  </aside>
+
+  <!-- ===== Main ===== -->
+  <main id="main-content" class="app-main">
+    <div class="d-flex align-items-center flex-wrap gap-3 mb-3">
+      <h1 class="page-title">運営者ダッシュボード</h1>
+    </div>
+    <p class="text-muted small mb-3">
+      テナント全体で共有(TENANT)または関係者限定(STAKEHOLDERS)で動いている業務量の集計です。
+      PRIVATE タスクは集計に含まれません。
+    </p>
+
+    <div id="error-alert" class="alert alert-danger d-none" role="alert"></div>
+
+    <div id="loading" class="text-center py-5">
+      <div class="spinner-border text-primary" role="status">
+        <span class="visually-hidden">Loading...</span>
+      </div>
+      <p class="mt-2 text-muted">集計を取得中...</p>
+    </div>
+
+    <div id="summary" class="d-none">
+      <!-- 数値カード -->
+      <div class="row row-cols-2 row-cols-md-3 row-cols-xl-5 g-3 mb-4">
+        <div class="col">
+          <div class="card h-100">
+            <div class="card-body">
+              <div class="text-muted small">総タスク数</div>
+              <div id="card-total" class="fs-3 fw-semibold">—</div>
+            </div>
+          </div>
+        </div>
+        <div class="col">
+          <div class="card h-100">
+            <div class="card-body">
+              <div class="text-muted small">当日期限</div>
+              <div id="card-today-due" class="fs-3 fw-semibold">—</div>
+            </div>
+          </div>
+        </div>
+        <div class="col">
+          <div class="card h-100">
+            <div class="card-body">
+              <div class="text-muted small">期限切れ</div>
+              <div id="card-overdue" class="fs-3 fw-semibold text-danger">—</div>
+            </div>
+          </div>
+        </div>
+        <div class="col">
+          <div class="card h-100">
+            <div class="card-body">
+              <div class="text-muted small">本日完了</div>
+              <div id="card-completed-today" class="fs-3 fw-semibold text-success">—</div>
+            </div>
+          </div>
+        </div>
+        <div class="col">
+          <div class="card h-100">
+            <div class="card-body">
+              <div class="text-muted small">メンバー数</div>
+              <div id="card-members" class="fs-3 fw-semibold">—</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- ブレークダウン -->
+      <div class="row g-3">
+        <div class="col-12 col-lg-6">
+          <div class="card h-100">
+            <div class="card-body">
+              <h2 class="h6 card-title">ステータス別件数</h2>
+              <table class="table table-sm mb-0">
+                <tbody id="status-breakdown"></tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+        <div class="col-12 col-lg-6">
+          <div class="card h-100">
+            <div class="card-body">
+              <h2 class="h6 card-title">優先度別件数</h2>
+              <table class="table table-sm mb-0">
+                <tbody id="priority-breakdown"></tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </main>
+</div>
+
+<script src="vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
+<script src="vendor/keycloak-js/keycloak.min.js"></script>
+<script src="js/dom.js"></script>
+<script src="js/auth.js"></script>
+<script src="js/api.js"></script>
+<script src="js/meta.js"></script>
+<script src="js/components/app-tenant-switcher.js"></script>
+<script src="js/tenant-dashboard.js"></script>
+</body>
+</html>

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/dashboard/adapter/persistence/DashboardQueryAdapter.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/dashboard/adapter/persistence/DashboardQueryAdapter.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Component;
 import xyz.dgz48.tasks.webapi.dashboard.domain.DashboardSummary;
 import xyz.dgz48.tasks.webapi.dashboard.domain.DashboardTask;
 import xyz.dgz48.tasks.webapi.dashboard.domain.DashboardTaskSections;
+import xyz.dgz48.tasks.webapi.dashboard.domain.TenantDashboardSummary;
 import xyz.dgz48.tasks.webapi.dashboard.usecase.DashboardQueryPort;
 
 /**
@@ -91,6 +92,49 @@ class DashboardQueryAdapter implements DashboardQueryPort {
         myOpenCount,
         statusBreakdown,
         priorityBreakdown);
+  }
+
+  @Override
+  public TenantDashboardSummary aggregateTenantSummary(LocalDate today, Long tenantId) {
+    List<DashboardSummaryRow> rows = repository.findTenantVisibleSummaryRows();
+
+    long todayDueCount = 0;
+    long overdueCount = 0;
+    long completedTodayCount = 0;
+    Map<String, Long> statusBreakdown = newBreakdown(STATUS_KEYS);
+    Map<String, Long> priorityBreakdown = newBreakdown(PRIORITY_KEYS);
+
+    for (DashboardSummaryRow row : rows) {
+      boolean done = DONE.equals(row.status());
+
+      // 当日期限(due_date = TODAY、ステータス不問)
+      if (row.dueDate().isEqual(today)) {
+        todayDueCount++;
+      }
+      // 期限切れ未完了(due_date < TODAY かつ未完了)
+      if (!done && row.dueDate().isBefore(today)) {
+        overdueCount++;
+      }
+      // 本日完了(status = DONE かつ completed_at の日付 = TODAY、JST)
+      LocalDateTime completedAt = row.completedAt();
+      if (done && completedAt != null && completedAt.toLocalDate().isEqual(today)) {
+        completedTodayCount++;
+      }
+      // ステータス別・優先度別(visibility ∈ {TENANT, STAKEHOLDERS} 全体)
+      statusBreakdown.merge(row.status(), 1L, (a, b) -> a + b);
+      priorityBreakdown.merge(row.priority(), 1L, (a, b) -> a + b);
+    }
+
+    long memberCount = repository.countActiveMembers(tenantId);
+
+    return new TenantDashboardSummary(
+        rows.size(),
+        todayDueCount,
+        overdueCount,
+        completedTodayCount,
+        statusBreakdown,
+        priorityBreakdown,
+        memberCount);
   }
 
   private static Map<String, Long> newBreakdown(List<String> keys) {

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/dashboard/adapter/persistence/DashboardQueryAdapter.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/dashboard/adapter/persistence/DashboardQueryAdapter.java
@@ -52,52 +52,52 @@ class DashboardQueryAdapter implements DashboardQueryPort {
   @Override
   public DashboardSummary aggregateSummary(Long userId, LocalDate today) {
     List<DashboardSummaryRow> rows = repository.findVisibleSummaryRows(userId);
+    AggregatedMetrics metrics = aggregate(rows, today);
 
-    long todayDueCount = 0;
-    long overdueCount = 0;
-    long completedTodayCount = 0;
-    long myOpenCount = 0;
-    Map<String, Long> statusBreakdown = newBreakdown(STATUS_KEYS);
-    Map<String, Long> priorityBreakdown = newBreakdown(PRIORITY_KEYS);
-
-    for (DashboardSummaryRow row : rows) {
-      boolean done = DONE.equals(row.status());
-
-      // 当日期限(due_date = TODAY、ステータス不問。OpenAPI DashboardSummary.todayDueCount)
-      if (row.dueDate().isEqual(today)) {
-        todayDueCount++;
-      }
-      // 期限切れ未完了(due_date < TODAY かつ未完了)
-      if (!done && row.dueDate().isBefore(today)) {
-        overdueCount++;
-      }
-      // 本日完了(status = DONE かつ completed_at の日付 = TODAY、JST)
-      LocalDateTime completedAt = row.completedAt();
-      if (done && completedAt != null && completedAt.toLocalDate().isEqual(today)) {
-        completedTodayCount++;
-      }
-      // 自分が所有する未完了(所有者視点指標、担当・関係者は含まない)
-      if (!done && row.ownerId().equals(userId)) {
-        myOpenCount++;
-      }
-      // ステータス別・優先度別(認可フィルタ通過タスク全体)
-      statusBreakdown.merge(row.status(), 1L, (a, b) -> a + b);
-      priorityBreakdown.merge(row.priority(), 1L, (a, b) -> a + b);
-    }
+    // 自分が所有する未完了(所有者視点指標、担当・関係者は含まない)。S-03 個人集計固有の指標。
+    long myOpenCount =
+        rows.stream()
+            .filter(row -> !DONE.equals(row.status()) && row.ownerId().equals(userId))
+            .count();
 
     return new DashboardSummary(
-        todayDueCount,
-        overdueCount,
-        completedTodayCount,
+        metrics.todayDueCount(),
+        metrics.overdueCount(),
+        metrics.completedTodayCount(),
         myOpenCount,
-        statusBreakdown,
-        priorityBreakdown);
+        metrics.statusBreakdown(),
+        metrics.priorityBreakdown());
   }
 
   @Override
   public TenantDashboardSummary aggregateTenantSummary(LocalDate today, Long tenantId) {
     List<DashboardSummaryRow> rows = repository.findTenantVisibleSummaryRows();
+    AggregatedMetrics metrics = aggregate(rows, today);
+    long memberCount = repository.countActiveMembers(tenantId);
 
+    return new TenantDashboardSummary(
+        rows.size(),
+        metrics.todayDueCount(),
+        metrics.overdueCount(),
+        metrics.completedTodayCount(),
+        metrics.statusBreakdown(),
+        metrics.priorityBreakdown(),
+        memberCount);
+  }
+
+  /** S-03 個人集計と S-15 運営者集計で共通の件数系・ブレークダウン指標(myOpenCount は除く)。 */
+  private record AggregatedMetrics(
+      long todayDueCount,
+      long overdueCount,
+      long completedTodayCount,
+      Map<String, Long> statusBreakdown,
+      Map<String, Long> priorityBreakdown) {}
+
+  /**
+   * 軽量射影行集合から共通指標を 1 パスで算出する。対象タスク集合の絞り込み(個人=3 役割評価 / 運営者=visibility ∈ {TENANT,
+   * STAKEHOLDERS})は呼び出し側のクエリが担い、本メソッドは集計のみを担う。
+   */
+  private AggregatedMetrics aggregate(List<DashboardSummaryRow> rows, LocalDate today) {
     long todayDueCount = 0;
     long overdueCount = 0;
     long completedTodayCount = 0;
@@ -120,21 +120,13 @@ class DashboardQueryAdapter implements DashboardQueryPort {
       if (done && completedAt != null && completedAt.toLocalDate().isEqual(today)) {
         completedTodayCount++;
       }
-      // ステータス別・優先度別(visibility ∈ {TENANT, STAKEHOLDERS} 全体)
+      // ステータス別・優先度別
       statusBreakdown.merge(row.status(), 1L, (a, b) -> a + b);
       priorityBreakdown.merge(row.priority(), 1L, (a, b) -> a + b);
     }
 
-    long memberCount = repository.countActiveMembers(tenantId);
-
-    return new TenantDashboardSummary(
-        rows.size(),
-        todayDueCount,
-        overdueCount,
-        completedTodayCount,
-        statusBreakdown,
-        priorityBreakdown,
-        memberCount);
+    return new AggregatedMetrics(
+        todayDueCount, overdueCount, completedTodayCount, statusBreakdown, priorityBreakdown);
   }
 
   private static Map<String, Long> newBreakdown(List<String> keys) {

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/dashboard/adapter/persistence/DashboardTaskViewRepository.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/dashboard/adapter/persistence/DashboardTaskViewRepository.java
@@ -101,4 +101,35 @@ interface DashboardTaskViewRepository extends Repository<DashboardTaskView, Long
         )
       """)
   List<DashboardSummaryRow> findVisibleSummaryRows(@Param("userId") Long userId);
+
+  /**
+   * S-15 テナント運営者集計の対象タスク(自テナント内の {@code visibility ∈ {TENANT, STAKEHOLDERS}})を軽量射影で取得する。
+   *
+   * <p>{@code PRIVATE} は件数も含めて除外する(NIST AC-4 整合)。テナント分離は Hibernate Filter "tenantFilter" が自動付与する
+   * ({@link DashboardTaskView} は {@code TenantFilteredEntity} を継承)。件数系・ブレークダウンは adapter 側で算出する。
+   */
+  @Query(
+      """
+      SELECT new xyz.dgz48.tasks.webapi.dashboard.adapter.persistence.DashboardSummaryRow(
+        t.status, t.priority, t.dueDate, t.completedAt, t.ownerId)
+      FROM DashboardTaskView t
+      WHERE t.deletedAt IS NULL
+        AND t.visibility IN ('TENANT', 'STAKEHOLDERS')
+      """)
+  List<DashboardSummaryRow> findTenantVisibleSummaryRows();
+
+  /**
+   * 現在テナントの ACTIVE 所属ユーザー数を取得する({@code TenantDashboardSummary.memberCount})。
+   *
+   * <p>native 理由: モジュール境界越え(tenant feature の {@code user_tenants} 参照)。{@code user_tenants} は {@code
+   * TenantFilteredEntity} 非適用テーブル(ADR-0010 §6.1)のため、テナント条件を {@code tenantId} で明示絞り込みする。
+   */
+  @Query(
+      value =
+          """
+          SELECT COUNT(*) FROM user_tenants
+          WHERE tenant_id = :tenantId AND status = 'ACTIVE'
+          """,
+      nativeQuery = true)
+  long countActiveMembers(@Param("tenantId") Long tenantId);
 }

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/dashboard/adapter/web/TenantDashboardController.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/dashboard/adapter/web/TenantDashboardController.java
@@ -1,0 +1,40 @@
+package xyz.dgz48.tasks.webapi.dashboard.adapter.web;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+import xyz.dgz48.tasks.webapi.dashboard.adapter.web.dto.TenantDashboardSummaryResponse;
+import xyz.dgz48.tasks.webapi.dashboard.usecase.GetTenantDashboardSummaryUseCase;
+import xyz.dgz48.tasks.webapi.shared.domain.TenantContext;
+
+/**
+ * S-15 テナント運営者向けダッシュボード API(A-28)。
+ *
+ * <p>認可は {@code hasRole('TENANT_ADMIN')} のみ。Member は 403、業務 API のため SaaS Admin(APP_ADMIN)も 403
+ * (§6.2.1)。{@code X-Tenant-Id} ヘッダ必須。集計対象は {@code visibility ∈ {TENANT, STAKEHOLDERS}} のタスクのみで、
+ * {@code PRIVATE} は件数も含めて除外する(ADR-0005 §3.5 / NIST AC-4)。S-03 個人視点({@link DashboardController})とは
+ * 認可スコープと集計対象が異なる。
+ */
+@RestController
+@RequestMapping("/api/tenant/dashboard")
+@RequiredArgsConstructor
+public class TenantDashboardController {
+
+  private final GetTenantDashboardSummaryUseCase getTenantDashboardSummaryUseCase;
+
+  @GetMapping("/summary")
+  @PreAuthorize("hasRole('TENANT_ADMIN')")
+  public ResponseEntity<TenantDashboardSummaryResponse> getTenantDashboardSummary() {
+    Long tenantId = TenantContext.get();
+    if (tenantId == null) {
+      throw new ResponseStatusException(HttpStatus.FORBIDDEN, "テナントが選択されていません");
+    }
+    return ResponseEntity.ok(
+        TenantDashboardSummaryResponse.from(getTenantDashboardSummaryUseCase.execute(tenantId)));
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/dashboard/adapter/web/TenantDashboardController.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/dashboard/adapter/web/TenantDashboardController.java
@@ -1,13 +1,12 @@
 package xyz.dgz48.tasks.webapi.dashboard.adapter.web;
 
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.server.ResponseStatusException;
 import xyz.dgz48.tasks.webapi.dashboard.adapter.web.dto.TenantDashboardSummaryResponse;
 import xyz.dgz48.tasks.webapi.dashboard.usecase.GetTenantDashboardSummaryUseCase;
 import xyz.dgz48.tasks.webapi.shared.domain.TenantContext;
@@ -30,10 +29,10 @@ public class TenantDashboardController {
   @GetMapping("/summary")
   @PreAuthorize("hasRole('TENANT_ADMIN')")
   public ResponseEntity<TenantDashboardSummaryResponse> getTenantDashboardSummary() {
-    Long tenantId = TenantContext.get();
-    if (tenantId == null) {
-      throw new ResponseStatusException(HttpStatus.FORBIDDEN, "テナントが選択されていません");
-    }
+    // TenantContextFilter が業務 API 到達前に X-Tenant-Id 検証 + ACTIVE メンバーシップ確認を済ませているため、
+    // ここに到達した時点で TenantContext は必ず確立済み(未確立なら Filter が 403 を返す)。
+    Long tenantId =
+        Objects.requireNonNull(TenantContext.get(), "TenantContext must be set by filter");
     return ResponseEntity.ok(
         TenantDashboardSummaryResponse.from(getTenantDashboardSummaryUseCase.execute(tenantId)));
   }

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/dashboard/adapter/web/dto/TenantDashboardSummaryResponse.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/dashboard/adapter/web/dto/TenantDashboardSummaryResponse.java
@@ -1,0 +1,26 @@
+package xyz.dgz48.tasks.webapi.dashboard.adapter.web.dto;
+
+import java.util.Map;
+import xyz.dgz48.tasks.webapi.dashboard.domain.TenantDashboardSummary;
+
+/** OpenAPI {@code TenantDashboardSummary} に対応する運営者向け数値カード集計レスポンス(S-15)。 */
+public record TenantDashboardSummaryResponse(
+    long totalTaskCount,
+    long todayDueCount,
+    long overdueCount,
+    long completedTodayCount,
+    Map<String, Long> statusBreakdown,
+    Map<String, Long> priorityBreakdown,
+    long memberCount) {
+
+  public static TenantDashboardSummaryResponse from(TenantDashboardSummary summary) {
+    return new TenantDashboardSummaryResponse(
+        summary.totalTaskCount(),
+        summary.todayDueCount(),
+        summary.overdueCount(),
+        summary.completedTodayCount(),
+        summary.statusBreakdown(),
+        summary.priorityBreakdown(),
+        summary.memberCount());
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/dashboard/domain/TenantDashboardSummary.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/dashboard/domain/TenantDashboardSummary.java
@@ -1,0 +1,23 @@
+package xyz.dgz48.tasks.webapi.dashboard.domain;
+
+import java.util.Map;
+
+/**
+ * S-15 テナント運営者向けダッシュボードの数値カード集計(OpenAPI {@code TenantDashboardSummary})。
+ *
+ * <p>Tenant Admin がテナント運営視点で把握する集計(基本設計書 §3.3.4 / §6.2.2.2、ADR-0005 §3.5)。
+ *
+ * <ul>
+ *   <li>集計対象は自テナント内の {@code visibility ∈ {TENANT, STAKEHOLDERS}} のタスクのみ。
+ *   <li><b>{@code PRIVATE} タスクは件数も含めて集計対象外</b>(NIST AC-4 整合、Tenant Admin であっても存在を集計値経由で推定できない)。
+ *   <li>{@code memberCount} はテナントの全 ACTIVE 所属ユーザー数(Tenant Admin を含む)。
+ * </ul>
+ */
+public record TenantDashboardSummary(
+    long totalTaskCount,
+    long todayDueCount,
+    long overdueCount,
+    long completedTodayCount,
+    Map<String, Long> statusBreakdown,
+    Map<String, Long> priorityBreakdown,
+    long memberCount) {}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/dashboard/usecase/DashboardQueryPort.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/dashboard/usecase/DashboardQueryPort.java
@@ -3,6 +3,7 @@ package xyz.dgz48.tasks.webapi.dashboard.usecase;
 import java.time.LocalDate;
 import xyz.dgz48.tasks.webapi.dashboard.domain.DashboardSummary;
 import xyz.dgz48.tasks.webapi.dashboard.domain.DashboardTaskSections;
+import xyz.dgz48.tasks.webapi.dashboard.domain.TenantDashboardSummary;
 
 /**
  * ダッシュボード集計の取得ポート(クリーンアーキの out port)。
@@ -32,4 +33,16 @@ public interface DashboardQueryPort {
    * @param today サーバ側システム日付(JST)
    */
   DashboardSummary aggregateSummary(Long userId, LocalDate today);
+
+  /**
+   * S-15 テナント運営者向けの数値カード集計を取得する。
+   *
+   * <p>集計対象は自テナント内の {@code visibility ∈ {TENANT, STAKEHOLDERS}} のタスクのみ({@code PRIVATE} は除外、NIST
+   * AC-4)。テナント分離(タスク集合)は Hibernate Filter が自動付与する。{@code memberCount} は {@code user_tenants}
+   * (Filter 非適用テーブル)を {@code tenantId} 明示絞り込みで算出する。
+   *
+   * @param today サーバ側システム日付(JST)
+   * @param tenantId 現在のテナント ID(memberCount 算出用)
+   */
+  TenantDashboardSummary aggregateTenantSummary(LocalDate today, Long tenantId);
 }

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/dashboard/usecase/GetTenantDashboardSummaryUseCase.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/dashboard/usecase/GetTenantDashboardSummaryUseCase.java
@@ -1,0 +1,30 @@
+package xyz.dgz48.tasks.webapi.dashboard.usecase;
+
+import io.micrometer.observation.annotation.Observed;
+import java.time.Clock;
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import xyz.dgz48.tasks.webapi.dashboard.domain.TenantDashboardSummary;
+
+/**
+ * S-15 テナント運営者向けダッシュボードの数値カード集計ユースケース(operationId: getTenantDashboardSummary)。
+ *
+ * <p>「今日」をサーバ側システム日付(JST、ADR-0009)で確定し、{@code visibility ∈ {TENANT, STAKEHOLDERS}} のタスク集合の集計を
+ * {@link DashboardQueryPort} に委譲する({@code PRIVATE} は除外、ADR-0005 §3.5 / NIST AC-4)。
+ */
+@Service
+@RequiredArgsConstructor
+public class GetTenantDashboardSummaryUseCase {
+
+  private final DashboardQueryPort dashboardQueryPort;
+  private final Clock clock;
+
+  @Observed(name = "dashboard.tenant.summary")
+  @Transactional(readOnly = true)
+  public TenantDashboardSummary execute(Long tenantId) {
+    LocalDate today = LocalDate.now(clock);
+    return dashboardQueryPort.aggregateTenantSummary(today, tenantId);
+  }
+}

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/dashboard/adapter/web/TenantDashboardIT.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/dashboard/adapter/web/TenantDashboardIT.java
@@ -13,11 +13,13 @@ import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.context.annotation.Import;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -64,9 +66,11 @@ class TenantDashboardIT {
   private Long adminUserId;
   private Long memberUserId;
   private Long invitedUserId;
+  private Long saasAdminUserId;
 
   private TasksAuthenticationToken adminToken;
   private TasksAuthenticationToken memberToken;
+  private TasksAuthenticationToken saasAdminToken;
 
   @BeforeEach
   void setUp() {
@@ -79,13 +83,18 @@ class TenantDashboardIT {
           var admin = new UserJpaEntity("sub-tda", "tda@example.com", "運営者", "ウンエイシャ", null);
           var member = new UserJpaEntity("sub-tdm", "tdm@example.com", "一般", "イッパン", null);
           var invited = new UserJpaEntity("sub-tdi", "tdi@example.com", "招待中", "ショウタイチュウ", null);
+          // SaaS Admin: このテナントに user_tenants 行を持たない(業務 API では非メンバー扱い)
+          var saasAdmin =
+              new UserJpaEntity("sub-tds", "tds@example.com", "SaaS管理者", "サースカンリシャ", null);
           em.persist(admin);
           em.persist(member);
           em.persist(invited);
+          em.persist(saasAdmin);
           em.flush();
           adminUserId = admin.getId();
           memberUserId = member.getId();
           invitedUserId = invited.getId();
+          saasAdminUserId = saasAdmin.getId();
 
           // 監査列(created_by/updated_by)解決のため認証コンテキストを設定
           SecurityContextHolder.getContext()
@@ -146,6 +155,12 @@ class TenantDashboardIT {
         new TasksAuthenticationToken(
             new TasksPrincipal(memberUserId, "sub-tdm", "tdm@example.com", "一般", "イッパン", null),
             List.of());
+    // ROLE_APP_ADMIN を持つが、当テナントの user_tenants 行を持たない(SaaS Admin の業務 API アクセス)
+    saasAdminToken =
+        new TasksAuthenticationToken(
+            new TasksPrincipal(
+                saasAdminUserId, "sub-tds", "tds@example.com", "SaaS管理者", "サースカンリシャ", null),
+            List.of(new SimpleGrantedAuthority("ROLE_APP_ADMIN")));
   }
 
   @AfterEach
@@ -165,10 +180,11 @@ class TenantDashboardIT {
           em.createNativeQuery("DELETE FROM tenants WHERE id = ?")
               .setParameter(1, tenantId)
               .executeUpdate();
-          em.createNativeQuery("DELETE FROM users WHERE id IN (?,?,?)")
+          em.createNativeQuery("DELETE FROM users WHERE id IN (?,?,?,?)")
               .setParameter(1, adminUserId)
               .setParameter(2, memberUserId)
               .setParameter(3, invitedUserId)
+              .setParameter(4, saasAdminUserId)
               .executeUpdate();
           return null;
         });
@@ -217,6 +233,114 @@ class TenantDashboardIT {
         .perform(
             get("/api/tenant/dashboard/summary").header("X-Tenant-Id", String.valueOf(tenantId)))
         .andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  void saasAdmin_isForbidden() throws Exception {
+    // 業務 API のため APP_ADMIN(当テナント非メンバー)は 403。Javadoc「SaaS Admin も 403」の回帰検知。
+    mockMvc
+        .perform(
+            get("/api/tenant/dashboard/summary")
+                .header("X-Tenant-Id", String.valueOf(tenantId))
+                .with(authentication(saasAdminToken)))
+        .andExpect(status().isForbidden());
+  }
+
+  /** テナント分離(ADR-0010)。Hibernate Filter が無効化された場合に他テナントのタスク混入を検知する。 */
+  @Nested
+  class CrossTenantIsolation {
+
+    private Long tenantBId;
+    private Long userBId;
+    private Long taskBId;
+
+    @BeforeEach
+    void setUpTenantB() {
+      txTemplate.execute(
+          ignored -> {
+            var userB = new UserJpaEntity("sub-tdb", "tdb@example.com", "別テナント", "ベツテナント", null);
+            em.persist(userB);
+            em.flush();
+            userBId = userB.getId();
+
+            SecurityContextHolder.getContext()
+                .setAuthentication(
+                    new TasksAuthenticationToken(
+                        new TasksPrincipal(
+                            userBId, "sub-tdb", "tdb@example.com", "別テナント", "ベツテナント", null),
+                        List.of()));
+
+            var tenantB = new TenantJpaEntity("TD-B", "別運営テナント");
+            em.persist(tenantB);
+            em.flush();
+            tenantBId = tenantB.getId();
+
+            em.createNativeQuery(
+                    "INSERT INTO user_tenants (user_id, tenant_id, role, status, joined_at)"
+                        + " VALUES (?,?,?,?,?)")
+                .setParameter(1, userBId)
+                .setParameter(2, tenantBId)
+                .setParameter(3, "TENANT_ADMIN")
+                .setParameter(4, "ACTIVE")
+                .setParameter(5, LocalDateTime.of(2026, 1, 1, 0, 0))
+                .executeUpdate();
+
+            // テナント B の当日期限 TENANT タスク。テナント A の集計に混入してはならない。
+            var taskB =
+                new TaskJpaEntity(
+                    tenantBId,
+                    userBId,
+                    "別テナントの当日タスク",
+                    null,
+                    TaskStatus.NOT_STARTED,
+                    Priority.MEDIUM,
+                    Visibility.TENANT,
+                    null,
+                    TODAY);
+            em.persist(taskB);
+            em.flush();
+            taskBId = taskB.getId();
+            return null;
+          });
+      SecurityContextHolder.clearContext();
+    }
+
+    @AfterEach
+    void tearDownTenantB() {
+      SecurityContextHolder.clearContext();
+      if (tenantBId == null) {
+        return;
+      }
+      txTemplate.execute(
+          ignored -> {
+            em.createNativeQuery("DELETE FROM tasks WHERE id = ?")
+                .setParameter(1, taskBId)
+                .executeUpdate();
+            em.createNativeQuery("DELETE FROM user_tenants WHERE tenant_id = ?")
+                .setParameter(1, tenantBId)
+                .executeUpdate();
+            em.createNativeQuery("DELETE FROM tenants WHERE id = ?")
+                .setParameter(1, tenantBId)
+                .executeUpdate();
+            em.createNativeQuery("DELETE FROM users WHERE id = ?")
+                .setParameter(1, userBId)
+                .executeUpdate();
+            return null;
+          });
+    }
+
+    @Test
+    void tenantA_summary_excludesTenantBTasks() throws Exception {
+      // テナント A の Admin で集計しても、テナント B のタスク(別テナント当日タスク)は混入しない。
+      mockMvc
+          .perform(
+              get("/api/tenant/dashboard/summary")
+                  .header("X-Tenant-Id", String.valueOf(tenantId))
+                  .with(authentication(adminToken)))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.totalTaskCount").value(4))
+          .andExpect(jsonPath("$.todayDueCount").value(1));
+    }
   }
 
   // --- helpers ---

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/dashboard/adapter/web/TenantDashboardIT.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/dashboard/adapter/web/TenantDashboardIT.java
@@ -1,0 +1,257 @@
+package xyz.dgz48.tasks.webapi.dashboard.adapter.web;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import jakarta.persistence.EntityManager;
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.support.TransactionTemplate;
+import xyz.dgz48.tasks.webapi.FixedClockConfiguration;
+import xyz.dgz48.tasks.webapi.MockJwtDecoderConfiguration;
+import xyz.dgz48.tasks.webapi.TestcontainersConfiguration;
+import xyz.dgz48.tasks.webapi.security.adapter.web.TasksAuthenticationToken;
+import xyz.dgz48.tasks.webapi.security.domain.TasksPrincipal;
+import xyz.dgz48.tasks.webapi.shared.infra.AppZones;
+import xyz.dgz48.tasks.webapi.task.adapter.persistence.TaskJpaEntity;
+import xyz.dgz48.tasks.webapi.task.domain.Priority;
+import xyz.dgz48.tasks.webapi.task.domain.TaskStatus;
+import xyz.dgz48.tasks.webapi.task.domain.Visibility;
+import xyz.dgz48.tasks.webapi.tenant.adapter.persistence.TenantJpaEntity;
+import xyz.dgz48.tasks.webapi.user.adapter.persistence.UserJpaEntity;
+
+/**
+ * S-15 テナント運営者向けダッシュボード API(A-28、GET /api/tenant/dashboard/summary)の統合テスト。
+ *
+ * <p>集計対象が {@code visibility ∈ {TENANT, STAKEHOLDERS}} に限定され <b>{@code PRIVATE}
+ * が件数も含めて漏れない</b>こと(ADR-0005 §3.5 / NIST AC-4)、{@code memberCount} が ACTIVE 所属のみ数えること、認可(Tenant
+ * Admin のみ・Member は 403)、テナント分離(ADR-0010)を検証する。固定 Clock(JST 2026-01-15)で当日判定を決定論的にする。
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@Import({
+  TestcontainersConfiguration.class,
+  MockJwtDecoderConfiguration.class,
+  FixedClockConfiguration.class
+})
+class TenantDashboardIT {
+
+  @Autowired MockMvc mockMvc;
+  @Autowired EntityManager em;
+  @Autowired TransactionTemplate txTemplate;
+
+  /** GetTenantDashboardSummaryUseCase が注入する Clock を固定し、当日(JST 2026-01-15)を決定論的にする。 */
+  @MockitoBean Clock clock;
+
+  private static final LocalDate TODAY = LocalDate.of(2026, 1, 15);
+
+  private Long tenantId;
+  private Long adminUserId;
+  private Long memberUserId;
+  private Long invitedUserId;
+
+  private TasksAuthenticationToken adminToken;
+  private TasksAuthenticationToken memberToken;
+
+  @BeforeEach
+  void setUp() {
+    when(clock.getZone()).thenReturn(AppZones.JST);
+    when(clock.instant())
+        .thenReturn(FixedClockConfiguration.FIXED_NOW.atZone(AppZones.JST).toInstant());
+
+    txTemplate.execute(
+        ignored -> {
+          var admin = new UserJpaEntity("sub-tda", "tda@example.com", "運営者", "ウンエイシャ", null);
+          var member = new UserJpaEntity("sub-tdm", "tdm@example.com", "一般", "イッパン", null);
+          var invited = new UserJpaEntity("sub-tdi", "tdi@example.com", "招待中", "ショウタイチュウ", null);
+          em.persist(admin);
+          em.persist(member);
+          em.persist(invited);
+          em.flush();
+          adminUserId = admin.getId();
+          memberUserId = member.getId();
+          invitedUserId = invited.getId();
+
+          // 監査列(created_by/updated_by)解決のため認証コンテキストを設定
+          SecurityContextHolder.getContext()
+              .setAuthentication(
+                  new TasksAuthenticationToken(
+                      new TasksPrincipal(
+                          adminUserId, "sub-tda", "tda@example.com", "運営者", "ウンエイシャ", null),
+                      List.of()));
+
+          var tenant = new TenantJpaEntity("TD-1", "運営ダッシュボードテナント");
+          em.persist(tenant);
+          em.flush();
+          tenantId = tenant.getId();
+
+          insertMembership(adminUserId, "TENANT_ADMIN", "ACTIVE");
+          insertMembership(memberUserId, "MEMBER", "ACTIVE");
+          // INVITED は memberCount に数えない
+          insertMembership(invitedUserId, "MEMBER", "INVITED");
+
+          // TENANT / STAKEHOLDERS は集計対象、PRIVATE は除外
+          persistTask(
+              "TA", TaskStatus.NOT_STARTED, Priority.MEDIUM, Visibility.TENANT, TODAY, null);
+          persistTask(
+              "TB",
+              TaskStatus.IN_PROGRESS,
+              Priority.HIGH,
+              Visibility.TENANT,
+              TODAY.minusDays(2),
+              null);
+          persistTask(
+              "TC",
+              TaskStatus.NOT_STARTED,
+              Priority.LOW,
+              Visibility.STAKEHOLDERS,
+              TODAY.plusDays(5),
+              null);
+          Long td =
+              persistTask(
+                  "TD",
+                  TaskStatus.DONE,
+                  Priority.MEDIUM,
+                  Visibility.TENANT,
+                  TODAY.minusDays(1),
+                  null);
+          setCompletedAt(td, TODAY.atTime(10, 0));
+          // TE: PRIVATE・当日期限・HIGH。漏れていれば todayDueCount / totalTaskCount / HIGH / NOT_STARTED が増える。
+          persistTask("TE", TaskStatus.NOT_STARTED, Priority.HIGH, Visibility.PRIVATE, TODAY, null);
+
+          return null;
+        });
+
+    SecurityContextHolder.clearContext();
+    adminToken =
+        new TasksAuthenticationToken(
+            new TasksPrincipal(adminUserId, "sub-tda", "tda@example.com", "運営者", "ウンエイシャ", null),
+            List.of());
+    memberToken =
+        new TasksAuthenticationToken(
+            new TasksPrincipal(memberUserId, "sub-tdm", "tdm@example.com", "一般", "イッパン", null),
+            List.of());
+  }
+
+  @AfterEach
+  void tearDown() {
+    SecurityContextHolder.clearContext();
+    if (tenantId == null) {
+      return;
+    }
+    txTemplate.execute(
+        ignored -> {
+          em.createNativeQuery("DELETE FROM tasks WHERE tenant_id = ?")
+              .setParameter(1, tenantId)
+              .executeUpdate();
+          em.createNativeQuery("DELETE FROM user_tenants WHERE tenant_id = ?")
+              .setParameter(1, tenantId)
+              .executeUpdate();
+          em.createNativeQuery("DELETE FROM tenants WHERE id = ?")
+              .setParameter(1, tenantId)
+              .executeUpdate();
+          em.createNativeQuery("DELETE FROM users WHERE id IN (?,?,?)")
+              .setParameter(1, adminUserId)
+              .setParameter(2, memberUserId)
+              .setParameter(3, invitedUserId)
+              .executeUpdate();
+          return null;
+        });
+  }
+
+  @Test
+  void aggregatesTenantAndStakeholdersTasks_excludingPrivate() throws Exception {
+    mockMvc
+        .perform(
+            get("/api/tenant/dashboard/summary")
+                .header("X-Tenant-Id", String.valueOf(tenantId))
+                .with(authentication(adminToken)))
+        .andExpect(status().isOk())
+        // 集計対象は TA/TB/TC/TD の 4 件(TE=PRIVATE は除外)
+        .andExpect(jsonPath("$.totalTaskCount").value(4))
+        // 当日期限: TA のみ(TE は PRIVATE で除外)
+        .andExpect(jsonPath("$.todayDueCount").value(1))
+        // 期限切れ未完了: TB のみ
+        .andExpect(jsonPath("$.overdueCount").value(1))
+        // 本日完了: TD のみ
+        .andExpect(jsonPath("$.completedTodayCount").value(1))
+        .andExpect(jsonPath("$.statusBreakdown.NOT_STARTED").value(2))
+        .andExpect(jsonPath("$.statusBreakdown.IN_PROGRESS").value(1))
+        .andExpect(jsonPath("$.statusBreakdown.DONE").value(1))
+        .andExpect(jsonPath("$.statusBreakdown.ON_HOLD").value(0))
+        .andExpect(jsonPath("$.priorityBreakdown.HIGH").value(1))
+        .andExpect(jsonPath("$.priorityBreakdown.MEDIUM").value(2))
+        .andExpect(jsonPath("$.priorityBreakdown.LOW").value(1))
+        // ACTIVE 所属のみ(admin + member の 2、INVITED は除外)
+        .andExpect(jsonPath("$.memberCount").value(2));
+  }
+
+  @Test
+  void member_isForbidden() throws Exception {
+    mockMvc
+        .perform(
+            get("/api/tenant/dashboard/summary")
+                .header("X-Tenant-Id", String.valueOf(tenantId))
+                .with(authentication(memberToken)))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  void unauthenticated_returns401() throws Exception {
+    mockMvc
+        .perform(
+            get("/api/tenant/dashboard/summary").header("X-Tenant-Id", String.valueOf(tenantId)))
+        .andExpect(status().isUnauthorized());
+  }
+
+  // --- helpers ---
+
+  private void insertMembership(Long userId, String role, String memberStatus) {
+    em.createNativeQuery(
+            "INSERT INTO user_tenants (user_id, tenant_id, role, status, joined_at)"
+                + " VALUES (?,?,?,?,?)")
+        .setParameter(1, userId)
+        .setParameter(2, tenantId)
+        .setParameter(3, role)
+        .setParameter(4, memberStatus)
+        .setParameter(5, LocalDateTime.of(2026, 1, 1, 0, 0))
+        .executeUpdate();
+  }
+
+  private void setCompletedAt(Long taskId, LocalDateTime completedAt) {
+    em.createNativeQuery("UPDATE tasks SET completed_at = ? WHERE id = ?")
+        .setParameter(1, completedAt)
+        .setParameter(2, taskId)
+        .executeUpdate();
+  }
+
+  private Long persistTask(
+      String title,
+      TaskStatus status,
+      Priority priority,
+      Visibility visibility,
+      LocalDate dueDate,
+      @org.jspecify.annotations.Nullable Long assigneeId) {
+    var task =
+        new TaskJpaEntity(
+            tenantId, adminUserId, title, null, status, priority, visibility, assigneeId, dueDate);
+    em.persist(task);
+    em.flush();
+    return task.getId();
+  }
+}

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/dashboard/usecase/GetTenantDashboardSummaryUseCaseTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/dashboard/usecase/GetTenantDashboardSummaryUseCaseTest.java
@@ -1,0 +1,33 @@
+package xyz.dgz48.tasks.webapi.dashboard.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import xyz.dgz48.tasks.webapi.dashboard.domain.TenantDashboardSummary;
+
+class GetTenantDashboardSummaryUseCaseTest {
+
+  private static final ZoneId JST = ZoneId.of("Asia/Tokyo");
+
+  private final Clock clock =
+      Clock.fixed(ZonedDateTime.of(2026, 1, 15, 19, 0, 0, 0, JST).toInstant(), JST);
+
+  @Test
+  void execute_resolvesTodayInJstAndDelegatesToPortWithTenantId() {
+    DashboardQueryPort port = mock(DashboardQueryPort.class);
+    TenantDashboardSummary expected = new TenantDashboardSummary(0, 0, 0, 0, Map.of(), Map.of(), 0);
+    when(port.aggregateTenantSummary(eq(LocalDate.of(2026, 1, 15)), eq(42L))).thenReturn(expected);
+
+    GetTenantDashboardSummaryUseCase useCase = new GetTenantDashboardSummaryUseCase(port, clock);
+
+    assertThat(useCase.execute(42L)).isSameAs(expected);
+  }
+}

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/SecurityConfigTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/SecurityConfigTest.java
@@ -37,6 +37,7 @@ import xyz.dgz48.tasks.webapi.audit.usecase.AuditLogPort;
 import xyz.dgz48.tasks.webapi.audit.usecase.AuthorizationDeniedAuditService;
 import xyz.dgz48.tasks.webapi.dashboard.usecase.GetDashboardSummaryUseCase;
 import xyz.dgz48.tasks.webapi.dashboard.usecase.GetDashboardTasksUseCase;
+import xyz.dgz48.tasks.webapi.dashboard.usecase.GetTenantDashboardSummaryUseCase;
 import xyz.dgz48.tasks.webapi.security.adapter.persistence.AppAdminUserRepository;
 import xyz.dgz48.tasks.webapi.security.usecase.GetMeUseCase;
 import xyz.dgz48.tasks.webapi.security.usecase.LogoutUseCase;
@@ -108,6 +109,7 @@ class SecurityConfigTest {
   @MockitoBean ListTenantUsersUseCase listTenantUsersUseCase;
   @MockitoBean GetDashboardTasksUseCase getDashboardTasksUseCase;
   @MockitoBean GetDashboardSummaryUseCase getDashboardSummaryUseCase;
+  @MockitoBean GetTenantDashboardSummaryUseCase getTenantDashboardSummaryUseCase;
   @MockitoBean CreateTenantUseCase createTenantUseCase;
 
   @Autowired MockMvc mockMvc;

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/TenantContextFilterTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/TenantContextFilterTest.java
@@ -25,6 +25,7 @@ import xyz.dgz48.tasks.webapi.audit.usecase.AuditLogPort;
 import xyz.dgz48.tasks.webapi.audit.usecase.AuthorizationDeniedAuditService;
 import xyz.dgz48.tasks.webapi.dashboard.usecase.GetDashboardSummaryUseCase;
 import xyz.dgz48.tasks.webapi.dashboard.usecase.GetDashboardTasksUseCase;
+import xyz.dgz48.tasks.webapi.dashboard.usecase.GetTenantDashboardSummaryUseCase;
 import xyz.dgz48.tasks.webapi.security.adapter.persistence.AppAdminUserRepository;
 import xyz.dgz48.tasks.webapi.security.usecase.GetMeUseCase;
 import xyz.dgz48.tasks.webapi.security.usecase.LogoutUseCase;
@@ -123,6 +124,7 @@ class TenantContextFilterTest {
   @MockitoBean ListTenantUsersUseCase listTenantUsersUseCase;
   @MockitoBean GetDashboardTasksUseCase getDashboardTasksUseCase;
   @MockitoBean GetDashboardSummaryUseCase getDashboardSummaryUseCase;
+  @MockitoBean GetTenantDashboardSummaryUseCase getTenantDashboardSummaryUseCase;
   @MockitoBean CreateTenantUseCase createTenantUseCase;
 
   @Autowired MockMvc mockMvc;


### PR DESCRIPTION
## 概要

A-28 テナント運営者向けダッシュボード集計 API (`GET /api/tenant/dashboard/summary`) と S-15 画面を実装する。Tenant Admin がテナント運営視点で業務量を把握するための集計。トラッカー #780 の 2 件目。

Closes #776

## 実装内容

### バックエンド (A-28)
- **`GetTenantDashboardSummaryUseCase`** / **`TenantDashboardController`** — `hasRole('TENANT_ADMIN')` のみ許可(Member は 403、業務 API のため SaaS Admin も 403)。`X-Tenant-Id` 必須(未選択は 403)。
- **集計対象は `visibility ∈ {TENANT, STAKEHOLDERS}` のみ**。`PRIVATE` は件数も含めて除外し、Tenant Admin であっても集計値経由で PRIVATE の存在を推定できない(ADR-0005 §3.5 / NIST AC-4)。
- タスク集合のテナント分離は Hibernate Filter "tenantFilter"(ADR-0010、`DashboardTaskView` 経由)が自動付与。`memberCount` は `TenantFilteredEntity` 非適用テーブルの `user_tenants` を `tenant_id` 明示絞り込みの native count で算出し、`status = ACTIVE` のみ数える(既存 `countTasksByTenantId` と同じ「モジュール境界越え native」方針)。
- 集計指標(`totalTaskCount` / `todayDueCount` / `overdueCount` / `completedTodayCount` / `statusBreakdown` / `priorityBreakdown`)は S-03 個人集計と同一の adapter 内ロジックを踏襲。「今日」は JST(ADR-0009)。

### フロントエンド (S-15)
- `tenant-dashboard.html` / `tenant-dashboard.js` を追加。数値カード(総タスク数・当日期限・期限切れ・本日完了・メンバー数)とステータス別 / 優先度別ブレークダウン表を描画。
- サイドバー「運営者ダッシュボード」導線(`tasks.html` の `admin-only` グループ)を当ページへ配線。Tenant Admin 以外は API が 403 を返すため、画面側でも管理者限定メッセージを表示。

## テスト
- `TenantDashboardIT`(Testcontainers): TENANT/STAKEHOLDERS 集計・**PRIVATE 除外の境界**(当日期限 PRIVATE が件数に漏れない)・`memberCount` が ACTIVE のみ・Member→403・未認証→401。
- `GetTenantDashboardSummaryUseCaseTest`: JST 当日解決 + tenantId をポートへ委譲。
- `SecurityConfigTest` / `TenantContextFilterTest` に新 usecase モックを追加。

`./gradlew :webapi:check`(spotless / JaCoCo 0.80 / 全 IT)green、`web/` の biome・html-validate・tsc も green。OpenAPI 既定の `TenantDashboardSummary` スキーマと一致。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
