### PR TITLE
feat(admin): S-12 プラットフォーム監視ダッシュボード + SaaS Admin シェル (Closes #799)

### DIFF
--- a/e2e/fixtures/auth.ts
+++ b/e2e/fixtures/auth.ts
@@ -10,6 +10,11 @@ export const ADMIN1 = {
   password: 'password',
 } as const;
 
+export const SAAS_ADMIN = {
+  username: 'admin@example.com',
+  password: 'admin',
+} as const;
+
 /**
  * Keycloak PKCE ログインを実行して tasks.html に到達するまで待機する。
  * tenant1-member1 は tenant1 に 1 所属しているため index.html が自動でテナントを
@@ -23,4 +28,23 @@ export async function loginAs(page: Page, username: string, password: string): P
   await page.click('#kc-login');
   // index.html が /api/auth/me を呼び、単一テナントを自動選択して tasks.html へ転送する。
   await page.waitForURL(/\/tasks\.html/, { timeout: 15_000 });
+}
+
+/**
+ * SaaS 運営者(APP_ADMIN)としてログインし admin.html に到達するまで待機する。
+ * admin@example.com はテナント未所属で APP_ADMIN realm role を持つため、
+ * index.html が APP_ADMIN を検知して admin.html へ転送する。
+ */
+export async function loginAsSaasAdmin(
+  page: Page,
+  username: string,
+  password: string,
+): Promise<void> {
+  await page.goto('/');
+  await page.waitForURL(/\/realms\/tasks\//);
+  await page.fill('#username', username);
+  await page.fill('#password', password);
+  await page.click('#kc-login');
+  // index.html が APP_ADMIN realm role を検知し admin.html へ転送する。
+  await page.waitForURL(/\/admin\.html/, { timeout: 15_000 });
 }

--- a/e2e/tests/admin.spec.ts
+++ b/e2e/tests/admin.spec.ts
@@ -1,0 +1,31 @@
+import { loginAsSaasAdmin, SAAS_ADMIN } from '../fixtures/auth';
+import { expect, test } from '../fixtures/test';
+
+// S-12 プラットフォーム監視 — SaaS 運営者(APP_ADMIN)専用画面のハッピーパス(コーディング規約 §9.7)。
+// admin@example.com でログイン → index.html が APP_ADMIN を検知して admin.html へ転送 →
+// プラットフォームメトリクスカードが表示されるまで。
+
+test.describe('S-12 プラットフォーム監視', () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAsSaasAdmin(page, SAAS_ADMIN.username, SAAS_ADMIN.password);
+  });
+
+  test('ログイン後に admin.html へ自動転送される', async ({ page }) => {
+    await expect(page).toHaveURL(/\/admin\.html/);
+    await expect(page.getByRole('heading', { name: 'プラットフォーム監視' })).toBeVisible();
+  });
+
+  test('プラットフォームメトリクスが表示される', async ({ page }) => {
+    // メトリクス取得完了でローディングが消え、メトリクス領域が表示される。
+    await expect(page.locator('#metrics')).toBeVisible({ timeout: 15_000 });
+    await expect(page.locator('#loading')).toBeHidden();
+
+    // 各カードの件数が数値で埋まる(初期プレースホルダ「—」から置き換わる)。
+    await expect(page.locator('#m-total-tenants')).not.toHaveText('—');
+    await expect(page.locator('#m-total-users')).not.toHaveText('—');
+    await expect(page.locator('#m-total-tasks')).not.toHaveText('—');
+
+    // SaaS Admin 画面はテナントスイッチャを持たない。
+    await expect(page.locator('#app-tenant-switcher')).toHaveCount(0);
+  });
+});

--- a/web/admin.html
+++ b/web/admin.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>プラットフォーム監視 — Tasks</title>
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+  <link rel="stylesheet" href="vendor/bootstrap/css/bootstrap.min.css">
+  <link rel="stylesheet" href="vendor/bootstrap-icons/bootstrap-icons.min.css">
+  <link rel="stylesheet" href="css/app.css">
+</head>
+<body>
+<a href="#main-content" class="visually-hidden-focusable position-absolute p-2 m-2 bg-primary text-white rounded">
+  メインコンテンツへスキップ
+</a>
+
+<!-- ===== Top navbar (SaaS Admin。テナントスイッチャは持たない) ===== -->
+<nav class="app-navbar d-flex align-items-center px-3 gap-3 sticky-top" aria-label="グローバルナビゲーション">
+  <a class="app-brand d-flex align-items-center gap-2" href="admin.html">
+    <i class="bi bi-shield-lock fs-5" aria-hidden="true"></i><span>Tasks 運営</span>
+  </a>
+  <div class="ms-auto d-flex align-items-center gap-3">
+    <div class="d-flex align-items-center gap-2">
+      <div id="user-avatar"
+        class="rounded-circle bg-primary-subtle text-primary d-grid"
+        aria-hidden="true">?</div>
+      <span id="nav-username" class="small d-none d-lg-inline"></span>
+    </div>
+    <button id="btn-logout" type="button" class="btn btn-outline-secondary btn-sm">
+      <i class="bi bi-box-arrow-right me-1" aria-hidden="true"></i>ログアウト
+    </button>
+  </div>
+</nav>
+
+<div class="app-layout">
+  <!-- ===== Sidebar (SaaS 運営) ===== -->
+  <aside class="app-sidebar d-none d-lg-block" aria-label="サイドナビゲーション">
+    <div class="nav-group-label" aria-hidden="true">SaaS 運営</div>
+    <a class="side-link active" href="admin.html" aria-current="page">
+      <i class="bi bi-speedometer2" aria-hidden="true"></i>プラットフォーム監視
+    </a>
+  </aside>
+
+  <!-- ===== Main ===== -->
+  <main id="main-content" class="app-main">
+    <div class="d-flex align-items-center flex-wrap gap-3 mb-3">
+      <h1 class="page-title">プラットフォーム監視</h1>
+    </div>
+
+    <div id="error-alert" class="alert alert-danger d-none" role="alert"></div>
+
+    <div id="loading" class="text-center py-5">
+      <div class="spinner-border text-primary" role="status">
+        <span class="visually-hidden">Loading...</span>
+      </div>
+      <p class="mt-2 text-muted">メトリクスを取得中...</p>
+    </div>
+
+    <div id="metrics" class="d-none">
+      <div class="row g-3">
+        <div class="col-12 col-sm-6 col-xl-3">
+          <div class="card h-100">
+            <div class="card-body">
+              <div class="text-muted small">総テナント数</div>
+              <div id="m-total-tenants" class="display-6 fw-semibold">—</div>
+              <div class="small text-muted">
+                ACTIVE <span id="m-active-tenants" class="fw-semibold text-success">—</span>
+                / SUSPENDED <span id="m-suspended-tenants" class="fw-semibold text-warning">—</span>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col-12 col-sm-6 col-xl-3">
+          <div class="card h-100">
+            <div class="card-body">
+              <div class="text-muted small">総ユーザー数</div>
+              <div id="m-total-users" class="display-6 fw-semibold">—</div>
+            </div>
+          </div>
+        </div>
+        <div class="col-12 col-sm-6 col-xl-3">
+          <div class="card h-100">
+            <div class="card-body">
+              <div class="text-muted small">総タスク数</div>
+              <div id="m-total-tasks" class="display-6 fw-semibold">—</div>
+              <div class="small text-muted">削除済みを除く</div>
+            </div>
+          </div>
+        </div>
+        <div class="col-12 col-sm-6 col-xl-3">
+          <div class="card h-100">
+            <div class="card-body">
+              <div class="text-muted small">新規テナント(直近24h)</div>
+              <div id="m-new-24h" class="display-6 fw-semibold">—</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </main>
+</div>
+
+<script src="vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
+<script src="vendor/keycloak-js/keycloak.min.js"></script>
+<script src="js/dom.js"></script>
+<script src="js/auth.js"></script>
+<script src="js/api.js"></script>
+<script src="js/admin.js"></script>
+</body>
+</html>

--- a/web/js/admin.js
+++ b/web/js/admin.js
@@ -1,0 +1,75 @@
+// @ts-check
+
+/** @type {HTMLElement} */ (mustQuery(document, '#btn-logout')).addEventListener('click', () =>
+  Auth.logout(),
+);
+
+/**
+ * エラーメッセージを表示し、ローディングを止める。
+ * @param {string} message
+ */
+function showError(message) {
+  /** @type {HTMLElement} */ (mustQuery(document, '#loading')).classList.add('d-none');
+  const el = /** @type {HTMLElement} */ (mustQuery(document, '#error-alert'));
+  el.textContent = message;
+  el.classList.remove('d-none');
+}
+
+/**
+ * 数値カードへ件数を反映する。
+ * @param {string} id
+ * @param {number} value
+ */
+function setMetric(id, value) {
+  /** @type {HTMLElement} */ (mustQuery(document, id)).textContent = value.toLocaleString('ja-JP');
+}
+
+/**
+ * @param {PlatformMetrics} m
+ */
+function render(m) {
+  setMetric('#m-total-tenants', m.totalTenants);
+  setMetric('#m-active-tenants', m.activeTenants);
+  setMetric('#m-suspended-tenants', m.suspendedTenants);
+  setMetric('#m-total-users', m.totalUsers);
+  setMetric('#m-total-tasks', m.totalTasks);
+  setMetric('#m-new-24h', m.newTenantsLast24h);
+
+  /** @type {HTMLElement} */ (mustQuery(document, '#loading')).classList.add('d-none');
+  /** @type {HTMLElement} */ (mustQuery(document, '#metrics')).classList.remove('d-none');
+}
+
+async function main() {
+  const authenticated = await Auth.init();
+  if (!authenticated) {
+    return;
+  }
+
+  const user = Auth.getUser();
+  const displayName = user?.name || user?.preferred_username || '';
+  /** @type {HTMLElement} */ (mustQuery(document, '#nav-username')).textContent = displayName;
+  /** @type {HTMLElement} */ (mustQuery(document, '#user-avatar')).textContent =
+    displayName.slice(0, 1) || '?';
+
+  if (!Auth.isAppAdmin()) {
+    showError('このページは SaaS 運営者(APP_ADMIN)のみ利用できます。');
+    return;
+  }
+
+  // プラットフォーム API はテナント非依存。残存する X-Tenant-Id を送らないようクリアする。
+  Api.setTenantId(null);
+
+  try {
+    const metrics = await Api.getPlatformMetrics();
+    render(metrics);
+  } catch (err) {
+    const e = /** @type {{ status?: number, message?: string }} */ (err);
+    showError(
+      e.status === 403
+        ? 'このページは SaaS 運営者(APP_ADMIN)のみ利用できます。'
+        : `メトリクスの取得に失敗しました: ${e.message ?? '不明なエラー'}`,
+    );
+  }
+}
+
+main();

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -127,6 +127,16 @@
  */
 
 /**
+ * @typedef {object} PlatformMetrics
+ * @property {number} totalTenants
+ * @property {number} activeTenants
+ * @property {number} suspendedTenants
+ * @property {number} totalUsers
+ * @property {number} totalTasks
+ * @property {number} newTenantsLast24h
+ */
+
+/**
  * @typedef {object} TenantDashboardSummary
  * @property {number} totalTaskCount
  * @property {number} todayDueCount
@@ -409,6 +419,15 @@ const Api = (() => {
   }
 
   /**
+   * GET /api/platform/metrics — プラットフォーム全体メトリクス(A-27、S-12、SaaS Admin)。
+   * X-Tenant-Id 不要(プラットフォーム API)。呼び出し前に setTenantId(null) でクリアすること。
+   * @returns {Promise<PlatformMetrics>}
+   */
+  function getPlatformMetrics() {
+    return request('/api/platform/metrics');
+  }
+
+  /**
    * GET /api/tenant/dashboard/summary — テナント運営者向けダッシュボード集計(A-28、S-15、Tenant Admin)。
    * @returns {Promise<TenantDashboardSummary>}
    */
@@ -547,6 +566,7 @@ const Api = (() => {
     inviteUser,
     updateMemberRole,
     removeMember,
+    getPlatformMetrics,
     getTenantDashboardSummary,
     getMyProfile,
     getNotificationSettings,

--- a/web/js/auth.js
+++ b/web/js/auth.js
@@ -96,6 +96,15 @@ const Auth = (() => {
   }
 
   /**
+   * ログイン中ユーザーが SaaS Admin(Keycloak realm role APP_ADMIN)か判定する。
+   * UI 導線の出し分け用。API の認可はサーバ側(app_admin_users)が正本で、これは表示制御のみ。
+   * @returns {boolean}
+   */
+  function isAppAdmin() {
+    return _keycloak ? _keycloak.hasRealmRole('APP_ADMIN') : false;
+  }
+
+  /**
    * Keycloak ログアウトエンドポイントへリダイレクト。
    */
   function logout() {
@@ -118,5 +127,5 @@ const Auth = (() => {
     }, 30000);
   }
 
-  return { init, getToken, refreshToken, getUser, logout };
+  return { init, getToken, refreshToken, getUser, isAppAdmin, logout };
 })();

--- a/web/js/index.js
+++ b/web/js/index.js
@@ -10,6 +10,12 @@ async function main() {
     return;
   }
 
+  // SaaS Admin(APP_ADMIN)は業務ダッシュボードではなくプラットフォーム監視へ誘導する(S-12)。
+  if (Auth.isAppAdmin()) {
+    window.location.replace('admin.html');
+    return;
+  }
+
   const user = Auth.getUser();
   /** @type {HTMLElement} */ (mustQuery(document, '#nav-username')).textContent =
     user?.name || user?.preferred_username || '';

--- a/web/package.json
+++ b/web/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "copy-vendor": "node scripts/copy-vendor.js",
-    "html-validate": "html-validate index.html tasks.html tenants-new.html tenant-dashboard.html notification-settings.html profile.html tenant-users.html",
+    "html-validate": "html-validate index.html tasks.html tenants-new.html tenant-dashboard.html notification-settings.html profile.html tenant-users.html admin.html",
     "serve": "node serve.mjs"
   },
   "engines": {

--- a/web/types/globals.d.ts
+++ b/web/types/globals.d.ts
@@ -24,8 +24,10 @@ interface KeycloakInstance {
   authenticated?: boolean;
   token?: string;
   idTokenParsed?: Record<string, unknown>;
+  realmAccess?: { roles: string[] };
   init(options: KeycloakInitOptions): Promise<boolean>;
   updateToken(minValidity: number): Promise<boolean>;
+  hasRealmRole(role: string): boolean;
   login(options?: { redirectUri?: string }): void;
   logout(options?: { redirectUri?: string }): void;
 }

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/security/adapter/web/TenantContextFilter.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/security/adapter/web/TenantContextFilter.java
@@ -122,14 +122,18 @@ public class TenantContextFilter extends OncePerRequestFilter {
   /**
    * 初期テナント自動解決を行わない免除パスか判定する。
    *
-   * <p>/api/auth/** (me / select / logout)、/api/tenants/** (SaaS Admin)、/actuator/** はテナントコンテキスト不要。
-   * /api/users/me (A-07 プロフィール取得) もテナント選択非依存のため免除する。ただし完全一致のみ免除し、
-   * /api/users/me/notification-settings (S-10、テナントスコープ) は免除しない。
+   * <p>/api/auth/** (me / select / logout)、/api/tenants/** (SaaS Admin)、/api/platform/** (SaaS
+   * Admin プラットフォーム API、A-27)、/actuator/** はテナントコンテキスト不要(基本設計書 §5.2 X-Tenant-Id 不要枠)。 /api/users/me
+   * (A-07 プロフィール取得) もテナント選択非依存のため免除する。ただし完全一致のみ免除し、 /api/users/me/notification-settings
+   * (S-10、テナントスコープ) は免除しない。
+   *
+   * <p>SaaS Admin はテナント未所属が通常のため、/api/platform を免除しないと初期テナント解決で 403 になる。
    */
   private static boolean isExemptPath(HttpServletRequest request) {
     String uri = request.getRequestURI();
     return uri.startsWith("/api/auth/")
         || uri.startsWith("/api/tenants")
+        || uri.startsWith("/api/platform")
         || uri.startsWith("/actuator/")
         || uri.equals("/actuator")
         || uri.equals("/api/users/me");

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/security/adapter/web/TenantContextFilter.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/security/adapter/web/TenantContextFilter.java
@@ -35,9 +35,9 @@ import xyz.dgz48.tasks.webapi.tenant.usecase.UserTenantsResolverService;
  * <p>ヘッダ指定時: 認証済みユーザーが指定テナントの ACTIVE メンバーでない場合は 403 を返す。メンバーの場合は ROLE_TENANT_ADMIN または ROLE_MEMBER
  * を SecurityContext に付与する。
  *
- * <p>ヘッダ未指定時: 免除パス({@code /api/auth/**}, {@code /api/tenants/**}, {@code /actuator/**})および
- * 非認証リクエストはそのまま通過。それ以外の認証済みリクエストは {@link UserTenantsResolverService} で初期テナントを自動解決する(ADR-0016)。
- * 所属テナント 0 件の場合は 403 を返す。
+ * <p>ヘッダ未指定時: 免除パス({@code /api/auth/**}, {@code /api/tenants/**}, {@code /api/platform/**}, {@code
+ * /actuator/**})および非認証リクエストはそのまま通過。それ以外の認証済みリクエストは {@link UserTenantsResolverService}
+ * で初期テナントを自動解決する(ADR-0016)。 所属テナント 0 件の場合は 403 を返す。
  *
  * <p>エラー応答は ADR-0011 の {@link ErrorResponse} 形式で返す。
  */

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/TenantContextFilterTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/TenantContextFilterTest.java
@@ -43,6 +43,7 @@ import xyz.dgz48.tasks.webapi.task.usecase.ListStakeholdersUseCase;
 import xyz.dgz48.tasks.webapi.task.usecase.ListTasksUseCase;
 import xyz.dgz48.tasks.webapi.task.usecase.RemoveStakeholderUseCase;
 import xyz.dgz48.tasks.webapi.task.usecase.UpdateTaskUseCase;
+import xyz.dgz48.tasks.webapi.tenant.domain.PlatformMetrics;
 import xyz.dgz48.tasks.webapi.tenant.domain.TenantMembership;
 import xyz.dgz48.tasks.webapi.tenant.domain.TenantRole;
 import xyz.dgz48.tasks.webapi.tenant.usecase.ChangeMemberRoleUseCase;
@@ -265,6 +266,17 @@ class TenantContextFilterTest {
   @WithMockMember
   void noHeader_exemptAuthPath_resolverNotCalled() throws Exception {
     mockMvc.perform(get("/api/auth/tenants/1/select"));
+    org.mockito.Mockito.verify(userTenantsResolverService, org.mockito.Mockito.never())
+        .resolveInitial(org.mockito.ArgumentMatchers.anyLong());
+  }
+
+  @Test
+  @WithMockSaasAdmin
+  void noHeader_exemptPlatformPath_reachesController_withoutTenantResolution() throws Exception {
+    // SaaS Admin はテナント未所属が通常。/api/platform は免除パスのため初期テナント解決を行わず到達できる(A-27)。
+    given(getPlatformMetricsUseCase.execute(org.mockito.ArgumentMatchers.anyLong()))
+        .willReturn(new PlatformMetrics(0L, 0L, 0L, 0L, 0L, 0L));
+    mockMvc.perform(get("/api/platform/metrics")).andExpect(status().isOk());
     org.mockito.Mockito.verify(userTenantsResolverService, org.mockito.Mockito.never())
         .resolveInitial(org.mockito.ArgumentMatchers.anyLong());
   }


### PR DESCRIPTION
## 概要

SaaS 運営者(APP_ADMIN)向けの管理画面シェルとプラットフォーム監視ダッシュボード(S-12)を追加します。トラッカー #802 の最初のサブ課題です。

`/api/platform/metrics`(A-27、`GetPlatformMetricsUseCase`)は既に実装済みでしたが、これを表示するフロント画面(S-12/13/14)が未着手でした。本 PR は **S-12 + SaaS Admin シェル基盤** を縦切りで実装します。

## 変更点

### フロントエンド
- **`web/admin.html` / `js/admin.js`(新規)**: テナントスイッチャを持たない SaaS Admin シェル + メトリクスカード(総テナント数 / ACTIVE / SUSPENDED / 総ユーザー数 / 総タスク数 / 新規24h)。`GET /api/platform/metrics` を呼び表示。
- **`js/auth.js`**: `isAppAdmin()`(Keycloak `APP_ADMIN` realm role 判定)を追加・export。
- **`js/api.js`**: `getPlatformMetrics()` + `PlatformMetrics` typedef を追加。
- **`js/index.js`**: `APP_ADMIN` ログイン時は `admin.html` へ自動転送。
- **`types/globals.d.ts`**: `KeycloakInstance` に `realmAccess` / `hasRealmRole` を追加。

### バックエンド
- **`TenantContextFilter`**: `/api/platform` を初期テナント解決の免除パスに追加。SaaS Admin はテナント未所属が通常のため、免除しないと初期テナント解決で 403 になる(潜在バグ修正)。`@PreAuthorize("hasRole('APP_ADMIN')")` による認可は従来どおり。

### E2E
- `SAAS_ADMIN` fixture + `loginAsSaasAdmin` ヘルパ(admin.html への転送を待機)+ `admin.spec.ts`(ログイン転送・メトリクスカード表示・スイッチャ不在を検証)。

## 確認

- `./gradlew :webapi:check` green(spotless / NullAway / JaCoCo 0.80 / Testcontainers IT、`TenantContextFilterTest` に免除パス疎通テスト追加)
- `cd web && npx biome ci . && npm run html-validate && npx tsc --noEmit` green
- `cd e2e && npx biome ci . && npx tsc --noEmit` green

Closes #799

🤖 Generated with [Claude Code](https://claude.com/claude-code)