### PR TITLE
feat(user): プロフィール取得 GET /api/users/me + S-09 (Closes #779)

### DIFF
--- a/web/js/api.js
+++ b/web/js/api.js
@@ -110,6 +110,15 @@
  */
 
 /**
+ * @typedef {object} UserProfile
+ * @property {number} id
+ * @property {string} email
+ * @property {string} fullName
+ * @property {string} fullNameKana
+ * @property {string|null} [departmentName]
+ */
+
+/**
  * @typedef {object} NotificationSettings
  * @property {boolean} emailDueToday
  * @property {boolean} emailOverdue
@@ -371,6 +380,14 @@ const Api = (() => {
   }
 
   /**
+   * GET /api/users/me — 自身のプロフィール取得(A-07、S-09)。テナント選択状態に依存しない。
+   * @returns {Promise<UserProfile>}
+   */
+  function getMyProfile() {
+    return request('/api/users/me');
+  }
+
+  /**
    * GET /api/users/me/notification-settings — 通知設定取得(A-23、S-10、現テナント)。
    * @returns {Promise<NotificationSettings>}
    */
@@ -491,6 +508,7 @@ const Api = (() => {
     changeVisibility,
     listTenantUsers,
     getTenantDashboardSummary,
+    getMyProfile,
     getNotificationSettings,
     updateNotificationSettings,
     listStakeholders,

--- a/web/js/profile.js
+++ b/web/js/profile.js
@@ -1,0 +1,74 @@
+// @ts-check
+
+/** @type {HTMLElement} */ (mustQuery(document, '#btn-logout')).addEventListener('click', () =>
+  Auth.logout(),
+);
+
+/**
+ * @param {string} message
+ */
+function showError(message) {
+  /** @type {HTMLElement} */ (mustQuery(document, '#loading')).classList.add('d-none');
+  const el = /** @type {HTMLElement} */ (mustQuery(document, '#error-alert'));
+  el.textContent = message;
+  el.classList.remove('d-none');
+}
+
+/**
+ * @param {string} id
+ * @param {string} value
+ */
+function setField(id, value) {
+  /** @type {HTMLElement} */ (mustQuery(document, id)).textContent = value;
+}
+
+/**
+ * @param {UserProfile} profile
+ */
+function render(profile) {
+  setField('#pf-full-name', profile.fullName);
+  setField('#pf-full-name-kana', profile.fullNameKana);
+  setField('#pf-email', profile.email);
+  setField('#pf-department', profile.departmentName || '—');
+
+  /** @type {HTMLElement} */ (mustQuery(document, '#loading')).classList.add('d-none');
+  /** @type {HTMLElement} */ (mustQuery(document, '#profile-card')).classList.remove('d-none');
+}
+
+async function main() {
+  const authenticated = await Auth.init();
+  if (!authenticated) {
+    return;
+  }
+
+  const user = Auth.getUser();
+  const displayName = user?.name || user?.preferred_username || '';
+  /** @type {HTMLElement} */ (mustQuery(document, '#nav-username')).textContent = displayName;
+  /** @type {HTMLElement} */ (mustQuery(document, '#user-avatar')).textContent =
+    displayName.slice(0, 1) || '?';
+
+  // テナントスイッチャ / 管理者サイドバーの表示用に所属テナントを取得(失敗してもプロフィール表示は継続)。
+  try {
+    const me = await Api.getMe();
+    const activeTenantId = Api.resolveActiveTenant(me.tenants);
+    /** @type {AppTenantSwitcherElement} */ (mustQuery(document, '#tenant-switcher')).setData(
+      me.tenants,
+      activeTenantId,
+    );
+    const activeTenant = me.tenants?.find((t) => t.id === activeTenantId);
+    if (activeTenant?.role === 'TENANT_ADMIN') {
+      document.body.classList.add('role-admin');
+    }
+  } catch {
+    // テナント情報の取得失敗はプロフィール表示の妨げにしない。
+  }
+
+  try {
+    const profile = await Api.getMyProfile();
+    render(profile);
+  } catch (err) {
+    showError(`プロフィールの取得に失敗しました: ${/** @type {any} */ (err).message}`);
+  }
+}
+
+main();

--- a/web/notification-settings.html
+++ b/web/notification-settings.html
@@ -53,7 +53,7 @@
       </a>
     </div>
     <div class="nav-group-label" aria-hidden="true">アカウント</div>
-    <a class="side-link" href="#"><i class="bi bi-person-circle" aria-hidden="true"></i>プロフィール</a>
+    <a class="side-link" href="profile.html"><i class="bi bi-person-circle" aria-hidden="true"></i>プロフィール</a>
     <a class="side-link active" href="notification-settings.html" aria-current="page">
       <i class="bi bi-bell" aria-hidden="true"></i>通知設定
     </a>

--- a/web/package.json
+++ b/web/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "copy-vendor": "node scripts/copy-vendor.js",
-    "html-validate": "html-validate index.html tasks.html tenants-new.html tenant-dashboard.html notification-settings.html",
+    "html-validate": "html-validate index.html tasks.html tenants-new.html tenant-dashboard.html notification-settings.html profile.html",
     "serve": "node serve.mjs"
   },
   "engines": {

--- a/web/profile.html
+++ b/web/profile.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>運営者ダッシュボード — Tasks</title>
+  <title>プロフィール — Tasks</title>
   <link rel="icon" type="image/svg+xml" href="/favicon.svg">
   <link rel="stylesheet" href="vendor/bootstrap/css/bootstrap.min.css">
   <link rel="stylesheet" href="vendor/bootstrap-icons/bootstrap-icons.min.css">
@@ -45,7 +45,7 @@
     </a>
     <div class="admin-only">
       <div class="nav-group-label" aria-hidden="true">テナント運営</div>
-      <a class="side-link active" href="tenant-dashboard.html" aria-current="page">
+      <a class="side-link" href="tenant-dashboard.html">
         <i class="bi bi-graph-up-arrow" aria-hidden="true"></i>運営者ダッシュボード
       </a>
       <a class="side-link" href="#">
@@ -53,19 +53,19 @@
       </a>
     </div>
     <div class="nav-group-label" aria-hidden="true">アカウント</div>
-    <a class="side-link" href="profile.html"><i class="bi bi-person-circle" aria-hidden="true"></i>プロフィール</a>
-    <a class="side-link" href="notification-settings.html"><i class="bi bi-bell" aria-hidden="true"></i>通知設定</a>
+    <a class="side-link active" href="profile.html" aria-current="page">
+      <i class="bi bi-person-circle" aria-hidden="true"></i>プロフィール
+    </a>
+    <a class="side-link" href="notification-settings.html">
+      <i class="bi bi-bell" aria-hidden="true"></i>通知設定
+    </a>
   </aside>
 
   <!-- ===== Main ===== -->
   <main id="main-content" class="app-main">
     <div class="d-flex align-items-center flex-wrap gap-3 mb-3">
-      <h1 class="page-title">運営者ダッシュボード</h1>
+      <h1 class="page-title">プロフィール</h1>
     </div>
-    <p class="text-muted small mb-3">
-      テナント全体で共有(TENANT)または関係者限定(STAKEHOLDERS)で動いている業務量の集計です。
-      PRIVATE タスクは集計に含まれません。
-    </p>
 
     <div id="error-alert" class="alert alert-danger d-none" role="alert"></div>
 
@@ -73,74 +73,23 @@
       <div class="spinner-border text-primary" role="status">
         <span class="visually-hidden">Loading...</span>
       </div>
-      <p class="mt-2 text-muted">集計を取得中...</p>
+      <p class="mt-2 text-muted">プロフィールを取得中...</p>
     </div>
 
-    <div id="summary" class="d-none">
-      <!-- 数値カード -->
-      <div class="row row-cols-2 row-cols-md-3 row-cols-xl-5 g-3 mb-4">
-        <div class="col">
-          <div class="card h-100">
-            <div class="card-body">
-              <div class="text-muted small">総タスク数</div>
-              <div id="card-total" class="fs-3 fw-semibold">—</div>
-            </div>
-          </div>
-        </div>
-        <div class="col">
-          <div class="card h-100">
-            <div class="card-body">
-              <div class="text-muted small">当日期限</div>
-              <div id="card-today-due" class="fs-3 fw-semibold">—</div>
-            </div>
-          </div>
-        </div>
-        <div class="col">
-          <div class="card h-100">
-            <div class="card-body">
-              <div class="text-muted small">期限切れ</div>
-              <div id="card-overdue" class="fs-3 fw-semibold text-danger">—</div>
-            </div>
-          </div>
-        </div>
-        <div class="col">
-          <div class="card h-100">
-            <div class="card-body">
-              <div class="text-muted small">本日完了</div>
-              <div id="card-completed-today" class="fs-3 fw-semibold text-success">—</div>
-            </div>
-          </div>
-        </div>
-        <div class="col">
-          <div class="card h-100">
-            <div class="card-body">
-              <div class="text-muted small">メンバー数</div>
-              <div id="card-members" class="fs-3 fw-semibold">—</div>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <!-- ブレークダウン -->
-      <div class="row g-3">
-        <div class="col-12 col-lg-6">
-          <div class="card h-100">
-            <div class="card-body">
-              <h2 class="h6 card-title">ステータス別件数</h2>
-              <table class="table table-sm mb-0">
-                <tbody id="status-breakdown"></tbody>
-              </table>
-            </div>
-          </div>
-        </div>
-        <div class="col-12 col-lg-6">
-          <div class="card h-100">
-            <div class="card-body">
-              <h2 class="h6 card-title">優先度別件数</h2>
-              <table class="table table-sm mb-0">
-                <tbody id="priority-breakdown"></tbody>
-              </table>
-            </div>
+    <div class="row justify-content-center">
+      <div class="col-12 col-md-9 col-lg-7">
+        <div id="profile-card" class="card d-none">
+          <div class="card-body">
+            <dl class="row mb-0">
+              <dt class="col-sm-4 text-muted">氏名</dt>
+              <dd id="pf-full-name" class="col-sm-8"></dd>
+              <dt class="col-sm-4 text-muted">フリガナ</dt>
+              <dd id="pf-full-name-kana" class="col-sm-8"></dd>
+              <dt class="col-sm-4 text-muted">メールアドレス</dt>
+              <dd id="pf-email" class="col-sm-8"></dd>
+              <dt class="col-sm-4 text-muted">部署</dt>
+              <dd id="pf-department" class="col-sm-8"></dd>
+            </dl>
           </div>
         </div>
       </div>
@@ -153,8 +102,7 @@
 <script src="js/dom.js"></script>
 <script src="js/auth.js"></script>
 <script src="js/api.js"></script>
-<script src="js/meta.js"></script>
 <script src="js/components/app-tenant-switcher.js"></script>
-<script src="js/tenant-dashboard.js"></script>
+<script src="js/profile.js"></script>
 </body>
 </html>

--- a/web/tasks.html
+++ b/web/tasks.html
@@ -53,7 +53,7 @@
       </a>
     </div>
     <div class="nav-group-label" aria-hidden="true">アカウント</div>
-    <a class="side-link" href="#"><i class="bi bi-person-circle" aria-hidden="true"></i>プロフィール</a>
+    <a class="side-link" href="profile.html"><i class="bi bi-person-circle" aria-hidden="true"></i>プロフィール</a>
     <a class="side-link" href="notification-settings.html"><i class="bi bi-bell" aria-hidden="true"></i>通知設定</a>
   </aside>
 

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/security/adapter/web/TenantContextFilter.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/security/adapter/web/TenantContextFilter.java
@@ -123,13 +123,16 @@ public class TenantContextFilter extends OncePerRequestFilter {
    * 初期テナント自動解決を行わない免除パスか判定する。
    *
    * <p>/api/auth/** (me / select / logout)、/api/tenants/** (SaaS Admin)、/actuator/** はテナントコンテキスト不要。
+   * /api/users/me (A-07 プロフィール取得) もテナント選択非依存のため免除する。ただし完全一致のみ免除し、
+   * /api/users/me/notification-settings (S-10、テナントスコープ) は免除しない。
    */
   private static boolean isExemptPath(HttpServletRequest request) {
     String uri = request.getRequestURI();
     return uri.startsWith("/api/auth/")
         || uri.startsWith("/api/tenants")
         || uri.startsWith("/actuator/")
-        || uri.equals("/actuator");
+        || uri.equals("/actuator")
+        || uri.equals("/api/users/me");
   }
 
   private void writeErrorResponse(

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/adapter/persistence/UserProfilePersistenceAdapter.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/adapter/persistence/UserProfilePersistenceAdapter.java
@@ -1,0 +1,27 @@
+package xyz.dgz48.tasks.webapi.user.adapter.persistence;
+
+import io.micrometer.observation.annotation.Observed;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import xyz.dgz48.tasks.webapi.user.domain.UserProfile;
+import xyz.dgz48.tasks.webapi.user.usecase.UserProfilePort;
+
+/** {@link UserProfilePort} の JPA 実装。{@code users} を ID で読み取り {@link UserProfile} へ射影する。 */
+@Observed(name = "user.profile.repository")
+@Component
+@RequiredArgsConstructor
+class UserProfilePersistenceAdapter implements UserProfilePort {
+
+  private final UserRepository userRepository;
+
+  @Override
+  public Optional<UserProfile> findById(Long userId) {
+    return userRepository.findById(userId).map(UserProfilePersistenceAdapter::toProfile);
+  }
+
+  private static UserProfile toProfile(UserJpaEntity e) {
+    return new UserProfile(
+        e.getId(), e.getEmail(), e.getFullName(), e.getFullNameKana(), e.getDepartmentName());
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/adapter/web/UserProfileController.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/adapter/web/UserProfileController.java
@@ -1,0 +1,29 @@
+package xyz.dgz48.tasks.webapi.user.adapter.web;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import xyz.dgz48.tasks.webapi.user.adapter.web.dto.UserProfileResponse;
+import xyz.dgz48.tasks.webapi.user.usecase.GetMyProfileUseCase;
+
+/**
+ * プロフィール API(A-07、S-09)。
+ *
+ * <p>{@code GET /api/users/me} はログイン中ユーザー自身のプロフィールを返す。テナント選択状態に依存しない({@code X-Tenant-Id} 不要、{@code
+ * TenantContextFilter} の免除パス)ため、テナント未所属・未選択でも参照できる。認証済みであれば全ロールで利用可。 所属テナント情報を含む {@code
+ * /api/auth/me} とは用途が異なる。
+ */
+@RestController
+@RequiredArgsConstructor
+public class UserProfileController {
+
+  private final GetMyProfileUseCase getMyProfileUseCase;
+
+  @GetMapping("/api/users/me")
+  public ResponseEntity<UserProfileResponse> getMyProfile(
+      @AuthenticationPrincipal(expression = "id") Long userId) {
+    return ResponseEntity.ok(UserProfileResponse.from(getMyProfileUseCase.execute(userId)));
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/adapter/web/dto/UserProfileResponse.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/adapter/web/dto/UserProfileResponse.java
@@ -1,0 +1,18 @@
+package xyz.dgz48.tasks.webapi.user.adapter.web.dto;
+
+import org.jspecify.annotations.Nullable;
+import xyz.dgz48.tasks.webapi.user.domain.UserProfile;
+
+/** OpenAPI {@code UserProfile} に対応するプロフィールレスポンス(A-07、S-09)。 */
+public record UserProfileResponse(
+    Long id, String email, String fullName, String fullNameKana, @Nullable String departmentName) {
+
+  public static UserProfileResponse from(UserProfile profile) {
+    return new UserProfileResponse(
+        profile.id(),
+        profile.email(),
+        profile.fullName(),
+        profile.fullNameKana(),
+        profile.departmentName());
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/adapter/web/dto/package-info.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/adapter/web/dto/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package xyz.dgz48.tasks.webapi.user.adapter.web.dto;
+
+import org.jspecify.annotations.NullMarked;

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/domain/UserProfile.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/domain/UserProfile.java
@@ -1,0 +1,11 @@
+package xyz.dgz48.tasks.webapi.user.domain;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * ログイン中ユーザー自身のプロフィール(A-07、S-09)。{@code users} テーブルの公開項目に対応(OpenAPI {@code UserProfile})。
+ *
+ * <p>テナント選択状態に依存しない。所属テナント情報を含む {@code /api/auth/me}(MeResponse)とは用途が異なる。
+ */
+public record UserProfile(
+    Long id, String email, String fullName, String fullNameKana, @Nullable String departmentName) {}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/usecase/GetMyProfileUseCase.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/usecase/GetMyProfileUseCase.java
@@ -1,0 +1,28 @@
+package xyz.dgz48.tasks.webapi.user.usecase;
+
+import io.micrometer.observation.annotation.Observed;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import xyz.dgz48.tasks.webapi.user.domain.UserProfile;
+
+/**
+ * プロフィール取得(A-07、operationId: getMyProfile)のユースケース。
+ *
+ * <p>ログイン中ユーザー自身のプロフィールを {@code users} から取得する。テナント選択状態に依存しない。認証済みユーザーは必ず {@code users}
+ * 行を持つ(ログイン時に作成・更新)ため、未存在は不変条件違反として例外とする。
+ */
+@Service
+@RequiredArgsConstructor
+public class GetMyProfileUseCase {
+
+  private final UserProfilePort userProfilePort;
+
+  @Observed(name = "user.profile.get")
+  @Transactional(readOnly = true)
+  public UserProfile execute(Long userId) {
+    return userProfilePort
+        .findById(userId)
+        .orElseThrow(() -> new IllegalStateException("認証済みユーザーのプロフィールが見つかりません: userId=" + userId));
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/usecase/UserProfilePort.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/usecase/UserProfilePort.java
@@ -1,0 +1,15 @@
+package xyz.dgz48.tasks.webapi.user.usecase;
+
+import java.util.Optional;
+import xyz.dgz48.tasks.webapi.user.domain.UserProfile;
+
+/**
+ * プロフィール取得ポート(クリーンアーキの out port)。
+ *
+ * <p>実装は adapter.persistence。{@code users} はプラットフォーム横断(テナント分離対象外)テーブルのため、{@code id} での単純読取とする。
+ */
+public interface UserProfilePort {
+
+  /** ユーザー ID でプロフィールを取得する(未存在なら空)。 */
+  Optional<UserProfile> findById(Long userId);
+}

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/SecurityConfigTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/SecurityConfigTest.java
@@ -71,6 +71,7 @@ import xyz.dgz48.tasks.webapi.tenant.usecase.UpdateTenantUseCase;
 import xyz.dgz48.tasks.webapi.tenant.usecase.UserTenantsResolverService;
 import xyz.dgz48.tasks.webapi.user.adapter.persistence.UserJpaEntity;
 import xyz.dgz48.tasks.webapi.user.adapter.persistence.UserRepository;
+import xyz.dgz48.tasks.webapi.user.usecase.GetMyProfileUseCase;
 
 @WebMvcTest
 @Import({
@@ -117,6 +118,7 @@ class SecurityConfigTest {
   @MockitoBean ListAuditLogsUseCase listAuditLogsUseCase;
   @MockitoBean GetNotificationSettingsUseCase getNotificationSettingsUseCase;
   @MockitoBean UpdateNotificationSettingsUseCase updateNotificationSettingsUseCase;
+  @MockitoBean GetMyProfileUseCase getMyProfileUseCase;
 
   @Autowired MockMvc mockMvc;
 

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/TenantContextFilterTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/TenantContextFilterTest.java
@@ -59,6 +59,7 @@ import xyz.dgz48.tasks.webapi.tenant.usecase.UpdateTenantStatusUseCase;
 import xyz.dgz48.tasks.webapi.tenant.usecase.UpdateTenantUseCase;
 import xyz.dgz48.tasks.webapi.tenant.usecase.UserTenantsResolverService;
 import xyz.dgz48.tasks.webapi.user.adapter.persistence.UserRepository;
+import xyz.dgz48.tasks.webapi.user.usecase.GetMyProfileUseCase;
 
 @WebMvcTest
 @Import({
@@ -132,6 +133,7 @@ class TenantContextFilterTest {
   @MockitoBean ListAuditLogsUseCase listAuditLogsUseCase;
   @MockitoBean GetNotificationSettingsUseCase getNotificationSettingsUseCase;
   @MockitoBean UpdateNotificationSettingsUseCase updateNotificationSettingsUseCase;
+  @MockitoBean GetMyProfileUseCase getMyProfileUseCase;
 
   @Autowired MockMvc mockMvc;
 

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/user/adapter/web/UserProfileIT.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/user/adapter/web/UserProfileIT.java
@@ -1,0 +1,163 @@
+package xyz.dgz48.tasks.webapi.user.adapter.web;
+
+import static org.hamcrest.Matchers.nullValue;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import jakarta.persistence.EntityManager;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.support.TransactionTemplate;
+import xyz.dgz48.tasks.webapi.MockJwtDecoderConfiguration;
+import xyz.dgz48.tasks.webapi.TestcontainersConfiguration;
+import xyz.dgz48.tasks.webapi.security.adapter.web.TasksAuthenticationToken;
+import xyz.dgz48.tasks.webapi.security.domain.TasksPrincipal;
+import xyz.dgz48.tasks.webapi.tenant.adapter.persistence.TenantJpaEntity;
+import xyz.dgz48.tasks.webapi.user.adapter.persistence.UserJpaEntity;
+
+/**
+ * プロフィール取得 API(A-07、GET /api/users/me、S-09)の統合テスト。
+ *
+ * <p>テナント選択状態に依存しないこと(X-Tenant-Id なし・テナント未所属でも 200)、{@code users} の値を返すこと、認可(認証必須)を検証する。
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@Import({TestcontainersConfiguration.class, MockJwtDecoderConfiguration.class})
+class UserProfileIT {
+
+  private static final String PATH = "/api/users/me";
+
+  @Autowired MockMvc mockMvc;
+  @Autowired EntityManager em;
+  @Autowired TransactionTemplate txTemplate;
+
+  private Long tenantId;
+  private Long memberUserId;
+  private Long tenantlessUserId;
+
+  private TasksAuthenticationToken memberToken;
+  private TasksAuthenticationToken tenantlessToken;
+
+  @BeforeEach
+  void setUp() {
+    txTemplate.execute(
+        ignored -> {
+          var member = new UserJpaEntity("sub-upm", "upm@example.com", "山田太郎", "ヤマダタロウ", "営業部");
+          var tenantless = new UserJpaEntity("sub-upt", "upt@example.com", "鈴木花子", "スズキハナコ", null);
+          em.persist(member);
+          em.persist(tenantless);
+          em.flush();
+          memberUserId = member.getId();
+          tenantlessUserId = tenantless.getId();
+
+          var tenant = new TenantJpaEntity("UP-1", "プロフィールテナント");
+          em.persist(tenant);
+          em.flush();
+          tenantId = tenant.getId();
+
+          insertMembership(memberUserId, tenantId);
+          // tenantless は意図的にどのテナントにも所属させない
+
+          return null;
+        });
+
+    SecurityContextHolder.clearContext();
+    memberToken =
+        new TasksAuthenticationToken(
+            new TasksPrincipal(memberUserId, "sub-upm", "upm@example.com", "山田太郎", "ヤマダタロウ", "営業部"),
+            List.of());
+    tenantlessToken =
+        new TasksAuthenticationToken(
+            new TasksPrincipal(
+                tenantlessUserId, "sub-upt", "upt@example.com", "鈴木花子", "スズキハナコ", null),
+            List.of());
+  }
+
+  @AfterEach
+  void tearDown() {
+    SecurityContextHolder.clearContext();
+    if (tenantId == null) {
+      return;
+    }
+    txTemplate.execute(
+        ignored -> {
+          em.createNativeQuery("DELETE FROM user_tenants WHERE tenant_id = ?")
+              .setParameter(1, tenantId)
+              .executeUpdate();
+          em.createNativeQuery("DELETE FROM tenants WHERE id = ?")
+              .setParameter(1, tenantId)
+              .executeUpdate();
+          em.createNativeQuery("DELETE FROM users WHERE id IN (?,?)")
+              .setParameter(1, memberUserId)
+              .setParameter(2, tenantlessUserId)
+              .executeUpdate();
+          return null;
+        });
+  }
+
+  @Test
+  void returnsProfileFromUsersTable_withoutTenantHeader() throws Exception {
+    mockMvc
+        .perform(get(PATH).with(authentication(memberToken)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(memberUserId))
+        .andExpect(jsonPath("$.email").value("upm@example.com"))
+        .andExpect(jsonPath("$.fullName").value("山田太郎"))
+        .andExpect(jsonPath("$.fullNameKana").value("ヤマダタロウ"))
+        .andExpect(jsonPath("$.departmentName").value("営業部"));
+  }
+
+  @Test
+  void returnsProfileForTenantlessUser() throws Exception {
+    // どのテナントにも所属しないユーザーでも、X-Tenant-Id なしで自身のプロフィールを取得できる(テナント非依存)。
+    mockMvc
+        .perform(get(PATH).with(authentication(tenantlessToken)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(tenantlessUserId))
+        .andExpect(jsonPath("$.email").value("upt@example.com"))
+        .andExpect(jsonPath("$.fullName").value("鈴木花子"))
+        .andExpect(jsonPath("$.departmentName").value(nullValue()));
+  }
+
+  @Test
+  void returnsProfile_withTenantHeader() throws Exception {
+    // X-Tenant-Id を付与してもメンバーであれば 200。
+    mockMvc
+        .perform(
+            get(PATH)
+                .header("X-Tenant-Id", String.valueOf(tenantId))
+                .with(authentication(memberToken)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(memberUserId));
+  }
+
+  @Test
+  void unauthenticated_returns401() throws Exception {
+    mockMvc.perform(get(PATH)).andExpect(status().isUnauthorized());
+  }
+
+  // --- helpers ---
+
+  private void insertMembership(Long userId, Long tid) {
+    em.createNativeQuery(
+            "INSERT INTO user_tenants (user_id, tenant_id, role, status, joined_at)"
+                + " VALUES (?,?,?,?,?)")
+        .setParameter(1, userId)
+        .setParameter(2, tid)
+        .setParameter(3, "MEMBER")
+        .setParameter(4, "ACTIVE")
+        .setParameter(5, LocalDateTime.of(2026, 1, 1, 0, 0))
+        .executeUpdate();
+  }
+}


### PR DESCRIPTION
## 概要

A-07 プロフィール取得 API (`GET /api/users/me`、operationId `getMyProfile`) とプロフィール画面 S-09 を実装する。トラッカー #780 の最後の課題。

Closes #779

## 実装内容

### バックエンド (A-07)
- **`GetMyProfileUseCase`** / **`UserProfileController`** — ログイン中ユーザー自身のプロフィールを `users` テーブルから読み取って返す。**テナント選択状態に依存しない**。所属テナント情報を含む `/api/auth/me`(MeResponse)とは別用途・別スキーマ(`UserProfile`)。
- **`TenantContextFilter` の免除パスに `/api/users/me` を完全一致で追加** — テナント未所属・未選択のユーザーでも 200。`/api/users/me/notification-settings`(S-10、テナントスコープ)は `equals` 判定のため免除されない。
- 認可は認証必須のみ(全ロール利用可、SaaS Admin / テナント未所属も自身のプロフィールは参照可)。認証済みユーザーは必ず `users` 行を持つため、未存在は不変条件違反として扱う。

### フロントエンド (S-09)
- `profile.html` / `profile.js`(氏名・フリガナ・メール・部署の読取専用表示)を追加。サイドバー「プロフィール」導線(`tasks.html` / `tenant-dashboard.html` / `notification-settings.html`)を当ページへ配線。

## テスト
- `UserProfileIT`(Testcontainers): `users` の値を返すこと、**X-Tenant-Id なし**で 200、**テナント未所属ユーザーでも 200**(テナント非依存)、X-Tenant-Id 付き(メンバー)でも 200、`departmentName` null、未認証=401。
- `SecurityConfigTest` / `TenantContextFilterTest` に新 usecase モックを追加。

`./gradlew :webapi:check`(spotless / JaCoCo 0.80 / 全 IT)green、`web/` の biome・html-validate・tsc も green。OpenAPI `getMyProfile` / `UserProfile` 契約と一致。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
