### PR TITLE
fix(security): native-image で @AuthenticationPrincipal(expression="id") を解決可能にする (Closes #806)

### DIFF
--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/security/infra/SecurityRuntimeHints.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/security/infra/SecurityRuntimeHints.java
@@ -1,0 +1,37 @@
+package xyz.dgz48.tasks.webapi.security.infra;
+
+import org.jspecify.annotations.Nullable;
+import org.springframework.aot.hint.MemberCategory;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.RuntimeHintsRegistrar;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.ImportRuntimeHints;
+import xyz.dgz48.tasks.webapi.security.domain.TasksPrincipal;
+
+/**
+ * native-image 用リフレクションヒント(security feature)。
+ *
+ * <p>コントローラの {@code @AuthenticationPrincipal(expression = "id")} は SpEL で {@link
+ * TasksPrincipal#getId()} をリフレクション解決する。native-image では対象型を明示登録しないと {@code SpelEvaluationException:
+ * EL1008E ... 'id' cannot be found} となり当該エンドポイントが 500 になる。
+ *
+ * <p>JVM ではリフレクションが常に可能なため CI(JVM テスト / e2e)では顕在化せず、native-image を実行する 環境(ADR-0008、dev/stg/prd の
+ * ECS)でのみ発生する。Spring AOT は principal の実型を静的に決定できず 自動登録しないため、ここで明示登録する。
+ */
+@Configuration(proxyBeanMethods = false)
+@ImportRuntimeHints(SecurityRuntimeHints.Registrar.class)
+class SecurityRuntimeHints {
+
+  static class Registrar implements RuntimeHintsRegistrar {
+
+    @Override
+    public void registerHints(RuntimeHints hints, @Nullable ClassLoader classLoader) {
+      hints
+          .reflection()
+          .registerType(
+              TasksPrincipal.class,
+              MemberCategory.INVOKE_PUBLIC_METHODS,
+              MemberCategory.DECLARED_FIELDS);
+    }
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/security/infra/package-info.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/security/infra/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package xyz.dgz48.tasks.webapi.security.infra;
+
+import org.jspecify.annotations.NullMarked;

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/infra/SecurityRuntimeHintsTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/infra/SecurityRuntimeHintsTest.java
@@ -1,0 +1,31 @@
+package xyz.dgz48.tasks.webapi.security.infra;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.aot.hint.MemberCategory;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.predicate.RuntimeHintsPredicates;
+import xyz.dgz48.tasks.webapi.security.domain.TasksPrincipal;
+
+/**
+ * {@code @AuthenticationPrincipal(expression = "id")} の native-image 対応を回帰固定する。
+ *
+ * <p>このヒントが失われると native-image でのみ SpEL EL1008E により当該エンドポイントが 500 になる (JVM
+ * テストでは検出できない退行)。本テストはヒント登録そのものを検証して退行を防ぐ。
+ */
+class SecurityRuntimeHintsTest {
+
+  @Test
+  void registersTasksPrincipalReflectionForAuthenticationPrincipalSpel() {
+    RuntimeHints hints = new RuntimeHints();
+
+    new SecurityRuntimeHints.Registrar().registerHints(hints, getClass().getClassLoader());
+
+    assertThat(
+            RuntimeHintsPredicates.reflection()
+                .onType(TasksPrincipal.class)
+                .withMemberCategory(MemberCategory.INVOKE_PUBLIC_METHODS))
+        .accepts(hints);
+  }
+}


### PR DESCRIPTION
## 概要

dev デプロイ(v0.2.0)の動作確認で、native-image 上で SaaS Admin 等 **13 エンドポイントが HTTP 500** になる退行を発見・修正します。

CloudWatch `/tasks/dev/webapi`:
```
org.springframework.expression.spel.SpelEvaluationException:
EL1008E: Property or field 'id' cannot be found on object of type
'xyz.dgz48.tasks.webapi.security.domain.TasksPrincipal'
```

## 原因

13 箇所のコントローラが `@AuthenticationPrincipal(expression = "id") Long userId` を使用。この SpEL は `TasksPrincipal#getId()` をリフレクション解決しますが、**native-image では対象型のリフレクションメタデータが未登録**のため失敗します。

- JVM ではリフレクションが常に可能 → 単体テスト・CI e2e(JVM 実行)では**再現せず**、native-image を実行する dev/stg/prd でのみ発生。
- `MeController` の `@AuthenticationPrincipal TasksPrincipal principal`(SpEL 非経由)や `TaskController` の `token.getPrincipal().getId()` は native でも正常に動作していた。

## 対処

`TasksPrincipal` を native リフレクションヒントに明示登録します。13 箇所の SpEL 規約はそのまま維持し、中央 1 箇所で解消する最小変更です(`NativeImageHintsConfig` と同じ仕組み、ただし型の所有モジュール security 内に配置)。

- **`security/infra/SecurityRuntimeHints`**: `TasksPrincipal` を `INVOKE_PUBLIC_METHODS` + `DECLARED_FIELDS` で登録。
- **`security/infra/package-info`**: `@NullMarked`。
- **`SecurityRuntimeHintsTest`**: `RuntimeHints` でヒント登録を検証(JVM で検出できない退行のため、登録そのものを回帰固定)。

## 確認

- `./gradlew :webapi:check` green(spotless / NullAway / JaCoCo / 全テスト / ModularityTests — 新規 `security.infra` がモジュール境界を侵さないことを確認)。
- 最終検証は **native-image を dev に再デプロイ**して 3 エンドポイントが 200 を返すことで行います(マージ後に v0.2.1 をデプロイ)。

## 補足(別 PR / フォローアップ)

- この退行は「native のみ・JVM テストで検出不能」が本質。デプロイ前に native スモークを挟む CI 改善を別途検討します(本 PR スコープ外)。
- 動作確認中に判明した **フロント資産の immutable キャッシュ問題**(`deploy.yml`)は別 PR で対応します。

Closes #806

🤖 Generated with [Claude Code](https://claude.com/claude-code)