### PR TITLE
fix(ci): フィンガープリント無しのアプリ資産を no-cache 配信にする (Closes #808)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -510,18 +510,20 @@ jobs:
 
           echo "Syncing ${SRC} → ${DST}"
 
-          # バージョン付きアセット(JS/CSS/フォント等): 長期 immutable cache
-          # index.html は後続ステップで上書きするので --exclude で除外
+          # vendor/ はサードパーティ依存(bootstrap / keycloak-js / フォント等)で内容が安定し
+          # バージョン更新時のみ変わるため長期 immutable で配信する(prefix 単位で --delete)。
+          aws s3 sync "${SRC}vendor/" "${DST}vendor/" \
+            --delete \
+            --cache-control "public, max-age=31536000, immutable"
+
+          # アプリ資産(*.html / js/*.js / css/*.css)はコンテンツハッシュでフィンガープリント
+          # していない(ファイル名固定)。immutable で配信すると内容更新後もブラウザが旧版を最大 1 年
+          # 保持し、CloudFront invalidation(エッジのみ)では解消しない。ETag 再検証前提の no-cache で
+          # 配信し、常に最新を取得させる(vendor/ は上で配信済みのため除外)。
           aws s3 sync "${SRC}" "${DST}" \
             --delete \
-            --cache-control "public, max-age=31536000, immutable" \
-            --exclude "index.html"
-
-          # index.html: 常に最新を取得させる(no-cache)
-          aws s3 cp \
-            "${SRC}index.html" \
-            "${DST}index.html" \
-            --cache-control "no-cache, no-store, must-revalidate"
+            --cache-control "no-cache" \
+            --exclude "vendor/*"
 
           echo "S3 sync complete"
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -478,7 +478,7 @@ jobs:
 
   # --------------------------------------------------------------------------
   # deploy-web — S3 バンドルを live/ prefix に sync + CloudFront invalidation。
-  # バージョン付きアセットは immutable cache、index.html は no-cache で配信。
+  # vendor/ は immutable cache、アプリ資産(html/js/css)は no-cache(ETag 再検証)で配信。
   # --------------------------------------------------------------------------
   deploy-web:
     name: Deploy web (${{ inputs.version }})


### PR DESCRIPTION
## 概要

`deploy.yml` の `deploy-web` が、フィンガープリント(内容ハッシュ)していないアプリ資産に `immutable, max-age=1年` を付与していた問題を修正します。v0.2.0 の dev デプロイ動作確認中に顕在化しました(#808)。

## 問題

`index.html` 以外の全資産(`js/*.js`, `*.html`, `css/*.css`, `vendor/**`)を `public, max-age=31536000, immutable` で配信。`js/auth.js` 等はファイル名固定(非フィンガープリント)のため、内容更新後もブラウザが旧版を最大 1 年保持し、CloudFront invalidation(エッジのみ)では解消しません。結果、新 `admin.js` ＋ 旧 `auth.js` の混在で `TypeError: Auth.isAppAdmin is not a function` が発生しました。

## 修正

- **アプリ資産(`*.html` / `js` / `css`)**: ETag 再検証前提の `no-cache` で配信(常に最新)。
- **`vendor/`**(bootstrap / keycloak-js / フォント等、内容安定): 長期 `immutable` を維持。prefix 単位の 2 パス sync で各サブツリーに `--delete` を効かせる。

## 確認

- `deploy.yml` の YAML パース OK。
- 効果は次回 dev デプロイ(v0.2.1)で `Cache-Control: no-cache`(`js/*.js` / `*.html`)を確認して検証します。
- 注: 既に旧 immutable をキャッシュ済みのブラウザは、本修正後のデプロイでもキャッシュ失効/ハードリロードまで旧版を保持します(新規訪問者・以後のデプロイは正常)。

## フォローアップ(別途)

恒久策としてビルド時のアセット・フィンガープリント(内容ハッシュ付きファイル名)+ immutable 復活は検討余地あり(本 PR スコープ外)。

Closes #808

🤖 Generated with [Claude Code](https://claude.com/claude-code)