### PR TITLE
feat(tenant): A-09 招待発行フロー(invitations + SES、ADR-0017) (Closes #793)

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -426,7 +426,11 @@ paths:
     post:
       tags: [User]
       summary: ユーザー招待 (Tenant Admin)
-      description: "認可: Tenant Admin のみ。oidc_subが既存usersに登録済みの場合、user_tenants に紐付け"
+      description: |
+        認可: Tenant Admin のみ。テナントは `X-Tenant-Id` ヘッダ駆動(テナント暗黙)。
+        ADR-0017(自前招待トークン)準拠。登録状況に関わらず `invitations` 行を作成し、SES で受諾リンク付き招待メールを送信する(201)。
+        トークンは平文をメールにのみ載せ、DB には SHA-256 ハッシュのみを保存(有効期限 7 日・one-time)。
+        受諾(トークン消費)と `user_tenants` 紐付けは受諾画面フローで行う。
       operationId: inviteUser
       requestBody:
         required: true
@@ -440,8 +444,7 @@ paths:
         "403": { $ref: "#/components/responses/Forbidden" }
         "409":
           $ref: "#/components/responses/Conflict"
-          description: 招待対象が既に `user_tenants` に登録済み(重複招待)。
-        "422": { $ref: "#/components/responses/UnprocessableContent" }
+          description: 招待対象の email が既に `user_tenants` に登録済み(重複招待)。
 
   /api/tenant/users/{userId}:
     delete:

--- a/docs/specs/基本設計書.md
+++ b/docs/specs/基本設計書.md
@@ -898,9 +898,7 @@ Java 実装の戻り型と `@RestControllerAdvice` 構成は [ADR-0011](../adr/0
 
 #### 5.4.2 422 Unprocessable Content 返却シナリオ
 
-| API | シナリオ | code |
-|---|---|---|
-| POST /api/tenant/users/invite | 招待メールアドレスに対応する oidc_sub が users テーブルに未登録 | E_UNPROCESSABLE |
+業務固有の 422 シナリオは現状なし。A-09 招待は ADR-0017(自前招待トークン)に従い、招待対象の登録状況に関わらず `invitations` 行を作成して招待メールを送信するため、旧整理の「未登録 email = E_UNPROCESSABLE」は廃止した(重複招待は §5.4.1 の 409)。バリデーション不正(メール形式等)は §5.3 の `E_VALIDATION`(400)で扱う。
 
 ## 6. セキュリティ設計(NIST準拠)
 

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/notification/usecase/package-info.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/notification/usecase/package-info.java
@@ -1,4 +1,6 @@
 @NullMarked
+@NamedInterface
 package xyz.dgz48.tasks.webapi.notification.usecase;
 
 import org.jspecify.annotations.NullMarked;
+import org.springframework.modulith.NamedInterface;

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/adapter/external/InviteMailAdapter.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/adapter/external/InviteMailAdapter.java
@@ -1,0 +1,36 @@
+package xyz.dgz48.tasks.webapi.tenant.adapter.external;
+
+import lombok.RequiredArgsConstructor;
+import xyz.dgz48.tasks.webapi.notification.usecase.EmailSenderPort;
+import xyz.dgz48.tasks.webapi.tenant.usecase.InviteMailPort;
+
+/**
+ * {@link InviteMailPort} の実装。受諾リンク付き招待メールを {@link EmailSenderPort}(notification feature の SES /
+ * ログ実装)経由で送信する(ADR-0017)。
+ *
+ * <p>平文トークンはメール本文(受諾 URL)にのみ載せる。DB にはハッシュのみが保存される。
+ */
+@RequiredArgsConstructor
+public class InviteMailAdapter implements InviteMailPort {
+
+  private static final String SUBJECT = "【Tasks】テナントへの招待";
+
+  private final EmailSenderPort emailSenderPort;
+  private final String acceptUrlBase;
+
+  @Override
+  public void sendInvitation(String email, String tenantName, String rawToken) {
+    String acceptUrl = acceptUrlBase + "?token=" + rawToken;
+    String body =
+        """
+        %s への招待が届いています。
+
+        以下のリンクから招待を承諾してください(有効期限: 発行から7日間):
+        %s
+
+        このメールに心当たりがない場合は破棄してください。
+        """
+            .formatted(tenantName, acceptUrl);
+    emailSenderPort.send(email, SUBJECT, body);
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/adapter/external/package-info.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/adapter/external/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package xyz.dgz48.tasks.webapi.tenant.adapter.external;
+
+import org.jspecify.annotations.NullMarked;

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/adapter/persistence/InvitationJpaEntity.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/adapter/persistence/InvitationJpaEntity.java
@@ -1,0 +1,84 @@
+package xyz.dgz48.tasks.webapi.tenant.adapter.persistence;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.jspecify.annotations.Nullable;
+import xyz.dgz48.tasks.webapi.shared.adapter.persistence.TenantFilteredEntity;
+import xyz.dgz48.tasks.webapi.tenant.domain.InvitationStatus;
+import xyz.dgz48.tasks.webapi.tenant.domain.TenantRole;
+
+/** 招待(invitations)JPA エンティティ。業務テーブルのため Hibernate tenantFilter 対象(ADR-0010 / ADR-0017)。 */
+@Entity
+@Table(name = "invitations")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+class InvitationJpaEntity extends TenantFilteredEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(name = "tenant_id", nullable = false)
+  private Long tenantId;
+
+  @Column(nullable = false, length = 255)
+  private String email;
+
+  @Column(name = "token_hash", nullable = false, length = 64)
+  private String tokenHash;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false, columnDefinition = "ENUM('PENDING','USED','REVOKED')")
+  private InvitationStatus status;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false, columnDefinition = "ENUM('TENANT_ADMIN','MEMBER')")
+  private TenantRole role;
+
+  @Column(name = "expires_at", nullable = false)
+  private LocalDateTime expiresAt;
+
+  @Column(name = "invited_by", nullable = false)
+  private Long invitedBy;
+
+  @Column(name = "created_at", nullable = false)
+  private LocalDateTime createdAt;
+
+  @Nullable
+  @Column(name = "consumed_at")
+  private LocalDateTime consumedAt;
+
+  /** 新規 PENDING 招待を生成する。 */
+  InvitationJpaEntity(
+      Long tenantId,
+      String email,
+      String tokenHash,
+      TenantRole role,
+      LocalDateTime expiresAt,
+      Long invitedBy,
+      LocalDateTime createdAt) {
+    this.tenantId = tenantId;
+    this.email = email;
+    this.tokenHash = tokenHash;
+    this.status = InvitationStatus.PENDING;
+    this.role = role;
+    this.expiresAt = expiresAt;
+    this.invitedBy = invitedBy;
+    this.createdAt = createdAt;
+  }
+
+  /** PENDING を REVOKED に遷移させる(再送・取消)。 */
+  void revoke() {
+    this.status = InvitationStatus.REVOKED;
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/adapter/persistence/InvitationJpaRepository.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/adapter/persistence/InvitationJpaRepository.java
@@ -1,0 +1,11 @@
+package xyz.dgz48.tasks.webapi.tenant.adapter.persistence;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import xyz.dgz48.tasks.webapi.tenant.domain.InvitationStatus;
+
+interface InvitationJpaRepository extends JpaRepository<InvitationJpaEntity, Long> {
+
+  /** 当該テナント・email・status の招待を返す(tenantFilter により tenant_id は自動絞り込み)。 */
+  List<InvitationJpaEntity> findByEmailAndStatus(String email, InvitationStatus status);
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/adapter/persistence/InvitationPersistenceAdapter.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/adapter/persistence/InvitationPersistenceAdapter.java
@@ -1,0 +1,60 @@
+package xyz.dgz48.tasks.webapi.tenant.adapter.persistence;
+
+import io.micrometer.observation.annotation.Observed;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import xyz.dgz48.tasks.webapi.tenant.domain.InvitationStatus;
+import xyz.dgz48.tasks.webapi.tenant.usecase.InvitationPort;
+import xyz.dgz48.tasks.webapi.user.adapter.persistence.UserRepository;
+
+/** {@link InvitationPort} の JPA 実装(ADR-0017)。 */
+@Observed(name = "tenant.invitation.repository")
+@Component
+@RequiredArgsConstructor
+class InvitationPersistenceAdapter implements InvitationPort {
+
+  private final InvitationJpaRepository invitationRepository;
+  private final UserTenantJpaRepository userTenantRepository;
+  private final UserRepository userRepository;
+  private final TenantJpaRepository tenantRepository;
+
+  @Override
+  @Transactional(readOnly = true)
+  public boolean isAlreadyMember(Long tenantId, String email) {
+    return userRepository
+        .findByEmail(email)
+        .map(user -> userTenantRepository.existsByIdUserIdAndIdTenantId(user.getId(), tenantId))
+        .orElse(false);
+  }
+
+  @Override
+  @Transactional
+  public void revokePending(Long tenantId, String email) {
+    // tenantFilter により tenant_id は自動絞り込み(ADR-0010)。
+    invitationRepository
+        .findByEmailAndStatus(email, InvitationStatus.PENDING)
+        .forEach(InvitationJpaEntity::revoke);
+  }
+
+  @Override
+  @Transactional
+  public void save(NewInvitation invitation) {
+    invitationRepository.save(
+        new InvitationJpaEntity(
+            invitation.tenantId(),
+            invitation.email(),
+            invitation.tokenHash(),
+            invitation.role(),
+            invitation.expiresAt(),
+            invitation.invitedBy(),
+            invitation.createdAt()));
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public Optional<String> findTenantName(Long tenantId) {
+    return tenantRepository.findById(tenantId).map(TenantJpaEntity::getName);
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/adapter/persistence/UserTenantJpaRepository.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/adapter/persistence/UserTenantJpaRepository.java
@@ -13,6 +13,9 @@ interface UserTenantJpaRepository extends JpaRepository<UserTenantJpaEntity, Use
   Optional<UserTenantJpaEntity> findByIdUserIdAndIdTenantIdAndStatus(
       Long userId, Long tenantId, UserTenantStatus status);
 
+  /** status 問わず、当該ユーザー×テナントの user_tenants 行が存在するか(招待の重複検出に使用)。 */
+  boolean existsByIdUserIdAndIdTenantId(Long userId, Long tenantId);
+
   List<UserTenantJpaEntity> findByIdUserIdAndStatusOrderByJoinedAtAsc(
       Long userId, UserTenantStatus status);
 

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/adapter/web/TenantMemberController.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/adapter/web/TenantMemberController.java
@@ -7,6 +7,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -16,11 +17,13 @@ import org.springframework.web.server.ResponseStatusException;
 import xyz.dgz48.tasks.webapi.shared.domain.TenantContext;
 import xyz.dgz48.tasks.webapi.tenant.adapter.web.dto.ChangeMemberRoleRequest;
 import xyz.dgz48.tasks.webapi.tenant.adapter.web.dto.TenantUserResponse;
+import xyz.dgz48.tasks.webapi.tenant.adapter.web.dto.UserInviteRequest;
 import xyz.dgz48.tasks.webapi.tenant.usecase.ChangeMemberRoleUseCase;
+import xyz.dgz48.tasks.webapi.tenant.usecase.InviteUserUseCase;
 import xyz.dgz48.tasks.webapi.tenant.usecase.RemoveMemberUseCase;
 
 /**
- * テナントメンバー管理 API(削除 / ロール変更)。Tenant Admin 専用。
+ * テナントメンバー管理 API(招待 / 削除 / ロール変更)。Tenant Admin 専用。
  *
  * <p>テナントは X-Tenant-Id ヘッダ駆動(テナント暗黙)で {@link TenantContext} から取得する(設計規約 X-Tenant-Id 不変則)。SaaS Admin
  * はメンバー管理権限を持たず、{@code TenantContextFilter} が当該パスでテナント解決に失敗するため 403 となる(基本設計書 §6.2.1)。直接追加(by
@@ -31,8 +34,19 @@ import xyz.dgz48.tasks.webapi.tenant.usecase.RemoveMemberUseCase;
 @RequiredArgsConstructor
 public class TenantMemberController {
 
+  private final InviteUserUseCase inviteUserUseCase;
   private final RemoveMemberUseCase removeMemberUseCase;
   private final ChangeMemberRoleUseCase changeMemberRoleUseCase;
+
+  /** POST /api/tenant/users/invite — 現在テナントへ email を招待する(A-09 / ADR-0017)。 */
+  @PostMapping("/invite")
+  @ResponseStatus(HttpStatus.CREATED)
+  @PreAuthorize("hasRole('TENANT_ADMIN')")
+  public void inviteUser(
+      @RequestBody @Valid UserInviteRequest request,
+      @AuthenticationPrincipal(expression = "id") Long callerId) {
+    inviteUserUseCase.execute(currentTenantId(), callerId, request.email(), request.role());
+  }
 
   /** DELETE /api/tenant/users/{userId} — 現在テナントから ACTIVE メンバーを削除する。 */
   @DeleteMapping("/{userId}")

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/adapter/web/TenantMemberExceptionHandler.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/adapter/web/TenantMemberExceptionHandler.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import xyz.dgz48.tasks.webapi.shared.infra.AppZones;
 import xyz.dgz48.tasks.webapi.shared.web.ErrorCode;
 import xyz.dgz48.tasks.webapi.shared.web.ErrorResponse;
+import xyz.dgz48.tasks.webapi.tenant.domain.UserAlreadyMemberException;
 import xyz.dgz48.tasks.webapi.tenant.domain.UserTenantNotFoundException;
 import xyz.dgz48.tasks.webapi.tenant.domain.UserTenantSelfOperationException;
 
@@ -23,6 +24,16 @@ public class TenantMemberExceptionHandler {
         HttpStatus.NOT_FOUND,
         ErrorCode.E_NOT_FOUND,
         Objects.requireNonNullElse(ex.getMessage(), "メンバーが見つかりません"),
+        request);
+  }
+
+  @ExceptionHandler(UserAlreadyMemberException.class)
+  @ResponseStatus(HttpStatus.CONFLICT)
+  public ErrorResponse handleConflict(UserAlreadyMemberException ex, HttpServletRequest request) {
+    return error(
+        HttpStatus.CONFLICT,
+        ErrorCode.E_CONFLICT,
+        Objects.requireNonNullElse(ex.getMessage(), "既にメンバーとして登録されています"),
         request);
   }
 

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/adapter/web/dto/UserInviteRequest.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/adapter/web/dto/UserInviteRequest.java
@@ -1,0 +1,11 @@
+package xyz.dgz48.tasks.webapi.tenant.adapter.web.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import xyz.dgz48.tasks.webapi.tenant.domain.TenantRole;
+
+/** POST /api/tenant/users/invite リクエスト(OpenAPI UserInviteRequest)。 */
+public record UserInviteRequest(
+    @NotBlank @Email @Size(max = 255) String email, @NotNull TenantRole role) {}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/domain/InvitationStatus.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/domain/InvitationStatus.java
@@ -1,0 +1,11 @@
+package xyz.dgz48.tasks.webapi.tenant.domain;
+
+/** 招待トークンの状態(ADR-0017 §3.1)。 */
+public enum InvitationStatus {
+  /** 発行済み・未消費。 */
+  PENDING,
+  /** 受諾成功により消費済み。 */
+  USED,
+  /** 再送または取消により失効。 */
+  REVOKED
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/domain/UserAlreadyMemberException.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/domain/UserAlreadyMemberException.java
@@ -1,0 +1,14 @@
+package xyz.dgz48.tasks.webapi.tenant.domain;
+
+import xyz.dgz48.tasks.webapi.shared.exception.DomainException;
+
+/**
+ * 招待対象の email が既にテナントの user_tenants に登録済み(重複招待)の場合にスローする業務例外。HTTP 409 にマップする(基本設計書 §5.4.1 /
+ * ADR-0017 §3.3)。
+ */
+public class UserAlreadyMemberException extends DomainException {
+
+  public UserAlreadyMemberException(String email, Long tenantId) {
+    super("メールアドレス %s は既にテナント %d のメンバーとして登録されています".formatted(email, tenantId));
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/infra/InviteProperties.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/infra/InviteProperties.java
@@ -1,0 +1,13 @@
+package xyz.dgz48.tasks.webapi.tenant.infra;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.bind.DefaultValue;
+
+/**
+ * 招待メール関連の設定(ADR-0017)。
+ *
+ * @param acceptUrlBase 招待受諾画面のベース URL。メールには {@code <acceptUrlBase>?token=<平文トークン>} を載せる
+ */
+@ConfigurationProperties("tenant.invite")
+public record InviteProperties(
+    @DefaultValue("http://localhost:8080/invitations/accept") String acceptUrlBase) {}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/infra/SecureRandomInviteTokenGenerator.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/infra/SecureRandomInviteTokenGenerator.java
@@ -1,0 +1,20 @@
+package xyz.dgz48.tasks.webapi.tenant.infra;
+
+import java.security.SecureRandom;
+import java.util.Base64;
+import xyz.dgz48.tasks.webapi.tenant.usecase.InviteTokenGenerator;
+
+/** {@link InviteTokenGenerator} の実装。SecureRandom 256bit を URL-safe Base64(パディングなし・約 43 文字)で返す。 */
+class SecureRandomInviteTokenGenerator implements InviteTokenGenerator {
+
+  private static final int TOKEN_BYTES = 32; // 256 bit
+  private final SecureRandom secureRandom = new SecureRandom();
+  private final Base64.Encoder encoder = Base64.getUrlEncoder().withoutPadding();
+
+  @Override
+  public String generate() {
+    byte[] bytes = new byte[TOKEN_BYTES];
+    secureRandom.nextBytes(bytes);
+    return encoder.encodeToString(bytes);
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/infra/TenantInfraConfig.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/infra/TenantInfraConfig.java
@@ -1,11 +1,17 @@
 package xyz.dgz48.tasks.webapi.tenant.infra;
 
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import xyz.dgz48.tasks.webapi.notification.usecase.EmailSenderPort;
+import xyz.dgz48.tasks.webapi.tenant.adapter.external.InviteMailAdapter;
 import xyz.dgz48.tasks.webapi.tenant.domain.TenantAuditDiffDomainService;
 import xyz.dgz48.tasks.webapi.tenant.domain.TenantCodeGenerator;
+import xyz.dgz48.tasks.webapi.tenant.usecase.InviteMailPort;
+import xyz.dgz48.tasks.webapi.tenant.usecase.InviteTokenGenerator;
 
 @Configuration
+@EnableConfigurationProperties(InviteProperties.class)
 class TenantInfraConfig {
 
   @Bean
@@ -16,5 +22,15 @@ class TenantInfraConfig {
   @Bean
   TenantCodeGenerator tenantCodeGenerator() {
     return new TenantCodeGenerator();
+  }
+
+  @Bean
+  InviteTokenGenerator inviteTokenGenerator() {
+    return new SecureRandomInviteTokenGenerator();
+  }
+
+  @Bean
+  InviteMailPort inviteMailPort(EmailSenderPort emailSenderPort, InviteProperties properties) {
+    return new InviteMailAdapter(emailSenderPort, properties.acceptUrlBase());
   }
 }

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/usecase/InvitationPort.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/usecase/InvitationPort.java
@@ -1,0 +1,31 @@
+package xyz.dgz48.tasks.webapi.tenant.usecase;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import xyz.dgz48.tasks.webapi.tenant.domain.TenantRole;
+
+/** 招待(invitations)の永続化・照会ポート(ADR-0017)。 */
+public interface InvitationPort {
+
+  /** 招待先 email に対応するユーザーが、既に当該テナントの user_tenants に登録済み(status 問わず)か。 */
+  boolean isAlreadyMember(Long tenantId, String email);
+
+  /** 当該テナント・email の PENDING 招待をすべて REVOKED にする(再送時の旧トークン失効。ADR-0017 §3.1)。 */
+  void revokePending(Long tenantId, String email);
+
+  /** PENDING 招待を 1 件作成する。 */
+  void save(NewInvitation invitation);
+
+  /** テナント名(招待メール文面用)。 */
+  Optional<String> findTenantName(Long tenantId);
+
+  /** 新規 PENDING 招待の永続化パラメータ。 */
+  record NewInvitation(
+      Long tenantId,
+      String email,
+      String tokenHash,
+      TenantRole role,
+      LocalDateTime expiresAt,
+      Long invitedBy,
+      LocalDateTime createdAt) {}
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/usecase/InviteMailPort.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/usecase/InviteMailPort.java
@@ -1,0 +1,14 @@
+package xyz.dgz48.tasks.webapi.tenant.usecase;
+
+/** 招待メール送信ポート(ADR-0017)。平文トークンを受け取り、受諾リンクを含むメールを送信する。 */
+public interface InviteMailPort {
+
+  /**
+   * 招待メールを送信する。
+   *
+   * @param email 招待先メールアドレス
+   * @param tenantName 招待元テナント名(文面に表示)
+   * @param rawToken 平文トークン(受諾 URL に埋め込む。DB には保存されない)
+   */
+  void sendInvitation(String email, String tenantName, String rawToken);
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/usecase/InviteTokenGenerator.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/usecase/InviteTokenGenerator.java
@@ -1,0 +1,8 @@
+package xyz.dgz48.tasks.webapi.tenant.usecase;
+
+/** 招待トークン(平文)の生成ポート。SecureRandom 256bit・URL-safe Base64(ADR-0017 §3.1)。 */
+public interface InviteTokenGenerator {
+
+  /** 新しい招待トークン(平文)を生成する。メールにのみ載せ、DB には保存しない。 */
+  String generate();
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/usecase/InviteTokenHasher.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/usecase/InviteTokenHasher.java
@@ -1,0 +1,24 @@
+package xyz.dgz48.tasks.webapi.tenant.usecase;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+
+/** 招待トークンの SHA-256 ハッシュ化(16進64文字)。DB には本ハッシュのみを保存する(ADR-0017 §3.1)。 */
+public final class InviteTokenHasher {
+
+  private InviteTokenHasher() {}
+
+  /** 平文トークンの SHA-256 を小文字 16 進(64 文字)で返す。 */
+  public static String sha256Hex(String rawToken) {
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      byte[] hash = digest.digest(rawToken.getBytes(StandardCharsets.UTF_8));
+      return HexFormat.of().formatHex(hash);
+    } catch (NoSuchAlgorithmException e) {
+      // SHA-256 は JDK 標準で必ず存在するため到達不能。
+      throw new IllegalStateException("SHA-256 が利用できません", e);
+    }
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/usecase/InviteUserUseCase.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/usecase/InviteUserUseCase.java
@@ -1,0 +1,53 @@
+package xyz.dgz48.tasks.webapi.tenant.usecase;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import xyz.dgz48.tasks.webapi.tenant.domain.TenantRole;
+import xyz.dgz48.tasks.webapi.tenant.domain.UserAlreadyMemberException;
+
+/**
+ * ユーザー招待ユースケース(A-09 / ADR-0017 選択肢 B)。
+ *
+ * <p>現在のテナント(X-Tenant-Id 駆動)に対して email を招待する。既に user_tenants に登録済みの email は重複招待として 409 ({@link
+ * UserAlreadyMemberException})。再送のため同一テナント・email の PENDING 招待は失効(REVOKED)させてから、新しい SecureRandom
+ * トークンを発行し、ハッシュのみを永続化して SES で招待メールを送る。
+ *
+ * <p>受諾(トークン消費)・user_tenants 紐付けは受諾画面フロー(別 Issue)で実装する。
+ */
+@Service
+@RequiredArgsConstructor
+public class InviteUserUseCase {
+
+  /** 招待トークンの有効期間(ADR-0017 §3.1)。 */
+  private static final Duration TOKEN_TTL = Duration.ofDays(7);
+
+  private final InvitationPort invitationPort;
+  private final InviteTokenGenerator tokenGenerator;
+  private final InviteMailPort inviteMailPort;
+  private final Clock clock;
+
+  @Transactional
+  public void execute(Long tenantId, Long callerId, String email, TenantRole role) {
+    if (invitationPort.isAlreadyMember(tenantId, email)) {
+      throw new UserAlreadyMemberException(email, tenantId);
+    }
+
+    invitationPort.revokePending(tenantId, email);
+
+    String rawToken = tokenGenerator.generate();
+    String tokenHash = InviteTokenHasher.sha256Hex(rawToken);
+    LocalDateTime now = LocalDateTime.now(clock);
+    LocalDateTime expiresAt = now.plus(TOKEN_TTL);
+
+    invitationPort.save(
+        new InvitationPort.NewInvitation(
+            tenantId, email, tokenHash, role, expiresAt, callerId, now));
+
+    String tenantName = invitationPort.findTenantName(tenantId).orElse("テナント");
+    inviteMailPort.sendInvitation(email, tenantName, rawToken);
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/adapter/persistence/UserRepository.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/adapter/persistence/UserRepository.java
@@ -5,4 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<UserJpaEntity, Long> {
   Optional<UserJpaEntity> findByOidcSub(String oidcSub);
+
+  Optional<UserJpaEntity> findByEmail(String email);
 }

--- a/webapi/src/main/resources/application.yml
+++ b/webapi/src/main/resources/application.yml
@@ -97,3 +97,9 @@ notification:
     enabled: ${NOTIFICATION_BATCH_ENABLED:true}
     cron: ${NOTIFICATION_BATCH_CRON:0 0 9 * * *}
     zone: ${NOTIFICATION_BATCH_ZONE:Asia/Tokyo}
+
+# A-09 招待(ADR-0017)。招待メールの受諾リンクのベース URL。
+# 平文トークンを <accept-url-base>?token=... の形でメール本文にのみ載せる(本番は実ドメインを設定)。
+tenant:
+  invite:
+    accept-url-base: ${TENANT_INVITE_ACCEPT_URL_BASE:http://localhost:8080/invitations/accept}

--- a/webapi/src/main/resources/db/migration/V1.0.0_05__create_invitations_table.sql
+++ b/webapi/src/main/resources/db/migration/V1.0.0_05__create_invitations_table.sql
@@ -1,0 +1,22 @@
+-- A-09 招待フロー(ADR-0017 選択肢 B: 自前招待トークン)。
+-- Tenant Admin が email を指定して招待 → invitations 行を作成し SES で送信。
+-- トークンは平文をメールにのみ載せ、DB には SHA-256 ハッシュ(64 hex)のみ保存する(ADR-0017 §3.1)。
+-- 受諾(token 消費)/ user_tenants 紐付けは受諾画面フロー(別 Issue)で実装する。
+
+CREATE TABLE invitations (
+    id          BIGINT       NOT NULL AUTO_INCREMENT,
+    tenant_id   BIGINT       NOT NULL COMMENT '招待先テナント(業務テーブル: Hibernate tenantFilter 対象)',
+    email       VARCHAR(255) NOT NULL COMMENT '招待先メールアドレス',
+    token_hash  CHAR(64)     NOT NULL COMMENT '招待トークンの SHA-256 ハッシュ(16進64文字)。平文は非保存',
+    status      ENUM('PENDING','USED','REVOKED') NOT NULL DEFAULT 'PENDING'
+                COMMENT '招待状態。受諾成功で USED、再送/取消で REVOKED(ADR-0017 §3.1)',
+    role        ENUM('TENANT_ADMIN','MEMBER')    NOT NULL COMMENT '受諾時に付与するロール',
+    expires_at  DATETIME     NOT NULL COMMENT '有効期限(発行から 7 日。ADR-0017 §3.1)',
+    invited_by  BIGINT       NOT NULL COMMENT '招待した Tenant Admin の users.id',
+    created_at  DATETIME     NOT NULL COMMENT '発行日時',
+    consumed_at DATETIME     NULL     COMMENT '受諾(消費)日時。未消費は NULL',
+    PRIMARY KEY (id),
+    UNIQUE KEY uq_invitations_token_hash (token_hash),
+    KEY idx_invitations_tenant_email (tenant_id, email),
+    KEY idx_invitations_tenant_status (tenant_id, status)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/SecurityConfigTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/SecurityConfigTest.java
@@ -60,6 +60,7 @@ import xyz.dgz48.tasks.webapi.tenant.usecase.ChangeMemberRoleUseCase;
 import xyz.dgz48.tasks.webapi.tenant.usecase.CreateTenantUseCase;
 import xyz.dgz48.tasks.webapi.tenant.usecase.GetPlatformMetricsUseCase;
 import xyz.dgz48.tasks.webapi.tenant.usecase.GetTenantUseCase;
+import xyz.dgz48.tasks.webapi.tenant.usecase.InviteUserUseCase;
 import xyz.dgz48.tasks.webapi.tenant.usecase.ListTenantUsersUseCase;
 import xyz.dgz48.tasks.webapi.tenant.usecase.ListTenantsUseCase;
 import xyz.dgz48.tasks.webapi.tenant.usecase.RemoveMemberUseCase;
@@ -100,6 +101,7 @@ class SecurityConfigTest {
   @MockitoBean AddStakeholderUseCase addStakeholderUseCase;
   @MockitoBean RemoveStakeholderUseCase removeStakeholderUseCase;
   @MockitoBean SwitchTenantUseCase switchTenantUseCase;
+  @MockitoBean InviteUserUseCase inviteUserUseCase;
   @MockitoBean RemoveMemberUseCase removeMemberUseCase;
   @MockitoBean ChangeMemberRoleUseCase changeMemberRoleUseCase;
   @MockitoBean ListTenantsUseCase listTenantsUseCase;

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/TenantContextFilterTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/TenantContextFilterTest.java
@@ -49,6 +49,7 @@ import xyz.dgz48.tasks.webapi.tenant.usecase.ChangeMemberRoleUseCase;
 import xyz.dgz48.tasks.webapi.tenant.usecase.CreateTenantUseCase;
 import xyz.dgz48.tasks.webapi.tenant.usecase.GetPlatformMetricsUseCase;
 import xyz.dgz48.tasks.webapi.tenant.usecase.GetTenantUseCase;
+import xyz.dgz48.tasks.webapi.tenant.usecase.InviteUserUseCase;
 import xyz.dgz48.tasks.webapi.tenant.usecase.ListTenantUsersUseCase;
 import xyz.dgz48.tasks.webapi.tenant.usecase.ListTenantsUseCase;
 import xyz.dgz48.tasks.webapi.tenant.usecase.RemoveMemberUseCase;
@@ -115,6 +116,7 @@ class TenantContextFilterTest {
   @MockitoBean AddStakeholderUseCase addStakeholderUseCase;
   @MockitoBean RemoveStakeholderUseCase removeStakeholderUseCase;
   @MockitoBean SwitchTenantUseCase switchTenantUseCase;
+  @MockitoBean InviteUserUseCase inviteUserUseCase;
   @MockitoBean RemoveMemberUseCase removeMemberUseCase;
   @MockitoBean ChangeMemberRoleUseCase changeMemberRoleUseCase;
   @MockitoBean ListTenantsUseCase listTenantsUseCase;

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/tenant/adapter/external/InviteMailAdapterTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/tenant/adapter/external/InviteMailAdapterTest.java
@@ -1,0 +1,36 @@
+package xyz.dgz48.tasks.webapi.tenant.adapter.external;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import xyz.dgz48.tasks.webapi.notification.usecase.EmailSenderPort;
+
+@ExtendWith(MockitoExtension.class)
+class InviteMailAdapterTest {
+
+  @Mock EmailSenderPort emailSenderPort;
+
+  @Test
+  void sendInvitation_buildsAcceptLinkWithRawToken() {
+    var adapter =
+        new InviteMailAdapter(emailSenderPort, "https://app.example.com/invitations/accept");
+
+    adapter.sendInvitation("invitee@example.com", "Acme テナント", "RAW-TOKEN-xyz");
+
+    ArgumentCaptor<String> to = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<String> subject = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<String> body = ArgumentCaptor.forClass(String.class);
+    verify(emailSenderPort).send(to.capture(), subject.capture(), body.capture());
+
+    assertThat(to.getValue()).isEqualTo("invitee@example.com");
+    assertThat(subject.getValue()).isNotBlank();
+    assertThat(body.getValue())
+        .contains("Acme テナント")
+        .contains("https://app.example.com/invitations/accept?token=RAW-TOKEN-xyz");
+  }
+}

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/tenant/adapter/web/InvitationIT.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/tenant/adapter/web/InvitationIT.java
@@ -1,0 +1,270 @@
+package xyz.dgz48.tasks.webapi.tenant.adapter.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import jakarta.persistence.EntityManager;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.support.TransactionTemplate;
+import xyz.dgz48.tasks.webapi.FixedClockConfiguration;
+import xyz.dgz48.tasks.webapi.MockJwtDecoderConfiguration;
+import xyz.dgz48.tasks.webapi.TestcontainersConfiguration;
+import xyz.dgz48.tasks.webapi.notification.usecase.EmailSenderPort;
+import xyz.dgz48.tasks.webapi.security.adapter.web.TasksAuthenticationToken;
+import xyz.dgz48.tasks.webapi.security.domain.TasksPrincipal;
+import xyz.dgz48.tasks.webapi.tenant.adapter.persistence.TenantJpaEntity;
+import xyz.dgz48.tasks.webapi.tenant.usecase.InviteTokenHasher;
+import xyz.dgz48.tasks.webapi.user.adapter.persistence.UserJpaEntity;
+
+/**
+ * A-09 招待発行(POST /api/tenant/users/invite、ADR-0017)の統合テスト。
+ *
+ * <p>Tenant Admin が新規 email を招待 → 201・invitations 行 PENDING・SES 送信(平文トークンの SHA-256 が DB の
+ * token_hash と一致)を検証する。既メンバーの重複招待は 409、再招待で旧 PENDING は REVOKED、SaaS Admin(非メンバー)は 403。
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@Import({
+  TestcontainersConfiguration.class,
+  MockJwtDecoderConfiguration.class,
+  FixedClockConfiguration.class
+})
+class InvitationIT {
+
+  private static final Pattern TOKEN_PATTERN = Pattern.compile("token=([A-Za-z0-9_-]+)");
+
+  @Autowired MockMvc mockMvc;
+  @Autowired EntityManager em;
+  @Autowired TransactionTemplate txTemplate;
+  @MockitoBean EmailSenderPort emailSenderPort;
+
+  private Long adminUserId;
+  private Long memberUserId;
+  private Long saasAdminUserId;
+  private Long tenantId;
+
+  private TasksAuthenticationToken tenantAdminToken;
+  private TasksAuthenticationToken saasAdminToken;
+
+  @BeforeEach
+  void setUp() {
+    txTemplate.execute(
+        ignored -> {
+          var adminUser =
+              new UserJpaEntity("sub-inv-admin", "inv-admin@example.com", "招待太郎", "ショウタイタロウ", null);
+          var memberUser =
+              new UserJpaEntity("sub-inv-member", "member@example.com", "既存花子", "キゾンハナコ", null);
+          var saasAdminUser =
+              new UserJpaEntity("sub-inv-saas", "inv-saas@example.com", "運営三郎", "ウンエイサブロウ", null);
+          em.persist(adminUser);
+          em.persist(memberUser);
+          em.persist(saasAdminUser);
+          em.flush();
+          adminUserId = adminUser.getId();
+          memberUserId = memberUser.getId();
+          saasAdminUserId = saasAdminUser.getId();
+
+          var tenant = new TenantJpaEntity("INV-IT-1", "招待ITテナント");
+          em.persist(tenant);
+          em.flush();
+          tenantId = tenant.getId();
+
+          insertMembership(adminUserId, tenantId, "TENANT_ADMIN");
+          insertMembership(memberUserId, tenantId, "MEMBER");
+          // saasAdminUser はどのテナントにも所属させない(非メンバー)。
+          return null;
+        });
+
+    SecurityContextHolder.clearContext();
+    tenantAdminToken =
+        new TasksAuthenticationToken(
+            new TasksPrincipal(
+                adminUserId, "sub-inv-admin", "inv-admin@example.com", "招待太郎", "ショウタイタロウ", null),
+            List.of());
+    saasAdminToken =
+        new TasksAuthenticationToken(
+            new TasksPrincipal(
+                saasAdminUserId, "sub-inv-saas", "inv-saas@example.com", "運営三郎", "ウンエイサブロウ", null),
+            List.of(new SimpleGrantedAuthority("ROLE_APP_ADMIN")));
+  }
+
+  @AfterEach
+  void tearDown() {
+    SecurityContextHolder.clearContext();
+    if (tenantId == null) {
+      return;
+    }
+    txTemplate.execute(
+        ignored -> {
+          em.createNativeQuery("DELETE FROM invitations WHERE tenant_id = ?")
+              .setParameter(1, tenantId)
+              .executeUpdate();
+          em.createNativeQuery("DELETE FROM user_tenants WHERE tenant_id = ?")
+              .setParameter(1, tenantId)
+              .executeUpdate();
+          em.createNativeQuery("DELETE FROM tenants WHERE id = ?")
+              .setParameter(1, tenantId)
+              .executeUpdate();
+          em.createNativeQuery("DELETE FROM users WHERE id IN (?,?,?)")
+              .setParameter(1, adminUserId)
+              .setParameter(2, memberUserId)
+              .setParameter(3, saasAdminUserId)
+              .executeUpdate();
+          return null;
+        });
+  }
+
+  @Test
+  void inviteUser_returns201_persistsPending_andSendsMailWithMatchingTokenHash() throws Exception {
+    String email = "newcomer@example.com";
+
+    mockMvc
+        .perform(
+            post("/api/tenant/users/invite")
+                .header("X-Tenant-Id", tenantId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"email\":\"" + email + "\",\"role\":\"MEMBER\"}")
+                .with(authentication(tenantAdminToken)))
+        .andExpect(status().isCreated());
+
+    // SES(モック)に送られた本文から平文トークンを取り出す
+    ArgumentCaptor<String> body = ArgumentCaptor.forClass(String.class);
+    org.mockito.Mockito.verify(emailSenderPort)
+        .send(
+            org.mockito.ArgumentMatchers.eq(email),
+            org.mockito.ArgumentMatchers.anyString(),
+            body.capture());
+    Matcher matcher = TOKEN_PATTERN.matcher(body.getValue());
+    assertThat(matcher.find()).isTrue();
+    String rawToken = matcher.group(1);
+    String expectedHash = InviteTokenHasher.sha256Hex(rawToken);
+
+    Object[] row = findInvitation(email);
+    assertThat(row[0]).isEqualTo(expectedHash); // token_hash
+    assertThat(row[1]).isEqualTo("PENDING"); // status
+    assertThat(row[2]).isEqualTo("MEMBER"); // role
+    assertThat(((Number) row[3]).longValue()).isEqualTo(adminUserId); // invited_by
+    // DB には平文を保存しない
+    assertThat(row[0]).isNotEqualTo(rawToken);
+  }
+
+  @Test
+  void inviteUser_returns409_whenEmailAlreadyMember() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/tenant/users/invite")
+                .header("X-Tenant-Id", tenantId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"email\":\"member@example.com\",\"role\":\"MEMBER\"}")
+                .with(authentication(tenantAdminToken)))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.code").value("E_CONFLICT"));
+
+    assertThat(countInvitations("member@example.com")).isZero();
+    org.mockito.Mockito.verifyNoInteractions(emailSenderPort);
+  }
+
+  @Test
+  void inviteUser_revokesPreviousPending_onReInvite() throws Exception {
+    String email = "twice@example.com";
+    invite(email);
+    invite(email);
+
+    assertThat(countInvitationsWithStatus(email, "PENDING")).isEqualTo(1);
+    assertThat(countInvitationsWithStatus(email, "REVOKED")).isEqualTo(1);
+  }
+
+  @Test
+  void inviteUser_returns403_whenSaasAdmin() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/tenant/users/invite")
+                .header("X-Tenant-Id", tenantId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"email\":\"newcomer@example.com\",\"role\":\"MEMBER\"}")
+                .with(authentication(saasAdminToken)))
+        .andExpect(status().isForbidden());
+  }
+
+  // --- helpers ---
+
+  private void invite(String email) throws Exception {
+    mockMvc
+        .perform(
+            post("/api/tenant/users/invite")
+                .header("X-Tenant-Id", tenantId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"email\":\"" + email + "\",\"role\":\"MEMBER\"}")
+                .with(authentication(tenantAdminToken)))
+        .andExpect(status().isCreated());
+  }
+
+  private void insertMembership(Long userId, Long tId, String role) {
+    em.createNativeQuery(
+            "INSERT INTO user_tenants (user_id, tenant_id, role, status, joined_at)"
+                + " VALUES (?,?,?,?,?)")
+        .setParameter(1, userId)
+        .setParameter(2, tId)
+        .setParameter(3, role)
+        .setParameter(4, "ACTIVE")
+        .setParameter(5, LocalDateTime.of(2026, 1, 1, 0, 0))
+        .executeUpdate();
+  }
+
+  private Object[] findInvitation(String email) {
+    return txTemplate.execute(
+        ignored ->
+            (Object[])
+                em.createNativeQuery(
+                        "SELECT token_hash, status, role, invited_by FROM invitations"
+                            + " WHERE tenant_id = ? AND email = ?")
+                    .setParameter(1, tenantId)
+                    .setParameter(2, email)
+                    .getSingleResult());
+  }
+
+  private long countInvitations(String email) {
+    return txTemplate.execute(
+        ignored ->
+            ((Number)
+                    em.createNativeQuery(
+                            "SELECT COUNT(*) FROM invitations WHERE tenant_id = ? AND email = ?")
+                        .setParameter(1, tenantId)
+                        .setParameter(2, email)
+                        .getSingleResult())
+                .longValue());
+  }
+
+  private long countInvitationsWithStatus(String email, String status) {
+    return txTemplate.execute(
+        ignored ->
+            ((Number)
+                    em.createNativeQuery(
+                            "SELECT COUNT(*) FROM invitations"
+                                + " WHERE tenant_id = ? AND email = ? AND status = ?")
+                        .setParameter(1, tenantId)
+                        .setParameter(2, email)
+                        .setParameter(3, status)
+                        .getSingleResult())
+                .longValue());
+  }
+}

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/tenant/adapter/web/TenantMemberControllerWebMvcTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/tenant/adapter/web/TenantMemberControllerWebMvcTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -34,10 +35,12 @@ import xyz.dgz48.tasks.webapi.security.adapter.web.WithMockSaasAdmin;
 import xyz.dgz48.tasks.webapi.security.adapter.web.WithMockTenantAdmin;
 import xyz.dgz48.tasks.webapi.tenant.domain.TenantRole;
 import xyz.dgz48.tasks.webapi.tenant.domain.TenantUserInfo;
+import xyz.dgz48.tasks.webapi.tenant.domain.UserAlreadyMemberException;
 import xyz.dgz48.tasks.webapi.tenant.domain.UserTenantNotFoundException;
 import xyz.dgz48.tasks.webapi.tenant.domain.UserTenantSelfOperationException;
 import xyz.dgz48.tasks.webapi.tenant.domain.UserTenantStatus;
 import xyz.dgz48.tasks.webapi.tenant.usecase.ChangeMemberRoleUseCase;
+import xyz.dgz48.tasks.webapi.tenant.usecase.InviteUserUseCase;
 import xyz.dgz48.tasks.webapi.tenant.usecase.RemoveMemberUseCase;
 import xyz.dgz48.tasks.webapi.tenant.usecase.TenantMembershipPort;
 import xyz.dgz48.tasks.webapi.tenant.usecase.UserTenantsResolverService;
@@ -66,6 +69,7 @@ class TenantMemberControllerWebMvcTest {
   @MockitoBean AppAdminUserRepository appAdminUserRepository;
   @MockitoBean TenantMembershipPort tenantMembershipPort;
   @MockitoBean UserTenantsResolverService userTenantsResolverService;
+  @MockitoBean InviteUserUseCase inviteUserUseCase;
   @MockitoBean RemoveMemberUseCase removeMemberUseCase;
   @MockitoBean ChangeMemberRoleUseCase changeMemberRoleUseCase;
 
@@ -237,5 +241,76 @@ class TenantMemberControllerWebMvcTest {
                 .content("{\"role\":\"TENANT_ADMIN\"}"))
         .andExpect(status().isForbidden())
         .andExpect(jsonPath("$.code").value("E_FORBIDDEN"));
+  }
+
+  // --- POST /api/tenant/users/invite ---
+
+  @Test
+  @WithMockTenantAdmin
+  void inviteUser_returns201_whenTenantAdmin() throws Exception {
+    doNothing().when(inviteUserUseCase).execute(eq(TENANT_ID), any(), eq("new@example.com"), any());
+
+    mockMvc
+        .perform(
+            post("/api/tenant/users/invite")
+                .header("X-Tenant-Id", TENANT_HEADER)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"email\":\"new@example.com\",\"role\":\"MEMBER\"}"))
+        .andExpect(status().isCreated());
+  }
+
+  @Test
+  @WithMockMember
+  void inviteUser_returns403_whenMember() throws Exception {
+    when(tenantMembershipPort.findActiveRole(anyLong(), eq(TENANT_ID)))
+        .thenReturn(Optional.of(TenantRole.MEMBER));
+
+    mockMvc
+        .perform(
+            post("/api/tenant/users/invite")
+                .header("X-Tenant-Id", TENANT_HEADER)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"email\":\"new@example.com\",\"role\":\"MEMBER\"}"))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  @WithMockSaasAdmin
+  void inviteUser_returns403_whenSaasAdmin() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/tenant/users/invite")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"email\":\"new@example.com\",\"role\":\"MEMBER\"}"))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  @WithMockTenantAdmin
+  void inviteUser_returns400_whenInvalidEmail() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/tenant/users/invite")
+                .header("X-Tenant-Id", TENANT_HEADER)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"email\":\"not-an-email\",\"role\":\"MEMBER\"}"))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @WithMockTenantAdmin
+  void inviteUser_returns409_whenAlreadyMember() throws Exception {
+    doThrow(new UserAlreadyMemberException("dup@example.com", TENANT_ID))
+        .when(inviteUserUseCase)
+        .execute(eq(TENANT_ID), any(), eq("dup@example.com"), any());
+
+    mockMvc
+        .perform(
+            post("/api/tenant/users/invite")
+                .header("X-Tenant-Id", TENANT_HEADER)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"email\":\"dup@example.com\",\"role\":\"MEMBER\"}"))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.code").value("E_CONFLICT"));
   }
 }

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/tenant/infra/SecureRandomInviteTokenGeneratorTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/tenant/infra/SecureRandomInviteTokenGeneratorTest.java
@@ -1,0 +1,23 @@
+package xyz.dgz48.tasks.webapi.tenant.infra;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import xyz.dgz48.tasks.webapi.tenant.usecase.InviteTokenGenerator;
+
+class SecureRandomInviteTokenGeneratorTest {
+
+  private final InviteTokenGenerator generator = new SecureRandomInviteTokenGenerator();
+
+  @Test
+  void generate_returnsUrlSafeBase64WithoutPadding() {
+    String token = generator.generate();
+    // URL-safe Base64(パディングなし): A-Z a-z 0-9 - _ のみ。256bit → 43 文字
+    assertThat(token).matches("[A-Za-z0-9_-]+").hasSize(43);
+  }
+
+  @Test
+  void generate_returnsDistinctTokens() {
+    assertThat(generator.generate()).isNotEqualTo(generator.generate());
+  }
+}

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/tenant/usecase/InviteTokenHasherTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/tenant/usecase/InviteTokenHasherTest.java
@@ -1,0 +1,26 @@
+package xyz.dgz48.tasks.webapi.tenant.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class InviteTokenHasherTest {
+
+  @Test
+  void sha256Hex_matchesKnownVector() {
+    // SHA-256("abc") の既知ベクタ
+    assertThat(InviteTokenHasher.sha256Hex("abc"))
+        .isEqualTo("ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
+  }
+
+  @Test
+  void sha256Hex_is64LowercaseHex() {
+    String hash = InviteTokenHasher.sha256Hex("some-random-token");
+    assertThat(hash).hasSize(64).matches("[0-9a-f]{64}");
+  }
+
+  @Test
+  void sha256Hex_isDeterministic() {
+    assertThat(InviteTokenHasher.sha256Hex("t")).isEqualTo(InviteTokenHasher.sha256Hex("t"));
+  }
+}

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/tenant/usecase/InviteUserUseCaseTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/tenant/usecase/InviteUserUseCaseTest.java
@@ -1,0 +1,94 @@
+package xyz.dgz48.tasks.webapi.tenant.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import xyz.dgz48.tasks.webapi.tenant.domain.TenantRole;
+import xyz.dgz48.tasks.webapi.tenant.domain.UserAlreadyMemberException;
+
+@ExtendWith(MockitoExtension.class)
+class InviteUserUseCaseTest {
+
+  private static final Long TENANT_ID = 10L;
+  private static final Long CALLER_ID = 1L;
+  private static final String EMAIL = "invitee@example.com";
+  private static final String RAW_TOKEN = "RAW-TOKEN-abc123";
+
+  private static final Clock FIXED_CLOCK =
+      Clock.fixed(Instant.parse("2026-06-27T00:00:00Z"), ZoneOffset.UTC);
+
+  @Mock InvitationPort invitationPort;
+  @Mock InviteTokenGenerator tokenGenerator;
+  @Mock InviteMailPort inviteMailPort;
+
+  private InviteUserUseCase useCase() {
+    return new InviteUserUseCase(invitationPort, tokenGenerator, inviteMailPort, FIXED_CLOCK);
+  }
+
+  @Test
+  void execute_createsInvitationAndSendsMail_whenNotMember() {
+    when(invitationPort.isAlreadyMember(TENANT_ID, EMAIL)).thenReturn(false);
+    when(tokenGenerator.generate()).thenReturn(RAW_TOKEN);
+    when(invitationPort.findTenantName(TENANT_ID)).thenReturn(Optional.of("Acme"));
+
+    useCase().execute(TENANT_ID, CALLER_ID, EMAIL, TenantRole.MEMBER);
+
+    // 再送のため旧 PENDING を失効
+    verify(invitationPort).revokePending(TENANT_ID, EMAIL);
+
+    ArgumentCaptor<InvitationPort.NewInvitation> captor =
+        ArgumentCaptor.forClass(InvitationPort.NewInvitation.class);
+    verify(invitationPort).save(captor.capture());
+    InvitationPort.NewInvitation saved = captor.getValue();
+    LocalDateTime now = LocalDateTime.now(FIXED_CLOCK);
+    assertThat(saved.tenantId()).isEqualTo(TENANT_ID);
+    assertThat(saved.email()).isEqualTo(EMAIL);
+    assertThat(saved.role()).isEqualTo(TenantRole.MEMBER);
+    assertThat(saved.invitedBy()).isEqualTo(CALLER_ID);
+    assertThat(saved.createdAt()).isEqualTo(now);
+    assertThat(saved.expiresAt()).isEqualTo(now.plusDays(7));
+    // DB にはハッシュのみ。平文は保存されない
+    assertThat(saved.tokenHash()).isEqualTo(InviteTokenHasher.sha256Hex(RAW_TOKEN));
+    assertThat(saved.tokenHash()).hasSize(64).isNotEqualTo(RAW_TOKEN);
+
+    // メールには平文トークンとテナント名を渡す
+    verify(inviteMailPort).sendInvitation(EMAIL, "Acme", RAW_TOKEN);
+  }
+
+  @Test
+  void execute_usesFallbackTenantName_whenTenantNameMissing() {
+    when(invitationPort.isAlreadyMember(TENANT_ID, EMAIL)).thenReturn(false);
+    when(tokenGenerator.generate()).thenReturn(RAW_TOKEN);
+    when(invitationPort.findTenantName(TENANT_ID)).thenReturn(Optional.empty());
+
+    useCase().execute(TENANT_ID, CALLER_ID, EMAIL, TenantRole.TENANT_ADMIN);
+
+    verify(inviteMailPort).sendInvitation(eq(EMAIL), eq("テナント"), eq(RAW_TOKEN));
+  }
+
+  @Test
+  void execute_throwsConflict_whenAlreadyMember() {
+    when(invitationPort.isAlreadyMember(TENANT_ID, EMAIL)).thenReturn(true);
+
+    assertThatThrownBy(() -> useCase().execute(TENANT_ID, CALLER_ID, EMAIL, TenantRole.MEMBER))
+        .isInstanceOf(UserAlreadyMemberException.class);
+
+    verify(invitationPort, never()).save(org.mockito.ArgumentMatchers.any());
+    verifyNoInteractions(tokenGenerator, inviteMailPort);
+  }
+}


### PR DESCRIPTION
## 概要
A-09 招待を ADR-0017(Accepted)**選択肢 B = 自前招待トークン**に準拠して実装する。Tracker #795 のサブ Issue #793。

ADR-0017 §6 のスコープ分割に従い、本 PR は **(a) invitations migration + domain/usecase + 招待発行 API + SES** を担当する。受諾画面・トークン消費・`user_tenants` 紐付け((b)/(c)、フロントエンド + Keycloak 会員登録 1 画面)は別 Issue。

> 設計方針は事前に確認済み(Issue 文面の「初回ログイン JIT」案ではなく ADR-0017 の invitations テーブル方式を採用)。

## 変更点
- **Flyway `V1.0.0_05__create_invitations_table.sql`**: `invitations`(`token_hash`=SHA-256 64hex のみ保存、`status` PENDING/USED/REVOKED、`expires_at`、`role`、`invited_by`、`consumed_at`)。業務テーブルとして `TenantFilteredEntity` 継承(Hibernate `tenantFilter` 対象)。
- **`InviteUserUseCase`(A-09)**: ① 既に `user_tenants` 登録済みの email は **409**(`UserAlreadyMemberException`)② 再送のため同一テナント・email の PENDING を **REVOKED** ③ `SecureRandom` 256bit トークン発行 → **SHA-256 ハッシュのみ永続化**(平文はメールのみ)→ **SES 送信**。TTL **7 日**。
- **`POST /api/tenant/users/invite`** を `TenantMemberController` に追加(**Tenant Admin 専用**・X-Tenant-Id 駆動)。SaaS Admin は非メンバーのため `TenantContextFilter` が 403(§6.2.1)。
- **メール送信の再利用**: `notification` の `EmailSenderPort` を `@NamedInterface` で公開し `tenant` から再利用(`tenant→notification`、非循環。ModularityTests green)。`InviteMailAdapter` が受諾リンク(`accept-url-base?token=平文`)を組み立て送信。
- **OpenAPI `inviteUser`** を ADR-0017 に整合(**422 廃止**、201/409)。**基本設計書 §5.4.2** の「未登録 email = E_UNPROCESSABLE」を廃止。`application.yml` に `tenant.invite.accept-url-base`(env override 可)。

## セキュリティ(ADR-0017 §3.3 受入チェック)
- トークン: SecureRandom 256bit / URL-safe Base64(43 文字)
- DB 漏洩耐性: 平文非保存・**SHA-256 ハッシュのみ**(IT で送信トークンの SHA-256 = DB `token_hash` を検証)
- 使い回し防止: 再送で旧 PENDING を REVOKED(有効トークンは常に高々 1 本)

## テスト
- ユニット: `InviteUserUseCaseTest`(409 / 再送 REVOKED / 保存フィールド / ハッシュ)、`InviteTokenHasherTest`(既知ベクタ)、`SecureRandomInviteTokenGeneratorTest`、`InviteMailAdapterTest`(受諾リンク組立)。
- スライス: `TenantMemberControllerWebMvcTest` に invite(201 / 403 member / 403 SaaS / 400 invalid email / 409)。
- IT: `InvitationIT`(発行→PENDING・送信トークンの SHA-256 が DB と一致・重複 409・再送 REVOKED・SaaS 403)。
- `./gradlew :webapi:check` green(spotless / NullAway / JaCoCo 0.80 / Modularity / Testcontainers IT)。

## 受け入れ条件
- [x] 招待 usecase(重複 409 / 再送失効 / トークン + SES)実装
- [x] Controller(`POST /api/tenant/users/invite`・Tenant Admin 専用)実装
- [x] 409(重複)/ 422 廃止 を OpenAPI・§5.4 に反映
- [x] SES 連携(招待メール)
- [x] テスト + カバレッジ 80%
- [ ] 初回ログイン JIT(INVITED→ACTIVE): ADR-0017 では受諾画面でのトークン消費に該当 → 受諾フロー Issue((b)/(c))へ委譲

Closes #793

🤖 Generated with [Claude Code](https://claude.com/claude-code)