### PR TITLE
feat(audit): 監査ログ参照 GET /api/audit-logs (Tenant Admin) (Closes #777)

### DIFF
--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/adapter/persistence/AuditLogJpaRepository.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/adapter/persistence/AuditLogJpaRepository.java
@@ -1,7 +1,13 @@
 package xyz.dgz48.tasks.webapi.audit.adapter.persistence;
 
+import java.time.LocalDateTime;
 import java.util.List;
+import org.jspecify.annotations.Nullable;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 interface AuditLogJpaRepository extends JpaRepository<AuditLogJpaEntity, Long> {
 
@@ -10,4 +16,24 @@ interface AuditLogJpaRepository extends JpaRepository<AuditLogJpaEntity, Long> {
 
   /** プラットフォーム連鎖(chain_key = 0、tenant_id IS NULL)の生存行を chain_seq 昇順で返す(B-05 検証用)。 */
   List<AuditLogJpaEntity> findByTenantIdIsNullOrderByChainSeqAsc();
+
+  /**
+   * 監査ログ参照(A-22)。{@code tenant_id = :tenantId} を明示絞り込みし({@code TenantFilteredEntity} 非適用)、
+   * created_at 降順・id 降順でページングする。{@code from} / {@code to} / {@code action} は null のとき絞り込みなし。
+   */
+  @Query(
+      """
+      SELECT a FROM AuditLogJpaEntity a
+      WHERE a.tenantId = :tenantId
+        AND (:from IS NULL OR a.createdAt >= :from)
+        AND (:to IS NULL OR a.createdAt < :to)
+        AND (:action IS NULL OR a.action = :action)
+      ORDER BY a.createdAt DESC, a.id DESC
+      """)
+  Page<AuditLogJpaEntity> search(
+      @Param("tenantId") long tenantId,
+      @Param("from") @Nullable LocalDateTime from,
+      @Param("to") @Nullable LocalDateTime to,
+      @Param("action") @Nullable String action,
+      Pageable pageable);
 }

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/adapter/persistence/AuditLogQueryAdapter.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/adapter/persistence/AuditLogQueryAdapter.java
@@ -1,0 +1,55 @@
+package xyz.dgz48.tasks.webapi.audit.adapter.persistence;
+
+import io.micrometer.observation.annotation.Observed;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Component;
+import xyz.dgz48.tasks.webapi.audit.domain.AuditLogEntry;
+import xyz.dgz48.tasks.webapi.audit.usecase.AuditLogPage;
+import xyz.dgz48.tasks.webapi.audit.usecase.AuditLogQueryPort;
+import xyz.dgz48.tasks.webapi.audit.usecase.AuditLogSearchCriteria;
+
+/**
+ * {@link AuditLogQueryPort} の JPA 実装。
+ *
+ * <p>{@code audit_logs} は {@code TenantFilteredEntity} 非適用のため、{@code tenant_id} をクエリで明示絞り込みする
+ * (ADR-0010 §6.1 / ADR-0020 §3.4)。ソート(created_at 降順)は JPQL の {@code ORDER BY} で固定するため {@link
+ * PageRequest} には sort を渡さない。
+ */
+@Observed(name = "audit.repository")
+@Component
+@RequiredArgsConstructor
+class AuditLogQueryAdapter implements AuditLogQueryPort {
+
+  private final AuditLogJpaRepository repository;
+
+  @Override
+  public AuditLogPage search(AuditLogSearchCriteria criteria) {
+    Page<AuditLogJpaEntity> page =
+        repository.search(
+            criteria.tenantId(),
+            criteria.from(),
+            criteria.to(),
+            criteria.action(),
+            PageRequest.of(criteria.page(), criteria.size()));
+
+    List<AuditLogEntry> content =
+        page.getContent().stream().map(AuditLogQueryAdapter::toEntry).toList();
+    return new AuditLogPage(content, page.getTotalElements());
+  }
+
+  private static AuditLogEntry toEntry(AuditLogJpaEntity e) {
+    String detail = e.getDetail();
+    return new AuditLogEntry(
+        e.getId(),
+        e.getUserId(),
+        e.getAction(),
+        e.getEntityType(),
+        e.getEntityId(),
+        detail == null || detail.isBlank() ? "{}" : detail,
+        e.getIpAddress(),
+        e.getCreatedAt());
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/adapter/web/AuditLogController.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/adapter/web/AuditLogController.java
@@ -1,0 +1,73 @@
+package xyz.dgz48.tasks.webapi.audit.adapter.web;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Pattern;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.Nullable;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import tools.jackson.databind.json.JsonMapper;
+import xyz.dgz48.tasks.webapi.audit.adapter.web.dto.AuditLogPageResponse;
+import xyz.dgz48.tasks.webapi.audit.adapter.web.dto.AuditLogResponse;
+import xyz.dgz48.tasks.webapi.audit.usecase.AuditLogPage;
+import xyz.dgz48.tasks.webapi.audit.usecase.AuditLogSearchCriteria;
+import xyz.dgz48.tasks.webapi.audit.usecase.ListAuditLogsUseCase;
+import xyz.dgz48.tasks.webapi.shared.domain.TenantContext;
+import xyz.dgz48.tasks.webapi.shared.infra.AppZones;
+
+/**
+ * 監査ログ参照 API(A-22、operationId: listAuditLogs)。
+ *
+ * <p>認可は {@code hasRole('TENANT_ADMIN')} のみ(Member / SaaS Admin は 403)。{@code X-Tenant-Id} 必須。
+ * 参照スコープは {@code audit_logs.tenant_id = 現在のテナント}(SaaS Admin の対象テナント操作も含む。横断操作 {@code
+ * tenant_id=NULL} は対象外。ADR-0020 §3.4)。画面なし(API のみ)。
+ */
+@RestController
+@RequestMapping("/api/audit-logs")
+@RequiredArgsConstructor
+public class AuditLogController {
+
+  private final ListAuditLogsUseCase listAuditLogsUseCase;
+  private final JsonMapper jsonMapper;
+
+  @GetMapping
+  @PreAuthorize("hasRole('TENANT_ADMIN')")
+  public ResponseEntity<AuditLogPageResponse> listAuditLogs(
+      @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+          @Nullable OffsetDateTime from,
+      @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+          @Nullable OffsetDateTime to,
+      @RequestParam(required = false) @Pattern(regexp = "^[A-Z][A-Z0-9_]*$")
+          @Nullable String action,
+      @RequestParam(defaultValue = "0") @Min(0) int page,
+      @RequestParam(defaultValue = "50") @Min(1) @Max(100) int size) {
+    // TenantContextFilter が業務 API 到達前に X-Tenant-Id + ACTIVE メンバーシップを検証済み(未確立なら 403)。
+    Long tenantId =
+        Objects.requireNonNull(TenantContext.get(), "TenantContext must be set by filter");
+
+    AuditLogSearchCriteria criteria =
+        new AuditLogSearchCriteria(tenantId, toJst(from), toJst(to), action, page, size);
+    AuditLogPage result = listAuditLogsUseCase.execute(criteria);
+
+    List<AuditLogResponse> content =
+        result.content().stream().map(entry -> AuditLogResponse.from(entry, jsonMapper)).toList();
+    return ResponseEntity.ok(new AuditLogPageResponse(content, result.totalElements()));
+  }
+
+  /**
+   * クエリの OffsetDateTime を、created_at(JST の LocalDateTime、ADR-0009)と比較するため同一インスタントの JST 壁時計へ変換する。
+   */
+  private static @Nullable LocalDateTime toJst(@Nullable OffsetDateTime value) {
+    return value == null ? null : value.atZoneSameInstant(AppZones.JST).toLocalDateTime();
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/adapter/web/dto/AuditLogPageResponse.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/adapter/web/dto/AuditLogPageResponse.java
@@ -1,0 +1,11 @@
+package xyz.dgz48.tasks.webapi.audit.adapter.web.dto;
+
+import java.util.List;
+
+/**
+ * OpenAPI {@code listAuditLogs} の 200 レスポンス({@code {content, totalElements}})。
+ *
+ * @param content created_at 降順の監査ログ列
+ * @param totalElements 絞り込み条件に一致する総件数
+ */
+public record AuditLogPageResponse(List<AuditLogResponse> content, long totalElements) {}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/adapter/web/dto/AuditLogResponse.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/adapter/web/dto/AuditLogResponse.java
@@ -1,0 +1,46 @@
+package xyz.dgz48.tasks.webapi.audit.adapter.web.dto;
+
+import java.time.OffsetDateTime;
+import java.util.Map;
+import org.jspecify.annotations.Nullable;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.json.JsonMapper;
+import xyz.dgz48.tasks.webapi.audit.domain.AuditLogEntry;
+import xyz.dgz48.tasks.webapi.shared.infra.AppZones;
+
+/**
+ * OpenAPI {@code AuditLog} に対応する監査ログ参照レスポンス(A-22)。
+ *
+ * <p>{@code detail} は DB の JSON 文字列を object として埋め込む。{@code createdAt} は JST オフセット付き(ADR-0009)。
+ */
+public record AuditLogResponse(
+    Long id,
+    @Nullable Long userId,
+    String action,
+    @Nullable String entityType,
+    @Nullable Long entityId,
+    Object detail,
+    @Nullable String ipAddress,
+    OffsetDateTime createdAt) {
+
+  public static AuditLogResponse from(AuditLogEntry entry, JsonMapper jsonMapper) {
+    return new AuditLogResponse(
+        entry.id(),
+        entry.userId(),
+        entry.action(),
+        entry.entityType(),
+        entry.entityId(),
+        parseDetail(entry.detailJson(), jsonMapper),
+        entry.ipAddress(),
+        entry.createdAt().atZone(AppZones.JST).toOffsetDateTime());
+  }
+
+  /** 保存済み JSON 文字列を object へ復元する。空・破損時は空 object を返す。 */
+  private static Object parseDetail(String detailJson, JsonMapper jsonMapper) {
+    try {
+      return jsonMapper.readValue(detailJson, Map.class);
+    } catch (JacksonException e) {
+      return Map.of();
+    }
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/adapter/web/dto/package-info.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/adapter/web/dto/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package xyz.dgz48.tasks.webapi.audit.adapter.web.dto;
+
+import org.jspecify.annotations.NullMarked;

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/adapter/web/package-info.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/adapter/web/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package xyz.dgz48.tasks.webapi.audit.adapter.web;
+
+import org.jspecify.annotations.NullMarked;

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/domain/AuditLogEntry.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/domain/AuditLogEntry.java
@@ -1,0 +1,24 @@
+package xyz.dgz48.tasks.webapi.audit.domain;
+
+import java.time.LocalDateTime;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * 監査ログ参照(A-22、{@code GET /api/audit-logs})の 1 レコード。
+ *
+ * <p>{@code audit_logs} テーブルのうち API で公開する列のみを保持する({@code tenant_id} / {@code actor_sub} / {@code
+ * hash_chain} 等の内部列は除外、OpenAPI {@code AuditLog} 参照)。{@code detailJson} は DB に保存された JSON
+ * 文字列をそのまま保持し、object への変換は web 層で行う(domain は Jackson 非依存)。
+ *
+ * @param userId 操作ユーザー({@code users.id})。認証失敗 / システム起因イベントは {@code null}。
+ * @param detailJson 監査詳細の JSON 文字列(空は {@code "{}"})。
+ */
+public record AuditLogEntry(
+    Long id,
+    @Nullable Long userId,
+    String action,
+    @Nullable String entityType,
+    @Nullable Long entityId,
+    String detailJson,
+    @Nullable String ipAddress,
+    LocalDateTime createdAt) {}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/usecase/AuditLogPage.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/usecase/AuditLogPage.java
@@ -1,0 +1,12 @@
+package xyz.dgz48.tasks.webapi.audit.usecase;
+
+import java.util.List;
+import xyz.dgz48.tasks.webapi.audit.domain.AuditLogEntry;
+
+/**
+ * 監査ログ参照(A-22)の 1 ページ分の結果。
+ *
+ * @param content created_at 降順のレコード列
+ * @param totalElements 絞り込み条件に一致する総件数
+ */
+public record AuditLogPage(List<AuditLogEntry> content, long totalElements) {}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/usecase/AuditLogQueryPort.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/usecase/AuditLogQueryPort.java
@@ -1,0 +1,13 @@
+package xyz.dgz48.tasks.webapi.audit.usecase;
+
+/**
+ * 監査ログ参照(A-22)の取得ポート(クリーンアーキの out port)。
+ *
+ * <p>実装は adapter.persistence。{@code audit_logs} は {@code TenantFilteredEntity} 非適用(tenant_id が
+ * nullable、 ADR-0010 §6.1)のため、テナント分離は実装側で {@code tenant_id = :tenantId} を明示絞り込みする。
+ */
+public interface AuditLogQueryPort {
+
+  /** 検索条件に一致する監査ログを created_at 降順・ページングで取得する。 */
+  AuditLogPage search(AuditLogSearchCriteria criteria);
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/usecase/AuditLogSearchCriteria.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/usecase/AuditLogSearchCriteria.java
@@ -1,0 +1,22 @@
+package xyz.dgz48.tasks.webapi.audit.usecase;
+
+import java.time.LocalDateTime;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * 監査ログ参照(A-22)の検索条件。
+ *
+ * <p>{@code tenantId} は現在のテナント({@code X-Tenant-Id})。参照スコープは {@code audit_logs.tenant_id = tenantId}
+ * に一致するレコード(ADR-0020 §3.4)。{@code from} / {@code to} は {@code created_at} の半開区間 {@code [from,
+ * to)}、{@code action} は完全一致。いずれも {@code null} なら絞り込みなし。
+ *
+ * @param from 開始日時(JST、{@code created_at >= from})
+ * @param to 終了日時(JST、{@code created_at < to})
+ */
+public record AuditLogSearchCriteria(
+    Long tenantId,
+    @Nullable LocalDateTime from,
+    @Nullable LocalDateTime to,
+    @Nullable String action,
+    int page,
+    int size) {}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/usecase/ListAuditLogsUseCase.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/audit/usecase/ListAuditLogsUseCase.java
@@ -1,0 +1,25 @@
+package xyz.dgz48.tasks.webapi.audit.usecase;
+
+import io.micrometer.observation.annotation.Observed;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 監査ログ参照(A-22、operationId: listAuditLogs)のユースケース。
+ *
+ * <p>Tenant Admin が自テナント({@code X-Tenant-Id})の監査ログを参照する。参照スコープ・テナント分離は {@link AuditLogQueryPort}
+ * 実装が担う(ADR-0020 §3.4)。
+ */
+@Service
+@RequiredArgsConstructor
+public class ListAuditLogsUseCase {
+
+  private final AuditLogQueryPort auditLogQueryPort;
+
+  @Observed(name = "audit.list")
+  @Transactional(readOnly = true)
+  public AuditLogPage execute(AuditLogSearchCriteria criteria) {
+    return auditLogQueryPort.search(criteria);
+  }
+}

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/audit/adapter/web/AuditLogIT.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/audit/adapter/web/AuditLogIT.java
@@ -1,0 +1,273 @@
+package xyz.dgz48.tasks.webapi.audit.adapter.web;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import jakarta.persistence.EntityManager;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.support.TransactionTemplate;
+import xyz.dgz48.tasks.webapi.MockJwtDecoderConfiguration;
+import xyz.dgz48.tasks.webapi.TestcontainersConfiguration;
+import xyz.dgz48.tasks.webapi.security.adapter.web.TasksAuthenticationToken;
+import xyz.dgz48.tasks.webapi.security.domain.TasksPrincipal;
+import xyz.dgz48.tasks.webapi.tenant.adapter.persistence.TenantJpaEntity;
+import xyz.dgz48.tasks.webapi.user.adapter.persistence.UserJpaEntity;
+
+/**
+ * 監査ログ参照 API(A-22、GET /api/audit-logs)の統合テスト。
+ *
+ * <p>自テナントスコープ(ADR-0020 §3.4: 他テナント行・横断 {@code tenant_id=NULL} 行を返さない)、created_at 降順、
+ * from/to/action 絞り込み、認可(Tenant Admin のみ・Member / SaaS Admin は 403)を検証する。
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@Import({TestcontainersConfiguration.class, MockJwtDecoderConfiguration.class})
+class AuditLogIT {
+
+  private static final String DUMMY_HASH = "a".repeat(64);
+
+  @Autowired MockMvc mockMvc;
+  @Autowired EntityManager em;
+  @Autowired TransactionTemplate txTemplate;
+
+  private Long tenantAId;
+  private Long tenantBId;
+  private Long adminUserId;
+  private Long memberUserId;
+  private Long saasAdminUserId;
+
+  private TasksAuthenticationToken adminToken;
+  private TasksAuthenticationToken memberToken;
+  private TasksAuthenticationToken saasAdminToken;
+
+  @BeforeEach
+  void setUp() {
+    txTemplate.execute(
+        ignored -> {
+          var admin = new UserJpaEntity("sub-ala", "ala@example.com", "監査管理者", "カンサカンリ", null);
+          var member = new UserJpaEntity("sub-alm", "alm@example.com", "一般", "イッパン", null);
+          var saasAdmin = new UserJpaEntity("sub-als", "als@example.com", "SaaS管理者", "サース", null);
+          em.persist(admin);
+          em.persist(member);
+          em.persist(saasAdmin);
+          em.flush();
+          adminUserId = admin.getId();
+          memberUserId = member.getId();
+          saasAdminUserId = saasAdmin.getId();
+
+          var tenantA = new TenantJpaEntity("AL-A", "監査テナントA");
+          var tenantB = new TenantJpaEntity("AL-B", "監査テナントB");
+          em.persist(tenantA);
+          em.persist(tenantB);
+          em.flush();
+          tenantAId = tenantA.getId();
+          tenantBId = tenantB.getId();
+
+          insertMembership(adminUserId, tenantAId, "TENANT_ADMIN");
+          insertMembership(memberUserId, tenantAId, "MEMBER");
+
+          // テナント A の監査ログ(4 件、created_at 昇順 = chain_seq 順)
+          insertAudit(tenantAId, adminUserId, "CREATE", "{\"taskId\":1}", day(1), 1);
+          insertAudit(tenantAId, adminUserId, "UPDATE", "{\"taskId\":1}", day(2), 2);
+          insertAudit(tenantAId, null, "LOGIN_FAILED", "{}", day(3), 3);
+          insertAudit(tenantAId, null, "TENANT_SUSPENDED", "{\"by\":\"saas\"}", day(4), 4);
+          // テナント B の行(返してはならない)
+          insertAudit(tenantBId, null, "DELETE", "{}", day(1), 1);
+          // 横断操作 tenant_id=NULL(返してはならない)
+          insertAudit(null, null, "LOGIN", "{}", day(1), 1);
+
+          return null;
+        });
+
+    SecurityContextHolder.clearContext();
+    adminToken =
+        new TasksAuthenticationToken(
+            new TasksPrincipal(adminUserId, "sub-ala", "ala@example.com", "監査管理者", "カンサカンリ", null),
+            List.of());
+    memberToken =
+        new TasksAuthenticationToken(
+            new TasksPrincipal(memberUserId, "sub-alm", "alm@example.com", "一般", "イッパン", null),
+            List.of());
+    saasAdminToken =
+        new TasksAuthenticationToken(
+            new TasksPrincipal(
+                saasAdminUserId, "sub-als", "als@example.com", "SaaS管理者", "サース", null),
+            List.of(new SimpleGrantedAuthority("ROLE_APP_ADMIN")));
+  }
+
+  @AfterEach
+  void tearDown() {
+    SecurityContextHolder.clearContext();
+    if (tenantAId == null) {
+      return;
+    }
+    txTemplate.execute(
+        ignored -> {
+          em.createNativeQuery(
+                  "DELETE FROM audit_logs WHERE tenant_id IN (?,?) OR tenant_id IS NULL")
+              .setParameter(1, tenantAId)
+              .setParameter(2, tenantBId)
+              .executeUpdate();
+          em.createNativeQuery("DELETE FROM user_tenants WHERE tenant_id = ?")
+              .setParameter(1, tenantAId)
+              .executeUpdate();
+          em.createNativeQuery("DELETE FROM tenants WHERE id IN (?,?)")
+              .setParameter(1, tenantAId)
+              .setParameter(2, tenantBId)
+              .executeUpdate();
+          em.createNativeQuery("DELETE FROM users WHERE id IN (?,?,?)")
+              .setParameter(1, adminUserId)
+              .setParameter(2, memberUserId)
+              .setParameter(3, saasAdminUserId)
+              .executeUpdate();
+          return null;
+        });
+  }
+
+  @Test
+  void returnsOnlyOwnTenantLogs_orderedByCreatedAtDesc() throws Exception {
+    mockMvc
+        .perform(
+            get("/api/audit-logs")
+                .header("X-Tenant-Id", String.valueOf(tenantAId))
+                .with(authentication(adminToken)))
+        .andExpect(status().isOk())
+        // テナント A の 4 件のみ(テナント B の DELETE・横断の LOGIN は除外)
+        .andExpect(jsonPath("$.totalElements").value(4))
+        .andExpect(jsonPath("$.content.length()").value(4))
+        // created_at 降順
+        .andExpect(jsonPath("$.content[0].action").value("TENANT_SUSPENDED"))
+        .andExpect(jsonPath("$.content[3].action").value("CREATE"))
+        // detail は object として復元される
+        .andExpect(jsonPath("$.content[3].detail.taskId").value(1))
+        // userId null(LOGIN_FAILED)
+        .andExpect(jsonPath("$.content[1].action").value("LOGIN_FAILED"))
+        .andExpect(jsonPath("$.content[1].userId").doesNotExist())
+        // 他テナント / 横断行の action が混入しない
+        .andExpect(jsonPath("$.content[?(@.action == 'DELETE')]").doesNotExist())
+        .andExpect(jsonPath("$.content[?(@.action == 'LOGIN')]").doesNotExist());
+  }
+
+  @Test
+  void filtersByAction() throws Exception {
+    mockMvc
+        .perform(
+            get("/api/audit-logs")
+                .header("X-Tenant-Id", String.valueOf(tenantAId))
+                .param("action", "CREATE")
+                .with(authentication(adminToken)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.totalElements").value(1))
+        .andExpect(jsonPath("$.content[0].action").value("CREATE"));
+  }
+
+  @Test
+  void filtersByCreatedAtRange_halfOpen() throws Exception {
+    // [06-02T00:00+09:00, 06-04T00:00+09:00) →
+    // UPDATE(06-02)・LOGIN_FAILED(06-03)。TENANT_SUSPENDED(06-04)は除外。
+    mockMvc
+        .perform(
+            get("/api/audit-logs")
+                .header("X-Tenant-Id", String.valueOf(tenantAId))
+                .param("from", "2026-06-02T00:00:00+09:00")
+                .param("to", "2026-06-04T00:00:00+09:00")
+                .with(authentication(adminToken)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.totalElements").value(2))
+        .andExpect(jsonPath("$.content[0].action").value("LOGIN_FAILED"))
+        .andExpect(jsonPath("$.content[1].action").value("UPDATE"));
+  }
+
+  @Test
+  void paginates() throws Exception {
+    mockMvc
+        .perform(
+            get("/api/audit-logs")
+                .header("X-Tenant-Id", String.valueOf(tenantAId))
+                .param("size", "2")
+                .with(authentication(adminToken)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.totalElements").value(4))
+        .andExpect(jsonPath("$.content.length()").value(2));
+  }
+
+  @Test
+  void member_isForbidden() throws Exception {
+    mockMvc
+        .perform(
+            get("/api/audit-logs")
+                .header("X-Tenant-Id", String.valueOf(tenantAId))
+                .with(authentication(memberToken)))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  void saasAdmin_isForbidden() throws Exception {
+    mockMvc
+        .perform(
+            get("/api/audit-logs")
+                .header("X-Tenant-Id", String.valueOf(tenantAId))
+                .with(authentication(saasAdminToken)))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  void unauthenticated_returns401() throws Exception {
+    mockMvc
+        .perform(get("/api/audit-logs").header("X-Tenant-Id", String.valueOf(tenantAId)))
+        .andExpect(status().isUnauthorized());
+  }
+
+  // --- helpers ---
+
+  private static LocalDateTime day(int dayOfMonth) {
+    return LocalDateTime.of(2026, 6, dayOfMonth, 10, 0);
+  }
+
+  private void insertMembership(Long userId, Long tenantId, String role) {
+    em.createNativeQuery(
+            "INSERT INTO user_tenants (user_id, tenant_id, role, status, joined_at)"
+                + " VALUES (?,?,?,?,?)")
+        .setParameter(1, userId)
+        .setParameter(2, tenantId)
+        .setParameter(3, role)
+        .setParameter(4, "ACTIVE")
+        .setParameter(5, LocalDateTime.of(2026, 1, 1, 0, 0))
+        .executeUpdate();
+  }
+
+  private void insertAudit(
+      @org.jspecify.annotations.Nullable Long tenantId,
+      @org.jspecify.annotations.Nullable Long userId,
+      String action,
+      String detailJson,
+      LocalDateTime createdAt,
+      long chainSeq) {
+    em.createNativeQuery(
+            "INSERT INTO audit_logs"
+                + " (tenant_id, user_id, action, detail, hash_chain, chain_seq, hash_key_id, created_at)"
+                + " VALUES (?,?,?,?,?,?,?,?)")
+        .setParameter(1, tenantId)
+        .setParameter(2, userId)
+        .setParameter(3, action)
+        .setParameter(4, detailJson)
+        .setParameter(5, DUMMY_HASH)
+        .setParameter(6, chainSeq)
+        .setParameter(7, "v1")
+        .setParameter(8, createdAt)
+        .executeUpdate();
+  }
+}

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/audit/usecase/ListAuditLogsUseCaseTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/audit/usecase/ListAuditLogsUseCaseTest.java
@@ -1,0 +1,24 @@
+package xyz.dgz48.tasks.webapi.audit.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ListAuditLogsUseCaseTest {
+
+  @Test
+  void execute_delegatesToPort() {
+    AuditLogQueryPort port = mock(AuditLogQueryPort.class);
+    AuditLogSearchCriteria criteria = new AuditLogSearchCriteria(7L, null, null, null, 0, 50);
+    AuditLogPage expected = new AuditLogPage(List.of(), 0);
+    when(port.search(eq(criteria))).thenReturn(expected);
+
+    ListAuditLogsUseCase useCase = new ListAuditLogsUseCase(port);
+
+    assertThat(useCase.execute(criteria)).isSameAs(expected);
+  }
+}

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/SecurityConfigTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/SecurityConfigTest.java
@@ -35,6 +35,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import xyz.dgz48.tasks.webapi.audit.usecase.AuditLogPort;
 import xyz.dgz48.tasks.webapi.audit.usecase.AuthorizationDeniedAuditService;
+import xyz.dgz48.tasks.webapi.audit.usecase.ListAuditLogsUseCase;
 import xyz.dgz48.tasks.webapi.dashboard.usecase.GetDashboardSummaryUseCase;
 import xyz.dgz48.tasks.webapi.dashboard.usecase.GetDashboardTasksUseCase;
 import xyz.dgz48.tasks.webapi.dashboard.usecase.GetTenantDashboardSummaryUseCase;
@@ -111,6 +112,7 @@ class SecurityConfigTest {
   @MockitoBean GetDashboardSummaryUseCase getDashboardSummaryUseCase;
   @MockitoBean GetTenantDashboardSummaryUseCase getTenantDashboardSummaryUseCase;
   @MockitoBean CreateTenantUseCase createTenantUseCase;
+  @MockitoBean ListAuditLogsUseCase listAuditLogsUseCase;
 
   @Autowired MockMvc mockMvc;
 

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/TenantContextFilterTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/TenantContextFilterTest.java
@@ -23,6 +23,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 import xyz.dgz48.tasks.webapi.audit.usecase.AuditLogPort;
 import xyz.dgz48.tasks.webapi.audit.usecase.AuthorizationDeniedAuditService;
+import xyz.dgz48.tasks.webapi.audit.usecase.ListAuditLogsUseCase;
 import xyz.dgz48.tasks.webapi.dashboard.usecase.GetDashboardSummaryUseCase;
 import xyz.dgz48.tasks.webapi.dashboard.usecase.GetDashboardTasksUseCase;
 import xyz.dgz48.tasks.webapi.dashboard.usecase.GetTenantDashboardSummaryUseCase;
@@ -126,6 +127,7 @@ class TenantContextFilterTest {
   @MockitoBean GetDashboardSummaryUseCase getDashboardSummaryUseCase;
   @MockitoBean GetTenantDashboardSummaryUseCase getTenantDashboardSummaryUseCase;
   @MockitoBean CreateTenantUseCase createTenantUseCase;
+  @MockitoBean ListAuditLogsUseCase listAuditLogsUseCase;
 
   @Autowired MockMvc mockMvc;
 


### PR DESCRIPTION
## 概要

A-22 監査ログ参照 API (`GET /api/audit-logs`) を実装する。Tenant Admin が自テナントの監査ログをページングで参照する読取専用 API(画面なし)。トラッカー #780 の 3 件目。ブロッカーだったハッシュチェーン基盤(#751)はマージ済み。

Closes #777

## 実装内容

- **`AuditLogController`** / **`ListAuditLogsUseCase`** — `hasRole('TENANT_ADMIN')` のみ(Member / SaaS Admin は 403)。`X-Tenant-Id` 必須。
- **参照スコープ(ADR-0020 §3.4)** — `audit_logs.tenant_id = 現在のテナント` に一致するレコードを返す。特定テナントを対象とする SaaS Admin 操作(停止・再開・名称更新等)は `tenant_id=当該テナント id` で記録されるため参照可能。横断操作(`tenant_id=NULL`)は対象外。`audit_logs` は `TenantFilteredEntity` 非適用(ADR-0010 §6.1)のため、クエリで `tenant_id` を明示絞り込み。
- **絞り込み** — `from` / `to`(`created_at` の半開区間 `[from, to)`、OffsetDateTime → JST 変換)、`action`(完全一致、`^[A-Z][A-Z0-9_]*$`)。`page` / `size`(最大 100、既定 50)。`created_at` 降順・`id` 降順。
- **レスポンス** — OpenAPI `AuditLog` 準拠。`detail` は保存済み JSON 文字列を object として復元。内部列(`tenant_id` / `actor_sub` / `hash_chain` 等)は非公開。`createdAt` は JST オフセット付き(ADR-0009)。

## テスト
- `AuditLogIT`(Testcontainers): 自テナントスコープ(**他テナント行・横断 `tenant_id=NULL` 行を返さない**)、`created_at` 降順、`action` 絞り込み、`from`/`to` 半開区間、ページング、`detail` の object 復元、`userId` null(認証失敗イベント)、Member→403、SaaS Admin(APP_ADMIN)→403、未認証→401。
- `ListAuditLogsUseCaseTest`: ポート委譲。
- `SecurityConfigTest` / `TenantContextFilterTest` に新 usecase モックを追加。

`./gradlew :webapi:check`(spotless / JaCoCo 0.80 / 全 IT)green。OpenAPI `listAuditLogs` 契約(`{content, totalElements}`)と一致。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
