### PR TITLE
feat(notification): 通知設定 GET/PUT /api/users/me/notification-settings + S-10 (Closes #778)

### DIFF
--- a/web/js/api.js
+++ b/web/js/api.js
@@ -110,6 +110,14 @@
  */
 
 /**
+ * @typedef {object} NotificationSettings
+ * @property {boolean} emailDueToday
+ * @property {boolean} emailOverdue
+ * @property {boolean} emailStakeholder
+ * @property {string} [updatedAt]
+ */
+
+/**
  * @typedef {object} TenantDashboardSummary
  * @property {number} totalTaskCount
  * @property {number} todayDueCount
@@ -363,6 +371,26 @@ const Api = (() => {
   }
 
   /**
+   * GET /api/users/me/notification-settings — 通知設定取得(A-23、S-10、現テナント)。
+   * @returns {Promise<NotificationSettings>}
+   */
+  function getNotificationSettings() {
+    return request('/api/users/me/notification-settings');
+  }
+
+  /**
+   * PUT /api/users/me/notification-settings — 通知設定更新(A-24、S-10、現テナント)。
+   * @param {NotificationSettings} body
+   * @returns {Promise<NotificationSettings>}
+   */
+  function updateNotificationSettings(body) {
+    return request('/api/users/me/notification-settings', {
+      method: 'PUT',
+      body: JSON.stringify(body),
+    });
+  }
+
+  /**
    * GET /api/tasks/{id} — タスク詳細取得(A-12)。ETag も返す。
    * @param {number} id
    * @returns {Promise<{task: TaskDetail, etag: string|null}>}
@@ -463,6 +491,8 @@ const Api = (() => {
     changeVisibility,
     listTenantUsers,
     getTenantDashboardSummary,
+    getNotificationSettings,
+    updateNotificationSettings,
     listStakeholders,
     addStakeholder,
     removeStakeholder,

--- a/web/js/notification-settings.js
+++ b/web/js/notification-settings.js
@@ -1,0 +1,107 @@
+// @ts-check
+
+/** @type {HTMLElement} */ (mustQuery(document, '#btn-logout')).addEventListener('click', () =>
+  Auth.logout(),
+);
+
+/**
+ * @param {string} message
+ */
+function showError(message) {
+  /** @type {HTMLElement} */ (mustQuery(document, '#loading')).classList.add('d-none');
+  const el = /** @type {HTMLElement} */ (mustQuery(document, '#error-alert'));
+  el.textContent = message;
+  el.classList.remove('d-none');
+}
+
+/**
+ * @param {string} id
+ * @returns {HTMLInputElement}
+ */
+function checkbox(id) {
+  return /** @type {HTMLInputElement} */ (mustQuery(document, id));
+}
+
+/**
+ * @param {NotificationSettings} settings
+ */
+function fillForm(settings) {
+  checkbox('#email-due-today').checked = settings.emailDueToday;
+  checkbox('#email-overdue').checked = settings.emailOverdue;
+  checkbox('#email-stakeholder').checked = settings.emailStakeholder;
+}
+
+/**
+ * @param {SubmitEvent} event
+ */
+async function onSubmit(event) {
+  event.preventDefault();
+  /** @type {HTMLElement} */ (mustQuery(document, '#saved-alert')).classList.add('d-none');
+  /** @type {HTMLElement} */ (mustQuery(document, '#error-alert')).classList.add('d-none');
+
+  const button = /** @type {HTMLButtonElement} */ (mustQuery(document, '#btn-save'));
+  button.disabled = true;
+  try {
+    const saved = await Api.updateNotificationSettings({
+      emailDueToday: checkbox('#email-due-today').checked,
+      emailOverdue: checkbox('#email-overdue').checked,
+      emailStakeholder: checkbox('#email-stakeholder').checked,
+    });
+    fillForm(saved);
+    /** @type {HTMLElement} */ (mustQuery(document, '#saved-alert')).classList.remove('d-none');
+  } catch (err) {
+    showError(`保存に失敗しました: ${/** @type {any} */ (err).message}`);
+  } finally {
+    button.disabled = false;
+  }
+}
+
+async function main() {
+  const authenticated = await Auth.init();
+  if (!authenticated) {
+    return;
+  }
+
+  const user = Auth.getUser();
+  const displayName = user?.name || user?.preferred_username || '';
+  /** @type {HTMLElement} */ (mustQuery(document, '#nav-username')).textContent = displayName;
+  /** @type {HTMLElement} */ (mustQuery(document, '#user-avatar')).textContent =
+    displayName.slice(0, 1) || '?';
+
+  /** @type {MeResponse} */
+  let me;
+  try {
+    me = await Api.getMe();
+  } catch (err) {
+    showError(`ユーザー情報の取得に失敗しました: ${/** @type {any} */ (err).message}`);
+    return;
+  }
+
+  const activeTenantId = Api.resolveActiveTenant(me.tenants);
+  if (activeTenantId === null) {
+    window.location.replace('index.html');
+    return;
+  }
+
+  /** @type {AppTenantSwitcherElement} */ (mustQuery(document, '#tenant-switcher')).setData(
+    me.tenants,
+    activeTenantId,
+  );
+  const activeTenant = me.tenants?.find((t) => t.id === activeTenantId);
+  if (activeTenant?.role === 'TENANT_ADMIN') {
+    document.body.classList.add('role-admin');
+  }
+
+  try {
+    const settings = await Api.getNotificationSettings();
+    fillForm(settings);
+    /** @type {HTMLElement} */ (mustQuery(document, '#loading')).classList.add('d-none');
+    const form = /** @type {HTMLFormElement} */ (mustQuery(document, '#settings-form'));
+    form.classList.remove('d-none');
+    form.addEventListener('submit', onSubmit);
+  } catch (err) {
+    showError(`設定の取得に失敗しました: ${/** @type {any} */ (err).message}`);
+  }
+}
+
+main();

--- a/web/notification-settings.html
+++ b/web/notification-settings.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>運営者ダッシュボード — Tasks</title>
+  <title>通知設定 — Tasks</title>
   <link rel="icon" type="image/svg+xml" href="/favicon.svg">
   <link rel="stylesheet" href="vendor/bootstrap/css/bootstrap.min.css">
   <link rel="stylesheet" href="vendor/bootstrap-icons/bootstrap-icons.min.css">
@@ -45,7 +45,7 @@
     </a>
     <div class="admin-only">
       <div class="nav-group-label" aria-hidden="true">テナント運営</div>
-      <a class="side-link active" href="tenant-dashboard.html" aria-current="page">
+      <a class="side-link" href="tenant-dashboard.html">
         <i class="bi bi-graph-up-arrow" aria-hidden="true"></i>運営者ダッシュボード
       </a>
       <a class="side-link" href="#">
@@ -54,95 +54,56 @@
     </div>
     <div class="nav-group-label" aria-hidden="true">アカウント</div>
     <a class="side-link" href="#"><i class="bi bi-person-circle" aria-hidden="true"></i>プロフィール</a>
-    <a class="side-link" href="notification-settings.html"><i class="bi bi-bell" aria-hidden="true"></i>通知設定</a>
+    <a class="side-link active" href="notification-settings.html" aria-current="page">
+      <i class="bi bi-bell" aria-hidden="true"></i>通知設定
+    </a>
   </aside>
 
   <!-- ===== Main ===== -->
   <main id="main-content" class="app-main">
     <div class="d-flex align-items-center flex-wrap gap-3 mb-3">
-      <h1 class="page-title">運営者ダッシュボード</h1>
+      <h1 class="page-title">通知設定</h1>
     </div>
-    <p class="text-muted small mb-3">
-      テナント全体で共有(TENANT)または関係者限定(STAKEHOLDERS)で動いている業務量の集計です。
-      PRIVATE タスクは集計に含まれません。
-    </p>
+    <p class="text-muted small mb-3">現在のテナントにおける、自分宛てのメール通知の ON/OFF を設定します。</p>
 
     <div id="error-alert" class="alert alert-danger d-none" role="alert"></div>
+    <div id="saved-alert" class="alert alert-success d-none" role="status">保存しました。</div>
 
     <div id="loading" class="text-center py-5">
       <div class="spinner-border text-primary" role="status">
         <span class="visually-hidden">Loading...</span>
       </div>
-      <p class="mt-2 text-muted">集計を取得中...</p>
+      <p class="mt-2 text-muted">設定を取得中...</p>
     </div>
 
-    <div id="summary" class="d-none">
-      <!-- 数値カード -->
-      <div class="row row-cols-2 row-cols-md-3 row-cols-xl-5 g-3 mb-4">
-        <div class="col">
-          <div class="card h-100">
-            <div class="card-body">
-              <div class="text-muted small">総タスク数</div>
-              <div id="card-total" class="fs-3 fw-semibold">—</div>
+    <div class="row justify-content-center">
+      <div class="col-12 col-md-9 col-lg-7">
+        <form id="settings-form" class="card d-none">
+          <div class="card-body">
+            <div class="form-check form-switch mb-3">
+              <input class="form-check-input" type="checkbox" role="switch" id="email-due-today">
+              <label class="form-check-label" for="email-due-today">
+                期限当日のメール通知
+                <span class="d-block text-muted small">期限が今日のタスクを当日に通知します。</span>
+              </label>
             </div>
-          </div>
-        </div>
-        <div class="col">
-          <div class="card h-100">
-            <div class="card-body">
-              <div class="text-muted small">当日期限</div>
-              <div id="card-today-due" class="fs-3 fw-semibold">—</div>
+            <div class="form-check form-switch mb-3">
+              <input class="form-check-input" type="checkbox" role="switch" id="email-overdue">
+              <label class="form-check-label" for="email-overdue">
+                期限超過のメール通知
+                <span class="d-block text-muted small">期限を過ぎた未完了タスクを通知します。</span>
+              </label>
             </div>
-          </div>
-        </div>
-        <div class="col">
-          <div class="card h-100">
-            <div class="card-body">
-              <div class="text-muted small">期限切れ</div>
-              <div id="card-overdue" class="fs-3 fw-semibold text-danger">—</div>
+            <div class="form-check form-switch mb-4">
+              <input class="form-check-input" type="checkbox" role="switch" id="email-stakeholder">
+              <label class="form-check-label" for="email-stakeholder">
+                関係者登録のメール通知
+                <span class="d-block text-muted small">タスクの関係者として登録されたときに通知します。</span>
+              </label>
             </div>
+            <button id="btn-save" type="submit" class="btn btn-primary">保存</button>
           </div>
-        </div>
-        <div class="col">
-          <div class="card h-100">
-            <div class="card-body">
-              <div class="text-muted small">本日完了</div>
-              <div id="card-completed-today" class="fs-3 fw-semibold text-success">—</div>
-            </div>
-          </div>
-        </div>
-        <div class="col">
-          <div class="card h-100">
-            <div class="card-body">
-              <div class="text-muted small">メンバー数</div>
-              <div id="card-members" class="fs-3 fw-semibold">—</div>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <!-- ブレークダウン -->
-      <div class="row g-3">
-        <div class="col-12 col-lg-6">
-          <div class="card h-100">
-            <div class="card-body">
-              <h2 class="h6 card-title">ステータス別件数</h2>
-              <table class="table table-sm mb-0">
-                <tbody id="status-breakdown"></tbody>
-              </table>
-            </div>
-          </div>
-        </div>
-        <div class="col-12 col-lg-6">
-          <div class="card h-100">
-            <div class="card-body">
-              <h2 class="h6 card-title">優先度別件数</h2>
-              <table class="table table-sm mb-0">
-                <tbody id="priority-breakdown"></tbody>
-              </table>
-            </div>
-          </div>
-        </div>
+        </form>
       </div>
     </div>
   </main>
@@ -153,8 +114,7 @@
 <script src="js/dom.js"></script>
 <script src="js/auth.js"></script>
 <script src="js/api.js"></script>
-<script src="js/meta.js"></script>
 <script src="js/components/app-tenant-switcher.js"></script>
-<script src="js/tenant-dashboard.js"></script>
+<script src="js/notification-settings.js"></script>
 </body>
 </html>

--- a/web/package.json
+++ b/web/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "copy-vendor": "node scripts/copy-vendor.js",
-    "html-validate": "html-validate index.html tasks.html tenants-new.html tenant-dashboard.html",
+    "html-validate": "html-validate index.html tasks.html tenants-new.html tenant-dashboard.html notification-settings.html",
     "serve": "node serve.mjs"
   },
   "engines": {

--- a/web/tasks.html
+++ b/web/tasks.html
@@ -54,7 +54,7 @@
     </div>
     <div class="nav-group-label" aria-hidden="true">アカウント</div>
     <a class="side-link" href="#"><i class="bi bi-person-circle" aria-hidden="true"></i>プロフィール</a>
-    <a class="side-link" href="#"><i class="bi bi-bell" aria-hidden="true"></i>通知設定</a>
+    <a class="side-link" href="notification-settings.html"><i class="bi bi-bell" aria-hidden="true"></i>通知設定</a>
   </aside>
 
   <!-- ===== Main ===== -->

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/notification/adapter/persistence/NotificationSettingsId.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/notification/adapter/persistence/NotificationSettingsId.java
@@ -1,0 +1,20 @@
+package xyz.dgz48.tasks.webapi.notification.adapter.persistence;
+
+import java.io.Serializable;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import org.jspecify.annotations.Nullable;
+
+/** {@link NotificationSettingsJpaEntity} の複合主キークラス(user_id, tenant_id)。 */
+@NoArgsConstructor
+@EqualsAndHashCode
+@SuppressWarnings("NullAway.Init") // JPA composite ID class requires no-args constructor
+class NotificationSettingsId implements Serializable {
+  @Nullable private Long userId;
+  @Nullable private Long tenantId;
+
+  NotificationSettingsId(Long userId, Long tenantId) {
+    this.userId = userId;
+    this.tenantId = tenantId;
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/notification/adapter/persistence/NotificationSettingsJpaEntity.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/notification/adapter/persistence/NotificationSettingsJpaEntity.java
@@ -1,0 +1,73 @@
+package xyz.dgz48.tasks.webapi.notification.adapter.persistence;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import xyz.dgz48.tasks.webapi.shared.adapter.persistence.TenantFilteredEntity;
+
+/**
+ * {@code user_notification_settings} テーブルの JPA エンティティ(S-10)。
+ *
+ * <p>{@code tenant_id BIGINT NOT NULL} を持つ業務テーブルのため {@link TenantFilteredEntity} を継承し、Hibernate
+ * Filter "tenantFilter"(ADR-0010)が SELECT にテナント条件を自動付与する。複合主キーは (user_id, tenant_id)。
+ */
+@Entity
+@Table(name = "user_notification_settings")
+@IdClass(NotificationSettingsId.class)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SuppressWarnings("NullAway.Init") // JPA requires no-args constructor; fields initialized via JPA
+class NotificationSettingsJpaEntity extends TenantFilteredEntity {
+
+  @Id
+  @Column(name = "user_id", nullable = false)
+  private Long userId;
+
+  @Id
+  @Column(name = "tenant_id", nullable = false)
+  private Long tenantId;
+
+  @Column(name = "email_due_today", nullable = false)
+  private boolean emailDueToday;
+
+  @Column(name = "email_overdue", nullable = false)
+  private boolean emailOverdue;
+
+  @Column(name = "email_stakeholder", nullable = false)
+  private boolean emailStakeholder;
+
+  @Column(name = "updated_at", nullable = false)
+  private LocalDateTime updatedAt;
+
+  NotificationSettingsJpaEntity(
+      Long userId,
+      Long tenantId,
+      boolean emailDueToday,
+      boolean emailOverdue,
+      boolean emailStakeholder,
+      LocalDateTime updatedAt) {
+    this.userId = userId;
+    this.tenantId = tenantId;
+    this.emailDueToday = emailDueToday;
+    this.emailOverdue = emailOverdue;
+    this.emailStakeholder = emailStakeholder;
+    this.updatedAt = updatedAt;
+  }
+
+  void update(
+      boolean emailDueToday,
+      boolean emailOverdue,
+      boolean emailStakeholder,
+      LocalDateTime updatedAt) {
+    this.emailDueToday = emailDueToday;
+    this.emailOverdue = emailOverdue;
+    this.emailStakeholder = emailStakeholder;
+    this.updatedAt = updatedAt;
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/notification/adapter/persistence/NotificationSettingsJpaRepository.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/notification/adapter/persistence/NotificationSettingsJpaRepository.java
@@ -1,0 +1,16 @@
+package xyz.dgz48.tasks.webapi.notification.adapter.persistence;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * 通知設定の JPA リポジトリ。
+ *
+ * <p>テナント分離は Hibernate Filter "tenantFilter"(ADR-0010)が自動付与するため、{@link #findByUserId(Long)} は
+ * 現在のテナントにおける当該ユーザーの 1 行のみを返す。
+ */
+interface NotificationSettingsJpaRepository
+    extends JpaRepository<NotificationSettingsJpaEntity, NotificationSettingsId> {
+
+  Optional<NotificationSettingsJpaEntity> findByUserId(Long userId);
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/notification/adapter/persistence/NotificationSettingsPersistenceAdapter.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/notification/adapter/persistence/NotificationSettingsPersistenceAdapter.java
@@ -1,0 +1,61 @@
+package xyz.dgz48.tasks.webapi.notification.adapter.persistence;
+
+import io.micrometer.observation.annotation.Observed;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import xyz.dgz48.tasks.webapi.notification.domain.NotificationSettings;
+import xyz.dgz48.tasks.webapi.notification.usecase.NotificationSettingsPort;
+
+/**
+ * {@link NotificationSettingsPort} の JPA 実装。
+ *
+ * <p>読み取りは Hibernate Filter により現在テナントへ自動絞り込み。upsert は SELECT(現在テナント)結果の有無で update / insert
+ * を分岐し、insert 時のみ {@code tenant_id} を明示設定する(Filter は INSERT に作用しないため)。
+ */
+@Observed(name = "notification.settings.repository")
+@Component
+@RequiredArgsConstructor
+class NotificationSettingsPersistenceAdapter implements NotificationSettingsPort {
+
+  private final NotificationSettingsJpaRepository repository;
+
+  @Override
+  public Optional<NotificationSettings> find(Long userId) {
+    return repository.findByUserId(userId).map(NotificationSettingsPersistenceAdapter::toDomain);
+  }
+
+  @Override
+  public NotificationSettings upsert(
+      Long userId,
+      Long tenantId,
+      boolean emailDueToday,
+      boolean emailOverdue,
+      boolean emailStakeholder,
+      LocalDateTime updatedAt) {
+    NotificationSettingsJpaEntity entity =
+        repository
+            .findByUserId(userId)
+            .map(
+                existing -> {
+                  existing.update(emailDueToday, emailOverdue, emailStakeholder, updatedAt);
+                  return existing;
+                })
+            .orElseGet(
+                () ->
+                    new NotificationSettingsJpaEntity(
+                        userId,
+                        tenantId,
+                        emailDueToday,
+                        emailOverdue,
+                        emailStakeholder,
+                        updatedAt));
+    return toDomain(repository.save(entity));
+  }
+
+  private static NotificationSettings toDomain(NotificationSettingsJpaEntity e) {
+    return new NotificationSettings(
+        e.isEmailDueToday(), e.isEmailOverdue(), e.isEmailStakeholder(), e.getUpdatedAt());
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/notification/adapter/web/NotificationSettingsController.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/notification/adapter/web/NotificationSettingsController.java
@@ -1,0 +1,61 @@
+package xyz.dgz48.tasks.webapi.notification.adapter.web;
+
+import jakarta.validation.Valid;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import xyz.dgz48.tasks.webapi.notification.adapter.web.dto.NotificationSettingsResponse;
+import xyz.dgz48.tasks.webapi.notification.adapter.web.dto.NotificationSettingsUpdateRequest;
+import xyz.dgz48.tasks.webapi.notification.usecase.GetNotificationSettingsUseCase;
+import xyz.dgz48.tasks.webapi.notification.usecase.UpdateNotificationSettingsCommand;
+import xyz.dgz48.tasks.webapi.notification.usecase.UpdateNotificationSettingsUseCase;
+import xyz.dgz48.tasks.webapi.shared.domain.TenantContext;
+
+/**
+ * 通知設定 API(A-23 取得 / A-24 更新、S-10)。
+ *
+ * <p>ログイン中ユーザー自身の、現在のテナント({@code X-Tenant-Id})における設定を扱う。業務 API のため {@code MEMBER} / {@code
+ * TENANT_ADMIN} のみ許可し、SaaS Admin は 403(§6.2.1)。テナント分離は Hibernate Filter(ADR-0010)。
+ */
+@RestController
+@RequestMapping("/api/users/me/notification-settings")
+@RequiredArgsConstructor
+public class NotificationSettingsController {
+
+  private final GetNotificationSettingsUseCase getNotificationSettingsUseCase;
+  private final UpdateNotificationSettingsUseCase updateNotificationSettingsUseCase;
+
+  @GetMapping
+  @PreAuthorize("hasAnyRole('TENANT_ADMIN', 'MEMBER')")
+  public ResponseEntity<NotificationSettingsResponse> get(
+      @AuthenticationPrincipal(expression = "id") Long userId) {
+    return ResponseEntity.ok(
+        NotificationSettingsResponse.from(getNotificationSettingsUseCase.execute(userId)));
+  }
+
+  @PutMapping
+  @PreAuthorize("hasAnyRole('TENANT_ADMIN', 'MEMBER')")
+  public ResponseEntity<NotificationSettingsResponse> update(
+      @AuthenticationPrincipal(expression = "id") Long userId,
+      @Valid @RequestBody NotificationSettingsUpdateRequest request) {
+    // TenantContextFilter が業務 API 到達前に X-Tenant-Id + ACTIVE メンバーシップを検証済み(未確立なら 403)。
+    Long tenantId =
+        Objects.requireNonNull(TenantContext.get(), "TenantContext must be set by filter");
+    UpdateNotificationSettingsCommand command =
+        new UpdateNotificationSettingsCommand(
+            userId,
+            tenantId,
+            request.emailDueToday(),
+            request.emailOverdue(),
+            request.emailStakeholder());
+    return ResponseEntity.ok(
+        NotificationSettingsResponse.from(updateNotificationSettingsUseCase.execute(command)));
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/notification/adapter/web/dto/NotificationSettingsResponse.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/notification/adapter/web/dto/NotificationSettingsResponse.java
@@ -1,0 +1,30 @@
+package xyz.dgz48.tasks.webapi.notification.adapter.web.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.time.OffsetDateTime;
+import org.jspecify.annotations.Nullable;
+import xyz.dgz48.tasks.webapi.notification.domain.NotificationSettings;
+import xyz.dgz48.tasks.webapi.shared.infra.AppZones;
+
+/**
+ * OpenAPI {@code NotificationSettings} に対応するレスポンス(S-10)。
+ *
+ * <p>{@code updatedAt} はレコード未存在(デフォルト)時 {@code null}。スキーマ上 nullable でないため、null のときはフィールド自体を
+ * 省略する({@code JsonInclude.NON_NULL})。値ありのときは JST オフセット付き(ADR-0009)。
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record NotificationSettingsResponse(
+    boolean emailDueToday,
+    boolean emailOverdue,
+    boolean emailStakeholder,
+    @Nullable OffsetDateTime updatedAt) {
+
+  public static NotificationSettingsResponse from(NotificationSettings settings) {
+    OffsetDateTime updatedAt =
+        settings.updatedAt() == null
+            ? null
+            : settings.updatedAt().atZone(AppZones.JST).toOffsetDateTime();
+    return new NotificationSettingsResponse(
+        settings.emailDueToday(), settings.emailOverdue(), settings.emailStakeholder(), updatedAt);
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/notification/adapter/web/dto/NotificationSettingsUpdateRequest.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/notification/adapter/web/dto/NotificationSettingsUpdateRequest.java
@@ -1,0 +1,13 @@
+package xyz.dgz48.tasks.webapi.notification.adapter.web.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * OpenAPI {@code NotificationSettings}(更新リクエスト本体、A-24)。
+ *
+ * <p>3 フラグはいずれも必須({@code required})。{@code updatedAt} は readOnly のため入力では受け取らない。
+ */
+public record NotificationSettingsUpdateRequest(
+    @NotNull Boolean emailDueToday,
+    @NotNull Boolean emailOverdue,
+    @NotNull Boolean emailStakeholder) {}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/notification/adapter/web/dto/package-info.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/notification/adapter/web/dto/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package xyz.dgz48.tasks.webapi.notification.adapter.web.dto;
+
+import org.jspecify.annotations.NullMarked;

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/notification/adapter/web/package-info.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/notification/adapter/web/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package xyz.dgz48.tasks.webapi.notification.adapter.web;
+
+import org.jspecify.annotations.NullMarked;

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/notification/domain/NotificationSettings.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/notification/domain/NotificationSettings.java
@@ -1,0 +1,23 @@
+package xyz.dgz48.tasks.webapi.notification.domain;
+
+import java.time.LocalDateTime;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * ユーザー通知設定(S-10、現在のテナントスコープ)。{@code user_notification_settings} に対応。
+ *
+ * <p>レコードが存在しない場合は {@link #defaults()}(全フラグ true、{@code updatedAt} は未設定)を用いる。
+ *
+ * @param updatedAt 最終更新日時。レコード未存在(デフォルト)時は {@code null}。
+ */
+public record NotificationSettings(
+    boolean emailDueToday,
+    boolean emailOverdue,
+    boolean emailStakeholder,
+    @Nullable LocalDateTime updatedAt) {
+
+  /** レコード未存在時の既定値(全フラグ true)。 */
+  public static NotificationSettings defaults() {
+    return new NotificationSettings(true, true, true, null);
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/notification/usecase/GetNotificationSettingsUseCase.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/notification/usecase/GetNotificationSettingsUseCase.java
@@ -1,0 +1,25 @@
+package xyz.dgz48.tasks.webapi.notification.usecase;
+
+import io.micrometer.observation.annotation.Observed;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import xyz.dgz48.tasks.webapi.notification.domain.NotificationSettings;
+
+/**
+ * 通知設定取得(A-23、operationId: getNotificationSettings)のユースケース。
+ *
+ * <p>レコードが無い場合は {@link NotificationSettings#defaults()}(全 true)を返す。
+ */
+@Service
+@RequiredArgsConstructor
+public class GetNotificationSettingsUseCase {
+
+  private final NotificationSettingsPort notificationSettingsPort;
+
+  @Observed(name = "notification.settings.get")
+  @Transactional(readOnly = true)
+  public NotificationSettings execute(Long userId) {
+    return notificationSettingsPort.find(userId).orElseGet(NotificationSettings::defaults);
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/notification/usecase/NotificationSettingsPort.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/notification/usecase/NotificationSettingsPort.java
@@ -1,0 +1,27 @@
+package xyz.dgz48.tasks.webapi.notification.usecase;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import xyz.dgz48.tasks.webapi.notification.domain.NotificationSettings;
+
+/**
+ * 通知設定の取得・更新ポート(クリーンアーキの out port)。
+ *
+ * <p>実装は adapter.persistence。テナント分離は Hibernate Filter(ADR-0010)が自動付与する({@code
+ * user_notification_settings} は {@code TenantFilteredEntity} 継承)。読み書きとも現在のテナント({@code X-Tenant-Id})
+ * スコープに限定される。
+ */
+public interface NotificationSettingsPort {
+
+  /** 現在のテナントにおける指定ユーザーの設定を取得する(未存在なら空)。 */
+  Optional<NotificationSettings> find(Long userId);
+
+  /** 現在のテナントにおける指定ユーザーの設定を upsert し、保存後の値を返す。 */
+  NotificationSettings upsert(
+      Long userId,
+      Long tenantId,
+      boolean emailDueToday,
+      boolean emailOverdue,
+      boolean emailStakeholder,
+      LocalDateTime updatedAt);
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/notification/usecase/UpdateNotificationSettingsCommand.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/notification/usecase/UpdateNotificationSettingsCommand.java
@@ -1,0 +1,14 @@
+package xyz.dgz48.tasks.webapi.notification.usecase;
+
+/**
+ * 通知設定更新(A-24)のコマンド。
+ *
+ * @param userId 更新対象ユーザー(ログイン中ユーザー自身)
+ * @param tenantId 現在のテナント(レコード新規作成時の tenant_id)
+ */
+public record UpdateNotificationSettingsCommand(
+    Long userId,
+    Long tenantId,
+    boolean emailDueToday,
+    boolean emailOverdue,
+    boolean emailStakeholder) {}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/notification/usecase/UpdateNotificationSettingsUseCase.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/notification/usecase/UpdateNotificationSettingsUseCase.java
@@ -1,0 +1,34 @@
+package xyz.dgz48.tasks.webapi.notification.usecase;
+
+import io.micrometer.observation.annotation.Observed;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import xyz.dgz48.tasks.webapi.notification.domain.NotificationSettings;
+
+/**
+ * 通知設定更新(A-24、operationId: updateNotificationSettings)のユースケース。
+ *
+ * <p>レコード未存在時は upsert(新規作成)する。{@code updated_at} はサーバ側システム時刻(JST、ADR-0009)。
+ */
+@Service
+@RequiredArgsConstructor
+public class UpdateNotificationSettingsUseCase {
+
+  private final NotificationSettingsPort notificationSettingsPort;
+  private final Clock clock;
+
+  @Observed(name = "notification.settings.update")
+  @Transactional
+  public NotificationSettings execute(UpdateNotificationSettingsCommand command) {
+    return notificationSettingsPort.upsert(
+        command.userId(),
+        command.tenantId(),
+        command.emailDueToday(),
+        command.emailOverdue(),
+        command.emailStakeholder(),
+        LocalDateTime.now(clock));
+  }
+}

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/notification/adapter/web/NotificationSettingsIT.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/notification/adapter/web/NotificationSettingsIT.java
@@ -1,0 +1,234 @@
+package xyz.dgz48.tasks.webapi.notification.adapter.web;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import jakarta.persistence.EntityManager;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.support.TransactionTemplate;
+import xyz.dgz48.tasks.webapi.MockJwtDecoderConfiguration;
+import xyz.dgz48.tasks.webapi.TestcontainersConfiguration;
+import xyz.dgz48.tasks.webapi.security.adapter.web.TasksAuthenticationToken;
+import xyz.dgz48.tasks.webapi.security.domain.TasksPrincipal;
+import xyz.dgz48.tasks.webapi.tenant.adapter.persistence.TenantJpaEntity;
+import xyz.dgz48.tasks.webapi.user.adapter.persistence.UserJpaEntity;
+
+/**
+ * 通知設定 API(A-23/A-24、GET/PUT /api/users/me/notification-settings、S-10)の統合テスト。
+ *
+ * <p>レコード未存在=デフォルト全 true、upsert の永続化、必須フラグ欠如=400、テナント別スコープ(ADR-0010)、認可を検証する。
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@Import({TestcontainersConfiguration.class, MockJwtDecoderConfiguration.class})
+class NotificationSettingsIT {
+
+  private static final String PATH = "/api/users/me/notification-settings";
+
+  @Autowired MockMvc mockMvc;
+  @Autowired EntityManager em;
+  @Autowired TransactionTemplate txTemplate;
+
+  private Long tenantAId;
+  private Long tenantBId;
+  private Long memberUserId;
+  private Long saasAdminUserId;
+
+  private TasksAuthenticationToken memberToken;
+  private TasksAuthenticationToken saasAdminToken;
+
+  @BeforeEach
+  void setUp() {
+    txTemplate.execute(
+        ignored -> {
+          var member = new UserJpaEntity("sub-nsm", "nsm@example.com", "通知ユーザー", "ツウチ", null);
+          var saasAdmin = new UserJpaEntity("sub-nss", "nss@example.com", "SaaS管理者", "サース", null);
+          em.persist(member);
+          em.persist(saasAdmin);
+          em.flush();
+          memberUserId = member.getId();
+          saasAdminUserId = saasAdmin.getId();
+
+          var tenantA = new TenantJpaEntity("NS-A", "通知テナントA");
+          var tenantB = new TenantJpaEntity("NS-B", "通知テナントB");
+          em.persist(tenantA);
+          em.persist(tenantB);
+          em.flush();
+          tenantAId = tenantA.getId();
+          tenantBId = tenantB.getId();
+
+          // member は両テナントの ACTIVE メンバー
+          insertMembership(memberUserId, tenantAId);
+          insertMembership(memberUserId, tenantBId);
+
+          return null;
+        });
+
+    SecurityContextHolder.clearContext();
+    memberToken =
+        new TasksAuthenticationToken(
+            new TasksPrincipal(memberUserId, "sub-nsm", "nsm@example.com", "通知ユーザー", "ツウチ", null),
+            List.of());
+    saasAdminToken =
+        new TasksAuthenticationToken(
+            new TasksPrincipal(
+                saasAdminUserId, "sub-nss", "nss@example.com", "SaaS管理者", "サース", null),
+            List.of(new SimpleGrantedAuthority("ROLE_APP_ADMIN")));
+  }
+
+  @AfterEach
+  void tearDown() {
+    SecurityContextHolder.clearContext();
+    if (tenantAId == null) {
+      return;
+    }
+    txTemplate.execute(
+        ignored -> {
+          em.createNativeQuery("DELETE FROM user_notification_settings WHERE tenant_id IN (?,?)")
+              .setParameter(1, tenantAId)
+              .setParameter(2, tenantBId)
+              .executeUpdate();
+          em.createNativeQuery("DELETE FROM user_tenants WHERE tenant_id IN (?,?)")
+              .setParameter(1, tenantAId)
+              .setParameter(2, tenantBId)
+              .executeUpdate();
+          em.createNativeQuery("DELETE FROM tenants WHERE id IN (?,?)")
+              .setParameter(1, tenantAId)
+              .setParameter(2, tenantBId)
+              .executeUpdate();
+          em.createNativeQuery("DELETE FROM users WHERE id IN (?,?)")
+              .setParameter(1, memberUserId)
+              .setParameter(2, saasAdminUserId)
+              .executeUpdate();
+          return null;
+        });
+  }
+
+  @Test
+  void get_returnsDefaultsWhenNoRecord() throws Exception {
+    mockMvc
+        .perform(
+            get(PATH)
+                .header("X-Tenant-Id", String.valueOf(tenantAId))
+                .with(authentication(memberToken)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.emailDueToday").value(true))
+        .andExpect(jsonPath("$.emailOverdue").value(true))
+        .andExpect(jsonPath("$.emailStakeholder").value(true))
+        // レコード未存在のため updatedAt は省略
+        .andExpect(jsonPath("$.updatedAt").doesNotExist());
+  }
+
+  @Test
+  void put_thenGet_persistsValues() throws Exception {
+    mockMvc
+        .perform(
+            put(PATH)
+                .header("X-Tenant-Id", String.valueOf(tenantAId))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    "{\"emailDueToday\":false,\"emailOverdue\":true,\"emailStakeholder\":false}")
+                .with(authentication(memberToken)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.emailDueToday").value(false))
+        .andExpect(jsonPath("$.emailOverdue").value(true))
+        .andExpect(jsonPath("$.emailStakeholder").value(false))
+        .andExpect(jsonPath("$.updatedAt").exists());
+
+    mockMvc
+        .perform(
+            get(PATH)
+                .header("X-Tenant-Id", String.valueOf(tenantAId))
+                .with(authentication(memberToken)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.emailDueToday").value(false))
+        .andExpect(jsonPath("$.emailOverdue").value(true))
+        .andExpect(jsonPath("$.emailStakeholder").value(false))
+        .andExpect(jsonPath("$.updatedAt").exists());
+  }
+
+  @Test
+  void put_missingField_returns400() throws Exception {
+    mockMvc
+        .perform(
+            put(PATH)
+                .header("X-Tenant-Id", String.valueOf(tenantAId))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"emailDueToday\":true,\"emailOverdue\":true}")
+                .with(authentication(memberToken)))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("E_VALIDATION"));
+  }
+
+  @Test
+  void settingsAreScopedPerTenant() throws Exception {
+    // テナント A で全 false に更新
+    mockMvc
+        .perform(
+            put(PATH)
+                .header("X-Tenant-Id", String.valueOf(tenantAId))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    "{\"emailDueToday\":false,\"emailOverdue\":false,\"emailStakeholder\":false}")
+                .with(authentication(memberToken)))
+        .andExpect(status().isOk());
+
+    // テナント B には影響しない(デフォルト全 true)
+    mockMvc
+        .perform(
+            get(PATH)
+                .header("X-Tenant-Id", String.valueOf(tenantBId))
+                .with(authentication(memberToken)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.emailDueToday").value(true))
+        .andExpect(jsonPath("$.emailOverdue").value(true))
+        .andExpect(jsonPath("$.emailStakeholder").value(true))
+        .andExpect(jsonPath("$.updatedAt").doesNotExist());
+  }
+
+  @Test
+  void saasAdmin_isForbidden() throws Exception {
+    mockMvc
+        .perform(
+            get(PATH)
+                .header("X-Tenant-Id", String.valueOf(tenantAId))
+                .with(authentication(saasAdminToken)))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  void unauthenticated_returns401() throws Exception {
+    mockMvc
+        .perform(get(PATH).header("X-Tenant-Id", String.valueOf(tenantAId)))
+        .andExpect(status().isUnauthorized());
+  }
+
+  // --- helpers ---
+
+  private void insertMembership(Long userId, Long tenantId) {
+    em.createNativeQuery(
+            "INSERT INTO user_tenants (user_id, tenant_id, role, status, joined_at)"
+                + " VALUES (?,?,?,?,?)")
+        .setParameter(1, userId)
+        .setParameter(2, tenantId)
+        .setParameter(3, "MEMBER")
+        .setParameter(4, "ACTIVE")
+        .setParameter(5, LocalDateTime.of(2026, 1, 1, 0, 0))
+        .executeUpdate();
+  }
+}

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/SecurityConfigTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/SecurityConfigTest.java
@@ -39,6 +39,8 @@ import xyz.dgz48.tasks.webapi.audit.usecase.ListAuditLogsUseCase;
 import xyz.dgz48.tasks.webapi.dashboard.usecase.GetDashboardSummaryUseCase;
 import xyz.dgz48.tasks.webapi.dashboard.usecase.GetDashboardTasksUseCase;
 import xyz.dgz48.tasks.webapi.dashboard.usecase.GetTenantDashboardSummaryUseCase;
+import xyz.dgz48.tasks.webapi.notification.usecase.GetNotificationSettingsUseCase;
+import xyz.dgz48.tasks.webapi.notification.usecase.UpdateNotificationSettingsUseCase;
 import xyz.dgz48.tasks.webapi.security.adapter.persistence.AppAdminUserRepository;
 import xyz.dgz48.tasks.webapi.security.usecase.GetMeUseCase;
 import xyz.dgz48.tasks.webapi.security.usecase.LogoutUseCase;
@@ -113,6 +115,8 @@ class SecurityConfigTest {
   @MockitoBean GetTenantDashboardSummaryUseCase getTenantDashboardSummaryUseCase;
   @MockitoBean CreateTenantUseCase createTenantUseCase;
   @MockitoBean ListAuditLogsUseCase listAuditLogsUseCase;
+  @MockitoBean GetNotificationSettingsUseCase getNotificationSettingsUseCase;
+  @MockitoBean UpdateNotificationSettingsUseCase updateNotificationSettingsUseCase;
 
   @Autowired MockMvc mockMvc;
 

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/TenantContextFilterTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/TenantContextFilterTest.java
@@ -27,6 +27,8 @@ import xyz.dgz48.tasks.webapi.audit.usecase.ListAuditLogsUseCase;
 import xyz.dgz48.tasks.webapi.dashboard.usecase.GetDashboardSummaryUseCase;
 import xyz.dgz48.tasks.webapi.dashboard.usecase.GetDashboardTasksUseCase;
 import xyz.dgz48.tasks.webapi.dashboard.usecase.GetTenantDashboardSummaryUseCase;
+import xyz.dgz48.tasks.webapi.notification.usecase.GetNotificationSettingsUseCase;
+import xyz.dgz48.tasks.webapi.notification.usecase.UpdateNotificationSettingsUseCase;
 import xyz.dgz48.tasks.webapi.security.adapter.persistence.AppAdminUserRepository;
 import xyz.dgz48.tasks.webapi.security.usecase.GetMeUseCase;
 import xyz.dgz48.tasks.webapi.security.usecase.LogoutUseCase;
@@ -128,6 +130,8 @@ class TenantContextFilterTest {
   @MockitoBean GetTenantDashboardSummaryUseCase getTenantDashboardSummaryUseCase;
   @MockitoBean CreateTenantUseCase createTenantUseCase;
   @MockitoBean ListAuditLogsUseCase listAuditLogsUseCase;
+  @MockitoBean GetNotificationSettingsUseCase getNotificationSettingsUseCase;
+  @MockitoBean UpdateNotificationSettingsUseCase updateNotificationSettingsUseCase;
 
   @Autowired MockMvc mockMvc;
 


### PR DESCRIPTION
## 概要

A-23(取得)/ A-24(更新)の通知設定 API と通知設定画面 S-10 を実装する。同一リソース・同一画面のため縦切り 1 件。トラッカー #780 の 4 件目。

Closes #778

## 実装内容

### バックエンド (A-23 / A-24)
- **`NotificationSettingsController`**(GET/PUT)/ **`GetNotificationSettingsUseCase`** / **`UpdateNotificationSettingsUseCase`** — `hasAnyRole('TENANT_ADMIN','MEMBER')`(SaaS Admin は 403)。`X-Tenant-Id` 必須(現テナントスコープ)。ログイン中ユーザー自身の設定を扱う。
- **デフォルト** — レコード未存在時は全フラグ `true` を返す(`NotificationSettings.defaults()`)。`updatedAt` は未存在時 `null` → JSON から省略(`@JsonInclude(NON_NULL)`。スキーマ上 nullable でないため null を送らない)。
- **PUT は upsert** — 既存行は更新、無ければ新規作成。`updated_at` はサーバ時刻(JST、ADR-0009)。3 フラグは必須(欠如時 400 `E_VALIDATION`)。
- **テナント分離** — `user_notification_settings` は `TenantFilteredEntity` 継承で Hibernate Filter(ADR-0010)が SELECT に `tenant_id` を自動付与。複合主キー (user_id, tenant_id)。`HibernateFilterEntityAuditTest` も green。

### フロントエンド (S-10)
- `notification-settings.html` / `notification-settings.js` を追加(3 トグルスイッチ + 保存、保存成功表示)。サイドバー「通知設定」導線(`tasks.html` / `tenant-dashboard.html`)を当ページへ配線。

## テスト
- `NotificationSettingsIT`(Testcontainers): デフォルト全 true(レコード未存在)、PUT→GET の永続化、必須フラグ欠如=400、**テナント別スコープ**(テナント A の更新がテナント B に影響しない)、SaaS Admin=403、未認証=401。
- `SecurityConfigTest` / `TenantContextFilterTest` に新 usecase モックを追加。

`./gradlew :webapi:check`(spotless / JaCoCo 0.80 / 全 IT)green、`web/` の biome・html-validate・tsc も green。OpenAPI `NotificationSettings`(GET/PUT)契約と一致。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
