### PR TITLE
feat(admin): S-13 テナント一覧画面 (SaaS Admin) (Closes #800)

### DIFF
--- a/e2e/tests/admin-tenants.spec.ts
+++ b/e2e/tests/admin-tenants.spec.ts
@@ -1,0 +1,44 @@
+import { loginAsSaasAdmin, SAAS_ADMIN } from '../fixtures/auth';
+import { expect, test } from '../fixtures/test';
+
+// S-13 テナント管理(一覧)— SaaS 運営者(APP_ADMIN)専用画面のハッピーパス(コーディング規約 §9.7)。
+// admin@example.com でログイン → admin.html → サイドバーから admin-tenants.html へ →
+// テナント一覧表示・状態フィルタ・S-14 詳細リンクの確認まで。
+
+test.describe('S-13 テナント管理(一覧)', () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAsSaasAdmin(page, SAAS_ADMIN.username, SAAS_ADMIN.password);
+    await page.goto('/admin-tenants.html');
+    await expect(page.locator('#result')).toBeVisible({ timeout: 15_000 });
+  });
+
+  test('テナント一覧が表示され、各行が S-14 詳細へリンクする', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: 'テナント管理' })).toBeVisible();
+    const table = page.locator('table[aria-label="テナント一覧"]');
+    await expect(table).toBeVisible();
+
+    // seed 済みの tenant1 が一覧に並ぶ。
+    const tbody = page.locator('#tenants-tbody');
+    await expect(tbody.locator('tr')).not.toHaveCount(0);
+
+    // 行のテナント名は S-14 詳細(admin-tenant-detail.html?id=...)へのリンク。
+    const firstLink = tbody.locator('tr').first().locator('a').first();
+    await expect(firstLink).toHaveAttribute('href', /admin-tenant-detail\.html\?id=\d+/);
+
+    // テナントスイッチャを持たない SaaS Admin 画面。
+    await expect(page.locator('#app-tenant-switcher')).toHaveCount(0);
+  });
+
+  test('状態フィルタで ACTIVE のみに絞り込める', async ({ page }) => {
+    await page.selectOption('#filter-status', 'ACTIVE');
+    await page.click('#btn-search');
+
+    // 絞り込み後も一覧が再描画される(空でなければ各行は ACTIVE バッジを持つ)。
+    await expect(page.locator('#result')).toBeVisible();
+    const badges = page.locator('#tenants-tbody tr .badge');
+    const count = await badges.count();
+    for (let i = 0; i < count; i++) {
+      await expect(badges.nth(i)).toHaveText('ACTIVE');
+    }
+  });
+});

--- a/web/admin-tenants.html
+++ b/web/admin-tenants.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>テナント管理 — Tasks</title>
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+  <link rel="stylesheet" href="vendor/bootstrap/css/bootstrap.min.css">
+  <link rel="stylesheet" href="vendor/bootstrap-icons/bootstrap-icons.min.css">
+  <link rel="stylesheet" href="css/app.css">
+</head>
+<body>
+<a href="#main-content" class="visually-hidden-focusable position-absolute p-2 m-2 bg-primary text-white rounded">
+  メインコンテンツへスキップ
+</a>
+
+<!-- ===== Top navbar (SaaS Admin。テナントスイッチャは持たない) ===== -->
+<nav class="app-navbar d-flex align-items-center px-3 gap-3 sticky-top" aria-label="グローバルナビゲーション">
+  <a class="app-brand d-flex align-items-center gap-2" href="admin.html">
+    <i class="bi bi-shield-lock fs-5" aria-hidden="true"></i><span>Tasks 運営</span>
+  </a>
+  <div class="ms-auto d-flex align-items-center gap-3">
+    <div class="d-flex align-items-center gap-2">
+      <div id="user-avatar"
+        class="rounded-circle bg-primary-subtle text-primary d-grid"
+        aria-hidden="true">?</div>
+      <span id="nav-username" class="small d-none d-lg-inline"></span>
+    </div>
+    <button id="btn-logout" type="button" class="btn btn-outline-secondary btn-sm">
+      <i class="bi bi-box-arrow-right me-1" aria-hidden="true"></i>ログアウト
+    </button>
+  </div>
+</nav>
+
+<div class="app-layout">
+  <!-- ===== Sidebar (SaaS 運営) ===== -->
+  <aside class="app-sidebar d-none d-lg-block" aria-label="サイドナビゲーション">
+    <div class="nav-group-label" aria-hidden="true">SaaS 運営</div>
+    <a class="side-link" href="admin.html">
+      <i class="bi bi-speedometer2" aria-hidden="true"></i>プラットフォーム監視
+    </a>
+    <a class="side-link active" href="admin-tenants.html" aria-current="page">
+      <i class="bi bi-building" aria-hidden="true"></i>テナント管理
+    </a>
+  </aside>
+
+  <!-- ===== Main ===== -->
+  <main id="main-content" class="app-main">
+    <div class="d-flex align-items-center flex-wrap gap-3 mb-3">
+      <h1 class="page-title">テナント管理</h1>
+    </div>
+
+    <div id="error-alert" class="alert alert-danger d-none" role="alert"></div>
+
+    <!-- ===== Filters ===== -->
+    <form id="filter-form" class="row g-2 align-items-end mb-3" aria-label="テナント絞り込み">
+      <div class="col-12 col-sm-4 col-lg-3">
+        <label for="filter-status" class="form-label small mb-1">状態</label>
+        <select id="filter-status" class="form-select form-select-sm">
+          <option value="">すべて</option>
+          <option value="ACTIVE">ACTIVE</option>
+          <option value="SUSPENDED">SUSPENDED</option>
+        </select>
+      </div>
+      <div class="col-12 col-sm-5 col-lg-4">
+        <label for="filter-keyword" class="form-label small mb-1">名前 / コード検索</label>
+        <input id="filter-keyword" type="search" class="form-control form-control-sm"
+          placeholder="テナント名またはコード" autocomplete="off">
+      </div>
+      <div class="col-12 col-sm-3 col-lg-2">
+        <button id="btn-search" type="submit" class="btn btn-primary btn-sm w-100">
+          <i class="bi bi-search me-1" aria-hidden="true"></i>検索
+        </button>
+      </div>
+    </form>
+
+    <div id="loading" class="text-center py-5">
+      <div class="spinner-border text-primary" role="status">
+        <span class="visually-hidden">Loading...</span>
+      </div>
+      <p class="mt-2 text-muted">テナントを取得中...</p>
+    </div>
+
+    <div id="result" class="d-none">
+      <div class="table-responsive">
+        <table class="table table-hover align-middle" aria-label="テナント一覧">
+          <thead>
+            <tr>
+              <th scope="col">テナント名</th>
+              <th scope="col">コード</th>
+              <th scope="col">プラン</th>
+              <th scope="col">状態</th>
+              <th scope="col" class="text-end">ユーザー</th>
+              <th scope="col" class="text-end">タスク</th>
+              <th scope="col">作成日</th>
+            </tr>
+          </thead>
+          <tbody id="tenants-tbody"></tbody>
+        </table>
+      </div>
+
+      <p id="empty-message" class="text-muted text-center py-4 d-none">
+        該当するテナントはありません。
+      </p>
+
+      <nav class="d-flex justify-content-between align-items-center mt-3" aria-label="ページネーション">
+        <span id="page-info" class="small text-muted"></span>
+        <div class="btn-group">
+          <button id="btn-prev" type="button" class="btn btn-outline-secondary btn-sm" disabled>
+            <i class="bi bi-chevron-left" aria-hidden="true"></i>前へ
+          </button>
+          <button id="btn-next" type="button" class="btn btn-outline-secondary btn-sm" disabled>
+            次へ<i class="bi bi-chevron-right" aria-hidden="true"></i>
+          </button>
+        </div>
+      </nav>
+    </div>
+  </main>
+</div>
+
+<script src="vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
+<script src="vendor/keycloak-js/keycloak.min.js"></script>
+<script src="js/dom.js"></script>
+<script src="js/auth.js"></script>
+<script src="js/api.js"></script>
+<script src="js/admin-tenants.js"></script>
+</body>
+</html>

--- a/web/admin.html
+++ b/web/admin.html
@@ -39,6 +39,9 @@
     <a class="side-link active" href="admin.html" aria-current="page">
       <i class="bi bi-speedometer2" aria-hidden="true"></i>プラットフォーム監視
     </a>
+    <a class="side-link" href="admin-tenants.html">
+      <i class="bi bi-building" aria-hidden="true"></i>テナント管理
+    </a>
   </aside>
 
   <!-- ===== Main ===== -->

--- a/web/js/admin-tenants.js
+++ b/web/js/admin-tenants.js
@@ -1,0 +1,196 @@
+// @ts-check
+
+/** @type {HTMLElement} */ (mustQuery(document, '#btn-logout')).addEventListener('click', () =>
+  Auth.logout(),
+);
+
+const TENANT_PAGE_SIZE = 50;
+
+/** 現在のページ番号(0 始まり)。 */
+let tenantListPage = 0;
+/** 現在の状態フィルタ(空はすべて)。 @type {'ACTIVE'|'SUSPENDED'|''} */
+let tenantListStatus = '';
+/** 現在の検索キーワード。 */
+let tenantListKeyword = '';
+
+/**
+ * エラーメッセージを表示し、ローディングを止める。
+ * @param {string} message
+ */
+function showError(message) {
+  /** @type {HTMLElement} */ (mustQuery(document, '#loading')).classList.add('d-none');
+  const el = /** @type {HTMLElement} */ (mustQuery(document, '#error-alert'));
+  el.textContent = message;
+  el.classList.remove('d-none');
+}
+
+/**
+ * テナント状態バッジの [ラベル, Bootstrap クラス] を返す。
+ * @param {string} status
+ * @returns {[string, string]}
+ */
+function statusBadge(status) {
+  if (status === 'ACTIVE') return ['ACTIVE', 'text-bg-success'];
+  if (status === 'SUSPENDED') return ['SUSPENDED', 'text-bg-warning'];
+  return [status, 'text-bg-secondary'];
+}
+
+/**
+ * ISO 日時を YYYY-MM-DD 表記にする。
+ * @param {string} iso
+ * @returns {string}
+ */
+function formatDate(iso) {
+  return iso ? iso.slice(0, 10) : '';
+}
+
+/**
+ * 1 テナント分の行要素を生成する。テナント名は S-14 詳細へのリンク。
+ * @param {Tenant} t
+ * @returns {HTMLTableRowElement}
+ */
+function buildRow(t) {
+  const tr = document.createElement('tr');
+
+  const tdName = document.createElement('td');
+  const link = document.createElement('a');
+  link.href = `admin-tenant-detail.html?id=${t.id}`;
+  link.textContent = t.name;
+  link.className = 'fw-semibold text-decoration-none';
+  tdName.append(link);
+
+  const tdCode = document.createElement('td');
+  tdCode.className = 'text-muted small font-monospace';
+  tdCode.textContent = t.code;
+
+  const tdPlan = document.createElement('td');
+  tdPlan.textContent = t.plan;
+
+  const tdStatus = document.createElement('td');
+  const [label, cls] = statusBadge(t.status);
+  const badge = document.createElement('span');
+  badge.className = `badge ${cls}`;
+  badge.textContent = label;
+  tdStatus.append(badge);
+
+  const tdUsers = document.createElement('td');
+  tdUsers.className = 'text-end';
+  tdUsers.textContent = t.userCount.toLocaleString('ja-JP');
+
+  const tdTasks = document.createElement('td');
+  tdTasks.className = 'text-end';
+  tdTasks.textContent = t.taskCount.toLocaleString('ja-JP');
+
+  const tdCreated = document.createElement('td');
+  tdCreated.className = 'text-muted small';
+  tdCreated.textContent = formatDate(t.createdAt);
+
+  tr.append(tdName, tdCode, tdPlan, tdStatus, tdUsers, tdTasks, tdCreated);
+  return tr;
+}
+
+/**
+ * 一覧ページを描画する。
+ * @param {TenantPage} page
+ */
+function render(page) {
+  const tbody = /** @type {HTMLElement} */ (mustQuery(document, '#tenants-tbody'));
+  tbody.replaceChildren();
+  for (const t of page.content) {
+    tbody.append(buildRow(t));
+  }
+
+  const empty = /** @type {HTMLElement} */ (mustQuery(document, '#empty-message'));
+  empty.classList.toggle('d-none', page.content.length > 0);
+
+  const from = page.totalElements === 0 ? 0 : page.number * page.size + 1;
+  const to = page.number * page.size + page.content.length;
+  /** @type {HTMLElement} */ (mustQuery(document, '#page-info')).textContent =
+    `${page.totalElements.toLocaleString('ja-JP')} 件中 ${from}–${to} 件(${page.number + 1} / ${Math.max(page.totalPages, 1)} ページ)`;
+
+  /** @type {HTMLButtonElement} */ (mustQuery(document, '#btn-prev')).disabled = page.number <= 0;
+  /** @type {HTMLButtonElement} */ (mustQuery(document, '#btn-next')).disabled =
+    page.number + 1 >= page.totalPages;
+
+  /** @type {HTMLElement} */ (mustQuery(document, '#loading')).classList.add('d-none');
+  /** @type {HTMLElement} */ (mustQuery(document, '#result')).classList.remove('d-none');
+}
+
+/** 現在のフィルタ条件でテナント一覧を取得して描画する。 */
+async function load() {
+  /** @type {HTMLElement} */ (mustQuery(document, '#loading')).classList.remove('d-none');
+  /** @type {HTMLElement} */ (mustQuery(document, '#error-alert')).classList.add('d-none');
+  try {
+    /** @type {{status?: 'ACTIVE'|'SUSPENDED', keyword?: string, page: number, size: number}} */
+    const params = { page: tenantListPage, size: TENANT_PAGE_SIZE };
+    if (tenantListStatus) params.status = tenantListStatus;
+    if (tenantListKeyword) params.keyword = tenantListKeyword;
+    const page = await Api.listTenants(params);
+    render(page);
+  } catch (err) {
+    const e = /** @type {{ status?: number, message?: string }} */ (err);
+    showError(
+      e.status === 403
+        ? 'このページは SaaS 運営者(APP_ADMIN)のみ利用できます。'
+        : `テナント一覧の取得に失敗しました: ${e.message ?? '不明なエラー'}`,
+    );
+  }
+}
+
+/** フィルタフォームとページングボタンのイベントを登録する。 */
+function wireControls() {
+  const form = /** @type {HTMLFormElement} */ (mustQuery(document, '#filter-form'));
+  const statusSelect = /** @type {HTMLSelectElement} */ (mustQuery(document, '#filter-status'));
+  const keywordInput = /** @type {HTMLInputElement} */ (mustQuery(document, '#filter-keyword'));
+
+  form.addEventListener('submit', (e) => {
+    e.preventDefault();
+    tenantListStatus = /** @type {'ACTIVE'|'SUSPENDED'|''} */ (statusSelect.value);
+    tenantListKeyword = keywordInput.value.trim();
+    tenantListPage = 0;
+    load();
+  });
+
+  /** @type {HTMLButtonElement} */ (mustQuery(document, '#btn-prev')).addEventListener(
+    'click',
+    () => {
+      if (tenantListPage > 0) {
+        tenantListPage -= 1;
+        load();
+      }
+    },
+  );
+  /** @type {HTMLButtonElement} */ (mustQuery(document, '#btn-next')).addEventListener(
+    'click',
+    () => {
+      tenantListPage += 1;
+      load();
+    },
+  );
+}
+
+async function main() {
+  const authenticated = await Auth.init();
+  if (!authenticated) {
+    return;
+  }
+
+  const user = Auth.getUser();
+  const displayName = user?.name || user?.preferred_username || '';
+  /** @type {HTMLElement} */ (mustQuery(document, '#nav-username')).textContent = displayName;
+  /** @type {HTMLElement} */ (mustQuery(document, '#user-avatar')).textContent =
+    displayName.slice(0, 1) || '?';
+
+  if (!Auth.isAppAdmin()) {
+    showError('このページは SaaS 運営者(APP_ADMIN)のみ利用できます。');
+    return;
+  }
+
+  // プラットフォーム API はテナント非依存。残存する X-Tenant-Id を送らないようクリアする。
+  Api.setTenantId(null);
+
+  wireControls();
+  await load();
+}
+
+main();

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -91,6 +91,15 @@
  */
 
 /**
+ * @typedef {object} TenantPage
+ * @property {Tenant[]} content
+ * @property {number} totalElements
+ * @property {number} totalPages
+ * @property {number} number
+ * @property {number} size
+ */
+
+/**
  * @typedef {object} TenantCreatedResponse
  * @property {Tenant} tenant
  * @property {TenantUser} initialAdmin
@@ -419,6 +428,26 @@ const Api = (() => {
   }
 
   /**
+   * GET /api/tenants — テナント一覧(A-04、S-13、SaaS Admin)。
+   * X-Tenant-Id 不要(プラットフォーム API)。呼び出し前に setTenantId(null) でクリアすること。
+   * @param {Object} [params]
+   * @param {'ACTIVE'|'SUSPENDED'} [params.status] - 状態フィルタ(未指定はすべて)
+   * @param {string} [params.keyword] - テナント名/コード部分一致
+   * @param {number} [params.page] - ページ番号(0 始まり)
+   * @param {number} [params.size] - 1 ページ件数(max 100、default 50)
+   * @returns {Promise<TenantPage>}
+   */
+  function listTenants(params = {}) {
+    const q = new URLSearchParams();
+    if (params.status) q.set('status', params.status);
+    if (params.keyword) q.set('keyword', params.keyword);
+    if (params.page !== undefined) q.set('page', String(params.page));
+    if (params.size !== undefined) q.set('size', String(params.size));
+    const qs = q.toString();
+    return request(`/api/tenants${qs ? `?${qs}` : ''}`);
+  }
+
+  /**
    * GET /api/platform/metrics — プラットフォーム全体メトリクス(A-27、S-12、SaaS Admin)。
    * X-Tenant-Id 不要(プラットフォーム API)。呼び出し前に setTenantId(null) でクリアすること。
    * @returns {Promise<PlatformMetrics>}
@@ -555,6 +584,7 @@ const Api = (() => {
     getMe,
     selectTenant,
     createTenant,
+    listTenants,
     listTasks,
     getTask,
     createTask,

--- a/web/package.json
+++ b/web/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "copy-vendor": "node scripts/copy-vendor.js",
-    "html-validate": "html-validate index.html tasks.html tenants-new.html tenant-dashboard.html notification-settings.html profile.html tenant-users.html admin.html",
+    "html-validate": "html-validate index.html tasks.html tenants-new.html tenant-dashboard.html notification-settings.html profile.html tenant-users.html admin.html admin-tenants.html",
     "serve": "node serve.mjs"
   },
   "engines": {


### PR DESCRIPTION
## 概要

SaaS 運営者(APP_ADMIN)向けの **テナント一覧画面(S-13)** を追加します。トラッカー #802 の 2 番目のサブ課題で、#799(S-12 + SaaS Admin シェル基盤)に続きます。

A-04 `GET /api/tenants`(`listTenants`)はバックエンド実装・テスト済みでしたが、表示する Web 画面が未着手でした。本 PR はその縦切り画面を追加します。

## 変更点

### フロントエンド
- **`web/admin-tenants.html` / `js/admin-tenants.js`(新規)**: 状態フィルタ(ACTIVE / SUSPENDED / すべて)+ 名前・コード検索 + ページング(50 件 / ページ、前へ・次へ)のテナント一覧。各行のテナント名は **S-14 詳細**(`admin-tenant-detail.html?id=...`)へのリンク。
- **`js/api.js`**: `listTenants({status, keyword, page, size})` + `TenantPage` typedef を追加。
- **`admin.html`**: サイドバー「SaaS 運営」グループに「テナント管理」リンクを追加(S-12 ⇄ S-13 の相互導線)。

SaaS Admin 専用ガード(`Auth.isAppAdmin`)と `Api.setTenantId(null)` による X-Tenant-Id クリアは S-12 と同方式。

### E2E
- `admin-tenants.spec.ts`: 一覧表示・各行の S-14 詳細リンク・状態フィルタ(ACTIVE 絞り込み)・テナントスイッチャ不在を検証。

## 確認

- `cd web && npx biome ci . && npm run html-validate && npx tsc --noEmit` green
- `cd e2e && npx biome ci . && npx tsc --noEmit` green
- バックエンド変更なし(フロントエンドのみ)

## 補足

各行リンク先の `admin-tenant-detail.html`(S-14)は次の #801 で追加します。本 PR ではリンク配線まで(href 検証は E2E 済み)。

Closes #800

🤖 Generated with [Claude Code](https://claude.com/claude-code)