### PR TITLE
feat(web): S-08 ユーザー管理画面(一覧/招待/ロール変更/削除) (Closes #794)

### DIFF
--- a/docs/specs/基本設計書.md
+++ b/docs/specs/基本設計書.md
@@ -249,7 +249,7 @@ flowchart TD
 | S-05 | タスク詳細 | /tasks/{id} | 1件のタスク内容表示・関係者一覧 |
 | S-06 | タスク登録/編集 | /tasks/new, /tasks/{id}/edit | 新規・編集兼用(編集は所有者のみ) |
 | S-07 | テナント切替 | /tenants/select | 所属テナントから選択 |
-| S-08 | ユーザー管理(テナント) | /tenant/users | Tenant Adminのみ。招待・ロール変更 |
+| S-08 | ユーザー管理(テナント) | /tenant/users | Tenant Adminのみ。メンバー一覧(状態 ACTIVE/INVITED)・招待(A-09)・ロール変更(A-10)・削除(A-30)。自分自身のロール変更/削除は不可 |
 | S-09 | プロフィール | /me | usersから氏名・部署を表示 |
 | S-10 | 通知設定 | /me/notifications | メール通知ON/OFF |
 | S-11 | テナント新規作成 | /tenants/new | 認証済みでテナント未所属のユーザーが利用。テナント名を入力して作成すると、自分自身が初代 Tenant Admin として登録される(セルフサインアップ、モデル B) |

--- a/e2e/fixtures/auth.ts
+++ b/e2e/fixtures/auth.ts
@@ -5,6 +5,11 @@ export const MEMBER1 = {
   password: 'password',
 } as const;
 
+export const ADMIN1 = {
+  username: 'tenant1-admin@example.com',
+  password: 'password',
+} as const;
+
 /**
  * Keycloak PKCE ログインを実行して tasks.html に到達するまで待機する。
  * tenant1-member1 は tenant1 に 1 所属しているため index.html が自動でテナントを

--- a/e2e/tests/tenant-users.spec.ts
+++ b/e2e/tests/tenant-users.spec.ts
@@ -1,0 +1,33 @@
+import { ADMIN1, loginAs } from '../fixtures/auth';
+import { expect, test } from '../fixtures/test';
+
+// S-08 ユーザー管理(テナント)— Tenant Admin 専用画面のハッピーパス(コーディング規約 §9.7)。
+// tenant1-admin でログイン → ユーザー管理画面に遷移 → メンバー一覧表示 → ユーザー招待まで。
+
+test.describe('S-08 ユーザー管理', () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAs(page, ADMIN1.username, ADMIN1.password);
+    await page.goto('/tenant-users.html');
+    await expect(page.locator('#content')).toBeVisible({ timeout: 15_000 });
+  });
+
+  test('メンバー一覧が表示される', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: 'ユーザー管理' })).toBeVisible();
+    const table = page.locator('table[aria-label="メンバー一覧"]');
+    await expect(table).toBeVisible();
+    // tenant1 の既存メンバー(seed)が一覧に並ぶ。
+    await expect(page.locator('#users-tbody')).toContainText('tenant1-member1@example.com');
+    // 自分(tenant1-admin)の行には「自分」バッジが付き、ロール変更・削除が無効化される。
+    await expect(page.locator('#users-tbody')).toContainText('自分');
+  });
+
+  test('ユーザーを招待できる', async ({ page }) => {
+    const email = `invitee-${Date.now()}@example.com`;
+    await page.fill('#invite-email', email);
+    await page.selectOption('#invite-role', 'MEMBER');
+    await page.click('#btn-invite');
+    await expect(page.locator('#invite-feedback')).toContainText('招待メールを送信しました', {
+      timeout: 10_000,
+    });
+  });
+});

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -372,6 +372,43 @@ const Api = (() => {
   }
 
   /**
+   * POST /api/tenant/users/invite — ユーザー招待(A-09、Tenant Admin)。
+   * 招待レコードを作成し SES で受諾リンク付きメールを送信する。重複(既メンバー)は 409。
+   * @param {{email: string, role: Role}} body
+   * @returns {Promise<void>}
+   */
+  function inviteUser(body) {
+    return request('/api/tenant/users/invite', {
+      method: 'POST',
+      body: JSON.stringify(body),
+    });
+  }
+
+  /**
+   * PUT /api/tenant/users/{userId}/role — ロール変更(A-10、Tenant Admin)。
+   * 自己ロール変更は 403、ACTIVE メンバー不在は 404。
+   * @param {number} userId
+   * @param {Role} role
+   * @returns {Promise<TenantUser>}
+   */
+  function updateMemberRole(userId, role) {
+    return request(`/api/tenant/users/${userId}/role`, {
+      method: 'PUT',
+      body: JSON.stringify({ role }),
+    });
+  }
+
+  /**
+   * DELETE /api/tenant/users/{userId} — テナントメンバー削除(A-30、Tenant Admin)。
+   * 自己削除は 403、ACTIVE メンバー不在は 404。
+   * @param {number} userId
+   * @returns {Promise<void>}
+   */
+  function removeMember(userId) {
+    return request(`/api/tenant/users/${userId}`, { method: 'DELETE' });
+  }
+
+  /**
    * GET /api/tenant/dashboard/summary — テナント運営者向けダッシュボード集計(A-28、S-15、Tenant Admin)。
    * @returns {Promise<TenantDashboardSummary>}
    */
@@ -507,6 +544,9 @@ const Api = (() => {
     changeStatus,
     changeVisibility,
     listTenantUsers,
+    inviteUser,
+    updateMemberRole,
+    removeMember,
     getTenantDashboardSummary,
     getMyProfile,
     getNotificationSettings,

--- a/web/js/tenant-users.js
+++ b/web/js/tenant-users.js
@@ -1,0 +1,265 @@
+// @ts-check
+
+/** @type {HTMLElement} */ (mustQuery(document, '#btn-logout')).addEventListener('click', () =>
+  Auth.logout(),
+);
+
+/** ログイン中ユーザーの内部 ID(自己操作の抑止に使用)。 */
+let myUserId = /** @type {number|null} */ (null);
+
+/**
+ * エラーメッセージを上部に表示する。
+ * @param {string} message
+ */
+function showError(message) {
+  const el = /** @type {HTMLElement} */ (mustQuery(document, '#error-alert'));
+  el.textContent = message;
+  el.classList.remove('d-none');
+}
+
+/**
+ * 招待フォームの結果メッセージを表示する。
+ * @param {string} message
+ * @param {boolean} ok
+ */
+function showInviteFeedback(message, ok) {
+  const el = /** @type {HTMLElement} */ (mustQuery(document, '#invite-feedback'));
+  el.textContent = message;
+  el.classList.remove('d-none', 'text-success', 'text-danger');
+  el.classList.add(ok ? 'text-success' : 'text-danger');
+}
+
+/**
+ * 状態バッジの [ラベル, Bootstrap クラス] を返す。
+ * @param {string} status
+ * @returns {[string, string]}
+ */
+function statusBadge(status) {
+  if (status === 'ACTIVE') return ['有効', 'text-bg-success'];
+  if (status === 'INVITED') return ['招待中', 'text-bg-warning'];
+  return ['無効', 'text-bg-secondary'];
+}
+
+/**
+ * 1 ユーザー分の行要素を生成する。
+ * @param {TenantUser} u
+ * @returns {HTMLTableRowElement}
+ */
+function buildRow(u) {
+  const isSelf = u.userId === myUserId;
+  const tr = document.createElement('tr');
+
+  const tdName = document.createElement('td');
+  tdName.textContent = u.fullName;
+  if (isSelf) {
+    const self = document.createElement('span');
+    self.className = 'badge text-bg-light ms-2';
+    self.textContent = '自分';
+    tdName.append(self);
+  }
+
+  const tdEmail = document.createElement('td');
+  tdEmail.className = 'text-muted small';
+  tdEmail.textContent = u.email;
+
+  // ロール(編集可能なセレクト。ACTIVE 以外・自分は変更不可)。
+  const tdRole = document.createElement('td');
+  const roleSelect = document.createElement('select');
+  roleSelect.className = 'form-select form-select-sm';
+  roleSelect.setAttribute('aria-label', `${u.fullName} のロール`);
+  for (const [v, l] of [
+    ['MEMBER', 'メンバー'],
+    ['TENANT_ADMIN', 'テナント管理者'],
+  ]) {
+    const opt = document.createElement('option');
+    opt.value = v;
+    opt.textContent = l;
+    if (u.role === v) opt.selected = true;
+    roleSelect.append(opt);
+  }
+  roleSelect.disabled = isSelf || u.status !== 'ACTIVE';
+  roleSelect.addEventListener('change', async () => {
+    const newRole = /** @type {Role} */ (roleSelect.value);
+    roleSelect.disabled = true;
+    try {
+      await Api.updateMemberRole(u.userId, newRole);
+      u.role = newRole;
+    } catch (err) {
+      roleSelect.value = u.role;
+      const e = /** @type {{ status?: number, message?: string }} */ (err);
+      showError(
+        e.status === 403
+          ? 'ロールを変更する権限がありません(自分自身は変更できません)。'
+          : `ロール変更に失敗しました: ${e.message ?? '不明なエラー'}`,
+      );
+    } finally {
+      roleSelect.disabled = isSelf || u.status !== 'ACTIVE';
+    }
+  });
+  tdRole.append(roleSelect);
+
+  const tdStatus = document.createElement('td');
+  const [label, cls] = statusBadge(u.status);
+  const badge = document.createElement('span');
+  badge.className = `badge ${cls}`;
+  badge.textContent = label;
+  tdStatus.append(badge);
+
+  // 操作(削除。自分は不可)。
+  const tdAct = document.createElement('td');
+  tdAct.className = 'text-end';
+  const delBtn = document.createElement('button');
+  delBtn.type = 'button';
+  delBtn.className = 'btn btn-outline-danger btn-sm';
+  delBtn.setAttribute('aria-label', `${u.fullName} を削除`);
+  const icon = document.createElement('i');
+  icon.className = 'bi bi-trash';
+  icon.setAttribute('aria-hidden', 'true');
+  delBtn.append(icon);
+  delBtn.disabled = isSelf;
+  delBtn.addEventListener('click', async () => {
+    if (!window.confirm(`${u.fullName}(${u.email})をテナントから削除しますか?`)) return;
+    delBtn.disabled = true;
+    try {
+      await Api.removeMember(u.userId);
+      tr.remove();
+    } catch (err) {
+      const e = /** @type {{ status?: number, message?: string }} */ (err);
+      showError(
+        e.status === 403
+          ? '削除する権限がありません(自分自身は削除できません)。'
+          : e.status === 404
+            ? 'このメンバーは既に存在しません。'
+            : `削除に失敗しました: ${e.message ?? '不明なエラー'}`,
+      );
+      delBtn.disabled = false;
+    }
+  });
+  tdAct.append(delBtn);
+
+  tr.append(tdName, tdEmail, tdRole, tdStatus, tdAct);
+  return tr;
+}
+
+/**
+ * メンバー一覧を描画する。
+ * @param {TenantUser[]} users
+ */
+function renderUsers(users) {
+  const tbody = /** @type {HTMLElement} */ (mustQuery(document, '#users-tbody'));
+  tbody.replaceChildren();
+  if (users.length === 0) {
+    const tr = document.createElement('tr');
+    const td = document.createElement('td');
+    td.colSpan = 5;
+    td.className = 'text-center text-muted py-4';
+    td.textContent = 'メンバーがいません。';
+    tr.append(td);
+    tbody.append(tr);
+    return;
+  }
+  for (const u of users) {
+    tbody.append(buildRow(u));
+  }
+}
+
+/** メンバー一覧を再取得して描画する。 */
+async function reloadUsers() {
+  const users = await Api.listTenantUsers();
+  renderUsers(users);
+}
+
+/** 招待フォームの送信処理を登録する。 */
+function wireInviteForm() {
+  const form = /** @type {HTMLFormElement} */ (mustQuery(document, '#invite-form'));
+  const emailInput = /** @type {HTMLInputElement} */ (mustQuery(document, '#invite-email'));
+  const roleSelect = /** @type {HTMLSelectElement} */ (mustQuery(document, '#invite-role'));
+  const btn = /** @type {HTMLButtonElement} */ (mustQuery(document, '#btn-invite'));
+
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const email = emailInput.value.trim();
+    const role = /** @type {Role} */ (roleSelect.value);
+    if (!email) {
+      showInviteFeedback('メールアドレスを入力してください。', false);
+      return;
+    }
+    btn.disabled = true;
+    try {
+      await Api.inviteUser({ email, role });
+      showInviteFeedback(`${email} に招待メールを送信しました。`, true);
+      form.reset();
+    } catch (err) {
+      const ex = /** @type {{ status?: number, message?: string }} */ (err);
+      showInviteFeedback(
+        ex.status === 409
+          ? 'このメールアドレスは既にテナントのメンバーです。'
+          : ex.status === 403
+            ? '招待する権限がありません。'
+            : `招待に失敗しました: ${ex.message ?? '不明なエラー'}`,
+        false,
+      );
+    } finally {
+      btn.disabled = false;
+    }
+  });
+}
+
+async function main() {
+  const authenticated = await Auth.init();
+  if (!authenticated) {
+    return;
+  }
+
+  const user = Auth.getUser();
+  const displayName = user?.name || user?.preferred_username || '';
+  /** @type {HTMLElement} */ (mustQuery(document, '#nav-username')).textContent = displayName;
+  /** @type {HTMLElement} */ (mustQuery(document, '#user-avatar')).textContent =
+    displayName.slice(0, 1) || '?';
+
+  /** @type {MeResponse} */
+  let me;
+  try {
+    me = await Api.getMe();
+  } catch (err) {
+    showError(`ユーザー情報の取得に失敗しました: ${/** @type {any} */ (err).message}`);
+    return;
+  }
+  myUserId = me.user.id;
+
+  const activeTenantId = Api.resolveActiveTenant(me.tenants);
+  if (activeTenantId === null) {
+    window.location.replace('index.html');
+    return;
+  }
+
+  /** @type {AppTenantSwitcherElement} */ (mustQuery(document, '#tenant-switcher')).setData(
+    me.tenants,
+    activeTenantId,
+  );
+
+  const activeTenant = me.tenants?.find((t) => t.id === activeTenantId);
+  if (activeTenant?.role !== 'TENANT_ADMIN') {
+    /** @type {HTMLElement} */ (mustQuery(document, '#loading')).classList.add('d-none');
+    showError('このページはテナント管理者のみ利用できます。');
+    return;
+  }
+  document.body.classList.add('role-admin');
+
+  try {
+    await reloadUsers();
+    wireInviteForm();
+    /** @type {HTMLElement} */ (mustQuery(document, '#loading')).classList.add('d-none');
+    /** @type {HTMLElement} */ (mustQuery(document, '#content')).classList.remove('d-none');
+  } catch (err) {
+    const e = /** @type {{ status?: number, message?: string }} */ (err);
+    /** @type {HTMLElement} */ (mustQuery(document, '#loading')).classList.add('d-none');
+    showError(
+      e.status === 403
+        ? 'このページはテナント管理者のみ利用できます。'
+        : `ユーザー一覧の取得に失敗しました: ${e.message ?? '不明なエラー'}`,
+    );
+  }
+}
+
+main();

--- a/web/notification-settings.html
+++ b/web/notification-settings.html
@@ -48,7 +48,7 @@
       <a class="side-link" href="tenant-dashboard.html">
         <i class="bi bi-graph-up-arrow" aria-hidden="true"></i>運営者ダッシュボード
       </a>
-      <a class="side-link" href="#">
+      <a class="side-link" href="tenant-users.html">
         <i class="bi bi-people" aria-hidden="true"></i>ユーザー管理
       </a>
     </div>

--- a/web/package.json
+++ b/web/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "copy-vendor": "node scripts/copy-vendor.js",
-    "html-validate": "html-validate index.html tasks.html tenants-new.html tenant-dashboard.html notification-settings.html profile.html",
+    "html-validate": "html-validate index.html tasks.html tenants-new.html tenant-dashboard.html notification-settings.html profile.html tenant-users.html",
     "serve": "node serve.mjs"
   },
   "engines": {

--- a/web/tasks.html
+++ b/web/tasks.html
@@ -48,7 +48,7 @@
       <a class="side-link" href="tenant-dashboard.html">
         <i class="bi bi-graph-up-arrow" aria-hidden="true"></i>運営者ダッシュボード
       </a>
-      <a class="side-link" href="#">
+      <a class="side-link" href="tenant-users.html">
         <i class="bi bi-people" aria-hidden="true"></i>ユーザー管理
       </a>
     </div>

--- a/web/tenant-dashboard.html
+++ b/web/tenant-dashboard.html
@@ -48,7 +48,7 @@
       <a class="side-link active" href="tenant-dashboard.html" aria-current="page">
         <i class="bi bi-graph-up-arrow" aria-hidden="true"></i>運営者ダッシュボード
       </a>
-      <a class="side-link" href="#">
+      <a class="side-link" href="tenant-users.html">
         <i class="bi bi-people" aria-hidden="true"></i>ユーザー管理
       </a>
     </div>

--- a/web/tenant-users.html
+++ b/web/tenant-users.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>プロフィール — Tasks</title>
+  <title>ユーザー管理 — Tasks</title>
   <link rel="icon" type="image/svg+xml" href="/favicon.svg">
   <link rel="stylesheet" href="vendor/bootstrap/css/bootstrap.min.css">
   <link rel="stylesheet" href="vendor/bootstrap-icons/bootstrap-icons.min.css">
@@ -48,12 +48,12 @@
       <a class="side-link" href="tenant-dashboard.html">
         <i class="bi bi-graph-up-arrow" aria-hidden="true"></i>運営者ダッシュボード
       </a>
-      <a class="side-link" href="tenant-users.html">
+      <a class="side-link active" href="tenant-users.html" aria-current="page">
         <i class="bi bi-people" aria-hidden="true"></i>ユーザー管理
       </a>
     </div>
     <div class="nav-group-label" aria-hidden="true">アカウント</div>
-    <a class="side-link active" href="profile.html" aria-current="page">
+    <a class="side-link" href="profile.html">
       <i class="bi bi-person-circle" aria-hidden="true"></i>プロフィール
     </a>
     <a class="side-link" href="notification-settings.html">
@@ -64,7 +64,7 @@
   <!-- ===== Main ===== -->
   <main id="main-content" class="app-main">
     <div class="d-flex align-items-center flex-wrap gap-3 mb-3">
-      <h1 class="page-title">プロフィール</h1>
+      <h1 class="page-title">ユーザー管理</h1>
     </div>
 
     <div id="error-alert" class="alert alert-danger d-none" role="alert"></div>
@@ -73,23 +73,54 @@
       <div class="spinner-border text-primary" role="status">
         <span class="visually-hidden">Loading...</span>
       </div>
-      <p class="mt-2 text-muted">プロフィールを取得中...</p>
+      <p class="mt-2 text-muted">ユーザー情報を取得中...</p>
     </div>
 
-    <div class="row justify-content-center">
-      <div class="col-12 col-md-9 col-lg-7">
-        <div id="profile-card" class="card d-none">
-          <div class="card-body">
-            <dl class="row mb-0">
-              <dt class="col-sm-4 text-muted">氏名</dt>
-              <dd id="pf-full-name" class="col-sm-8"></dd>
-              <dt class="col-sm-4 text-muted">フリガナ</dt>
-              <dd id="pf-full-name-kana" class="col-sm-8"></dd>
-              <dt class="col-sm-4 text-muted">メールアドレス</dt>
-              <dd id="pf-email" class="col-sm-8"></dd>
-              <dt class="col-sm-4 text-muted">部署</dt>
-              <dd id="pf-department" class="col-sm-8"></dd>
-            </dl>
+    <div id="content" class="d-none">
+      <!-- ===== 招待フォーム ===== -->
+      <div class="card mb-4">
+        <div class="card-body">
+          <h2 class="h6 mb-3">ユーザーを招待</h2>
+          <form id="invite-form" class="row g-2 align-items-end" novalidate>
+            <div class="col-12 col-md-6">
+              <label for="invite-email" class="form-label small text-muted">メールアドレス</label>
+              <input type="email" id="invite-email" class="form-control" required
+                placeholder="user@example.com" autocomplete="off">
+            </div>
+            <div class="col-8 col-md-3">
+              <label for="invite-role" class="form-label small text-muted">ロール</label>
+              <select id="invite-role" class="form-select">
+                <option value="MEMBER" selected>メンバー</option>
+                <option value="TENANT_ADMIN">テナント管理者</option>
+              </select>
+            </div>
+            <div class="col-4 col-md-3 d-grid">
+              <button type="submit" id="btn-invite" class="btn btn-primary">
+                <i class="bi bi-envelope-plus me-1" aria-hidden="true"></i>招待
+              </button>
+            </div>
+          </form>
+          <div id="invite-feedback" class="small mt-2 d-none" role="status"></div>
+        </div>
+      </div>
+
+      <!-- ===== メンバー一覧 ===== -->
+      <div class="card">
+        <div class="card-body">
+          <h2 class="h6 mb-3">メンバー一覧</h2>
+          <div class="table-responsive">
+            <table class="table align-middle mb-0" aria-label="メンバー一覧">
+              <thead>
+                <tr>
+                  <th scope="col">氏名</th>
+                  <th scope="col">メールアドレス</th>
+                  <th scope="col">ロール</th>
+                  <th scope="col">状態</th>
+                  <th scope="col" class="text-end">操作</th>
+                </tr>
+              </thead>
+              <tbody id="users-tbody"></tbody>
+            </table>
           </div>
         </div>
       </div>
@@ -103,6 +134,6 @@
 <script src="js/auth.js"></script>
 <script src="js/api.js"></script>
 <script src="js/components/app-tenant-switcher.js"></script>
-<script src="js/profile.js"></script>
+<script src="js/tenant-users.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## 概要
S-08「ユーザー管理(テナント)」(Tenant Admin 専用)を縦切りで実装する。Tracker #795 のサブ Issue #794(#792/#793 マージ後の最終ピース)。サイドバーの「ユーザー管理」プレースホルダ(`href="#"`)を実画面に接続する。

## 変更点
- **`web/tenant-users.html` + `web/js/tenant-users.js`**:
  - メンバー一覧(氏名 / メール / ロール / 状態)。状態は **ACTIVE/INVITED** をバッジ表示。
  - **招待フォーム**(email + ロール、A-09)。結果を inline 表示(409=既メンバー / 403 を区別)。
  - **行内ロール変更**(`PUT /api/tenant/users/{id}/role`、A-10)。`<select>` 変更で適用、失敗時は元に戻す。
  - **削除**(`DELETE /api/tenant/users/{id}`、A-30)。確認ダイアログ後に実行。
  - **自分自身の行**はロール変更/削除を無効化(API の 403 と整合・自己ロックアウト防止)。
  - Tenant Admin 以外・テナント未選択はガード(403 表示 / index へリダイレクト)。
- **`web/js/api.js`**: `inviteUser` / `updateMemberRole` / `removeMember` を追加(既存 `listTenantUsers` と同パターン・X-Tenant-Id 自動付与)。
- **サイドバー導線**: 「ユーザー管理」リンクを `profile` / `tasks` / `tenant-dashboard` / `notification-settings` の 4 ページで `tenant-users.html` に接続(`.admin-only` 配下なので Tenant Admin のみ表示)。
- **`web/package.json`**: html-validate 対象に `tenant-users.html` を追加。
- **E2E**: `e2e/tests/tenant-users.spec.ts`(tenant1-admin でログイン → 画面遷移 → メンバー一覧表示 + 招待のハッピーパス、規約 §9.7)。fixtures に `ADMIN1` を追加。
- **基本設計書 §3.2** S-08 行に 一覧/削除(A-30)・自己操作不可を追記。

## 検証
- `npx biome ci .`(web / e2e)green
- `npm run html-validate`(tenant-users.html 追加)green
- `npx tsc --noEmit`(web / e2e)green
- E2E は CI(e2e-test-changes)で実行。

## 受け入れ条件
- [x] 一覧表示(状態 INVITED/ACTIVE 区別)
- [x] 招待フォーム(email)+ 結果反映
- [x] ロール変更 UI + 反映
- [x] メンバー削除 UI + 反映
- [x] Tenant Admin 専用導線(サイドバーリンク有効化)
- [x] E2E ハッピーパス spec 1 本(規約 §9.7)

Closes #794

🤖 Generated with [Claude Code](https://claude.com/claude-code)