### PR TITLE
feat(dashboard): S-03 個人ダッシュボード画面を実装 (Closes #813)

### DIFF
--- a/e2e/fixtures/auth.ts
+++ b/e2e/fixtures/auth.ts
@@ -16,9 +16,10 @@ export const SAAS_ADMIN = {
 } as const;
 
 /**
- * Keycloak PKCE ログインを実行して tasks.html に到達するまで待機する。
+ * Keycloak PKCE ログインを実行して dashboard.html に到達するまで待機する。
  * tenant1-member1 は tenant1 に 1 所属しているため index.html が自動でテナントを
- * 選択し tasks.html にリダイレクトする。
+ * 選択し、ログイン後の既定表示である個人ダッシュボード(S-03)へリダイレクトする。
+ * タスク一覧を操作するテストはログイン後に明示的に tasks.html へ遷移すること。
  */
 export async function loginAs(page: Page, username: string, password: string): Promise<void> {
   await page.goto('/');
@@ -26,8 +27,8 @@ export async function loginAs(page: Page, username: string, password: string): P
   await page.fill('#username', username);
   await page.fill('#password', password);
   await page.click('#kc-login');
-  // index.html が /api/auth/me を呼び、単一テナントを自動選択して tasks.html へ転送する。
-  await page.waitForURL(/\/tasks\.html/, { timeout: 15_000 });
+  // index.html が /api/auth/me を呼び、単一テナントを自動選択して dashboard.html へ転送する。
+  await page.waitForURL(/\/dashboard\.html/, { timeout: 15_000 });
 }
 
 /**

--- a/e2e/tests/a11y-task-table.spec.ts
+++ b/e2e/tests/a11y-task-table.spec.ts
@@ -23,6 +23,8 @@ const todayJST = () =>
 test.describe('a11y: display:contents 行の role 露出 (#554)', () => {
   test.beforeEach(async ({ page }) => {
     await loginAs(page, MEMBER1.username, MEMBER1.password);
+    // ログイン後の既定表示はダッシュボード(S-03)。タスク一覧へ明示遷移する。
+    await page.goto('/tasks.html');
     await expect(page.locator('#task-panel')).toBeVisible({ timeout: 15_000 });
   });
 

--- a/e2e/tests/auth.spec.ts
+++ b/e2e/tests/auth.spec.ts
@@ -3,12 +3,12 @@ import { expect, test } from '../fixtures/test';
 
 // ADR-0023 §6 Step 4 — Keycloak ログイン往復
 // 認証情報を入力して Keycloak PKCE フローを完了し、
-// tasks.html(タスク一覧)へ戻ることを確認する。
+// ログイン後の既定表示である個人ダッシュボード(S-03)へ戻ることを確認する。
 // ※ 未認証での Keycloak リダイレクトは top.spec.ts が担当する。
 
-test('Keycloak ログイン後にタスク一覧へ遷移して認証済み状態になる', async ({ page }) => {
+test('Keycloak ログイン後にダッシュボードへ遷移して認証済み状態になる', async ({ page }) => {
   await loginAs(page, MEMBER1.username, MEMBER1.password);
-  await expect(page.getByRole('heading', { name: 'タスク一覧' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'ダッシュボード' })).toBeVisible();
   // ナビバーにユーザー名が表示される
   await expect(page.locator('#nav-username')).not.toBeEmpty();
 });

--- a/e2e/tests/dashboard.spec.ts
+++ b/e2e/tests/dashboard.spec.ts
@@ -1,0 +1,46 @@
+import { loginAs, MEMBER1 } from '../fixtures/auth';
+import { expect, test } from '../fixtures/test';
+
+// S-03 個人ダッシュボード(#813)
+// ログイン後の既定表示として数値カードと 4 セクション(期限切れ / 今日対応 / 今後 / 本日完了)
+// が描画され、タスク一覧へ遷移できることを確認する。
+
+test.describe('個人ダッシュボード (S-03)', () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAs(page, MEMBER1.username, MEMBER1.password);
+  });
+
+  test('数値カードと 4 セクションが表示される', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: 'ダッシュボード', level: 1 })).toBeVisible();
+
+    // 集計取得後にコンテンツが表示される(ローディングが解除される)。
+    await expect(page.locator('#content')).toBeVisible({ timeout: 15_000 });
+    await expect(page.locator('#loading')).toBeHidden();
+
+    // 数値カード 4 枚は数値(空でない)を表示する。
+    for (const id of [
+      '#card-today-due',
+      '#card-overdue',
+      '#card-completed-today',
+      '#card-my-open',
+    ]) {
+      await expect(page.locator(id)).toHaveText(/\d+/);
+    }
+
+    // 4 セクションの見出しが存在する。
+    for (const name of ['期限切れ', '今日対応', '今後', '本日完了']) {
+      await expect(page.getByRole('heading', { name: new RegExp(name) })).toBeVisible();
+    }
+
+    // ナビバーのテナントチップにテナント名が表示される。
+    await expect(page.locator('app-tenant-switcher')).toContainText('テナント1');
+  });
+
+  test('サイドバーからタスク一覧へ遷移できる', async ({ page }) => {
+    await expect(page.locator('#content')).toBeVisible({ timeout: 15_000 });
+
+    await page.getByRole('link', { name: 'タスク一覧' }).first().click();
+    await page.waitForURL(/\/tasks\.html/);
+    await expect(page.locator('#task-panel')).toBeVisible({ timeout: 15_000 });
+  });
+});

--- a/e2e/tests/tasks.spec.ts
+++ b/e2e/tests/tasks.spec.ts
@@ -6,6 +6,8 @@ import { expect, test } from '../fixtures/test';
 test.describe('タスク一覧 + CRUD', () => {
   test.beforeEach(async ({ page }) => {
     await loginAs(page, MEMBER1.username, MEMBER1.password);
+    // ログイン後の既定表示はダッシュボード(S-03)。タスク一覧へ明示遷移する。
+    await page.goto('/tasks.html');
     // タスクパネルが表示されるまで待機
     await expect(page.locator('#task-panel')).toBeVisible({ timeout: 15_000 });
   });

--- a/web/css/app.css
+++ b/web/css/app.css
@@ -574,3 +574,12 @@ app-task-row {
 .drawer-chip-rm:hover {
   color: #c92a2a;
 }
+
+/* ===== Dashboard / 個人ダッシュボード (S-03) ===== */
+.dash-task-item:last-child {
+  border-bottom: 0 !important;
+}
+/* flex 子要素での text-truncate を効かせるため min-width をリセットする */
+.dash-task-title {
+  min-width: 0;
+}

--- a/web/dashboard.html
+++ b/web/dashboard.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>運営者ダッシュボード — Tasks</title>
+  <title>ダッシュボード — Tasks</title>
   <link rel="icon" type="image/svg+xml" href="/favicon.svg">
   <link rel="stylesheet" href="vendor/bootstrap/css/bootstrap.min.css">
   <link rel="stylesheet" href="vendor/bootstrap-icons/bootstrap-icons.min.css">
@@ -37,7 +37,7 @@
   <!-- ===== Sidebar ===== -->
   <aside class="app-sidebar d-none d-lg-block" aria-label="サイドナビゲーション">
     <div class="nav-group-label" aria-hidden="true">メイン</div>
-    <a class="side-link" href="dashboard.html">
+    <a class="side-link active" href="dashboard.html" aria-current="page">
       <i class="bi bi-speedometer2" aria-hidden="true"></i>ダッシュボード
     </a>
     <a class="side-link" href="tasks.html">
@@ -45,7 +45,7 @@
     </a>
     <div class="admin-only">
       <div class="nav-group-label" aria-hidden="true">テナント運営</div>
-      <a class="side-link active" href="tenant-dashboard.html" aria-current="page">
+      <a class="side-link" href="tenant-dashboard.html">
         <i class="bi bi-graph-up-arrow" aria-hidden="true"></i>運営者ダッシュボード
       </a>
       <a class="side-link" href="tenant-users.html">
@@ -60,11 +60,13 @@
   <!-- ===== Main ===== -->
   <main id="main-content" class="app-main">
     <div class="d-flex align-items-center flex-wrap gap-3 mb-3">
-      <h1 class="page-title">運営者ダッシュボード</h1>
+      <h1 class="page-title">ダッシュボード</h1>
+      <a href="tasks.html" class="ms-auto btn btn-outline-secondary btn-sm">
+        <i class="bi bi-list-check me-1" aria-hidden="true"></i>タスク一覧へ
+      </a>
     </div>
     <p class="text-muted small mb-3">
-      テナント全体で共有(TENANT)または関係者限定(STAKEHOLDERS)で動いている業務量の集計です。
-      PRIVATE タスクは集計に含まれません。
+      あなたが所有・担当・関係するタスクの当日状況と振り返りです。参照できないタスクは含まれません。
     </p>
 
     <div id="error-alert" class="alert alert-danger d-none" role="alert"></div>
@@ -76,17 +78,9 @@
       <p class="mt-2 text-muted">集計を取得中...</p>
     </div>
 
-    <div id="summary" class="d-none">
+    <div id="content" class="d-none">
       <!-- 数値カード -->
-      <div class="row row-cols-2 row-cols-md-3 row-cols-xl-5 g-3 mb-4">
-        <div class="col">
-          <div class="card h-100">
-            <div class="card-body">
-              <div class="text-muted small">総タスク数</div>
-              <div id="card-total" class="fs-3 fw-semibold">—</div>
-            </div>
-          </div>
-        </div>
+      <div class="row row-cols-2 row-cols-xl-4 g-3 mb-4">
         <div class="col">
           <div class="card h-100">
             <div class="card-body">
@@ -114,36 +108,53 @@
         <div class="col">
           <div class="card h-100">
             <div class="card-body">
-              <div class="text-muted small">メンバー数</div>
-              <div id="card-members" class="fs-3 fw-semibold">—</div>
+              <div class="text-muted small">未完了(自分)</div>
+              <div id="card-my-open" class="fs-3 fw-semibold">—</div>
             </div>
           </div>
         </div>
       </div>
 
-      <!-- ブレークダウン -->
-      <div class="row g-3">
-        <div class="col-12 col-lg-6">
-          <div class="card h-100">
-            <div class="card-body">
-              <h2 class="h6 card-title">ステータス別件数</h2>
-              <table class="table table-sm mb-0">
-                <tbody id="status-breakdown"></tbody>
-              </table>
-            </div>
-          </div>
+      <!-- タスクセクション -->
+      <section class="card mb-3" aria-labelledby="sec-overdue-title">
+        <div class="card-body">
+          <h2 id="sec-overdue-title" class="h6 card-title text-danger">
+            <i class="bi bi-exclamation-triangle me-1" aria-hidden="true"></i>期限切れ
+            <span id="count-overdue" class="badge text-bg-danger ms-1">0</span>
+          </h2>
+          <ul id="list-overdue" class="dash-task-list list-unstyled mb-0"></ul>
         </div>
-        <div class="col-12 col-lg-6">
-          <div class="card h-100">
-            <div class="card-body">
-              <h2 class="h6 card-title">優先度別件数</h2>
-              <table class="table table-sm mb-0">
-                <tbody id="priority-breakdown"></tbody>
-              </table>
-            </div>
-          </div>
+      </section>
+
+      <section class="card mb-3" aria-labelledby="sec-today-title">
+        <div class="card-body">
+          <h2 id="sec-today-title" class="h6 card-title">
+            <i class="bi bi-calendar-event me-1" aria-hidden="true"></i>今日対応
+            <span id="count-today" class="badge text-bg-secondary ms-1">0</span>
+          </h2>
+          <ul id="list-today" class="dash-task-list list-unstyled mb-0"></ul>
         </div>
-      </div>
+      </section>
+
+      <section class="card mb-3" aria-labelledby="sec-upcoming-title">
+        <div class="card-body">
+          <h2 id="sec-upcoming-title" class="h6 card-title">
+            <i class="bi bi-calendar-week me-1" aria-hidden="true"></i>今後
+            <span id="count-upcoming" class="badge text-bg-secondary ms-1">0</span>
+          </h2>
+          <ul id="list-upcoming" class="dash-task-list list-unstyled mb-0"></ul>
+        </div>
+      </section>
+
+      <section class="card mb-3" aria-labelledby="sec-completed-title">
+        <div class="card-body">
+          <h2 id="sec-completed-title" class="h6 card-title text-success">
+            <i class="bi bi-check2-circle me-1" aria-hidden="true"></i>本日完了
+            <span id="count-completed" class="badge text-bg-success ms-1">0</span>
+          </h2>
+          <ul id="list-completed" class="dash-task-list list-unstyled mb-0"></ul>
+        </div>
+      </section>
     </div>
   </main>
 </div>
@@ -154,7 +165,9 @@
 <script src="js/auth.js"></script>
 <script src="js/api.js"></script>
 <script src="js/meta.js"></script>
+<script src="js/components/app-status-badge.js"></script>
+<script src="js/components/app-priority-badge.js"></script>
 <script src="js/components/app-tenant-switcher.js"></script>
-<script src="js/tenant-dashboard.js"></script>
+<script src="js/dashboard.js"></script>
 </body>
 </html>

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -156,6 +156,24 @@
  * @property {number} memberCount
  */
 
+/**
+ * @typedef {object} DashboardSummary
+ * @property {number} todayDueCount
+ * @property {number} overdueCount
+ * @property {number} completedTodayCount
+ * @property {number} myOpenCount
+ * @property {Record<string, number>} statusBreakdown
+ * @property {Record<string, number>} priorityBreakdown
+ */
+
+/**
+ * @typedef {object} DashboardTaskSections
+ * @property {Task[]} overdue
+ * @property {Task[]} today
+ * @property {Task[]} upcoming
+ * @property {Task[]} completedToday
+ */
+
 const Api = (() => {
   const _envMatch = window.location.hostname.match(/^tasks(?:-(\w+))?\.dgz48\.xyz$/);
   const BASE_URL = _envMatch
@@ -502,6 +520,24 @@ const Api = (() => {
   }
 
   /**
+   * GET /api/dashboard/summary — 個人ダッシュボードの数値カード集計(A-25、S-03、現テナント)。
+   * @returns {Promise<DashboardSummary>}
+   */
+  function getDashboardSummary() {
+    return request('/api/dashboard/summary');
+  }
+
+  /**
+   * GET /api/dashboard/tasks — 個人ダッシュボードの 4 セクション一括(A-26、S-03、現テナント)。
+   * @param {number} [dueWithinDays] - 「今後」に含める期限の先読み日数(1〜14、既定 3)。
+   * @returns {Promise<DashboardTaskSections>}
+   */
+  function getDashboardTasks(dueWithinDays) {
+    const q = dueWithinDays != null ? `?dueWithinDays=${dueWithinDays}` : '';
+    return request(`/api/dashboard/tasks${q}`);
+  }
+
+  /**
    * GET /api/users/me — 自身のプロフィール取得(A-07、S-09)。テナント選択状態に依存しない。
    * @returns {Promise<UserProfile>}
    */
@@ -638,6 +674,8 @@ const Api = (() => {
     removeMember,
     getPlatformMetrics,
     getTenantDashboardSummary,
+    getDashboardSummary,
+    getDashboardTasks,
     getMyProfile,
     getNotificationSettings,
     updateNotificationSettings,

--- a/web/js/dashboard.js
+++ b/web/js/dashboard.js
@@ -1,0 +1,178 @@
+// @ts-check
+// 個人ダッシュボード(S-03)。/api/dashboard/summary の数値カードと
+// /api/dashboard/tasks の 4 セクション(期限切れ / 今日 / 今後 / 本日完了)を描画する。
+// 参照専用のため #810(native @RequestBody 書込 500)の影響を受けない。
+
+/** 「今後」に含める期限の先読み日数(1〜14)。基本設計書 §3.3 の既定値に合わせる。 */
+const DUE_WITHIN_DAYS = 3;
+
+/** @type {HTMLElement} */ (mustQuery(document, '#btn-logout')).addEventListener('click', () =>
+  Auth.logout(),
+);
+
+/**
+ * エラーメッセージを表示し、ローディングを止める。
+ * @param {string} message
+ */
+function showError(message) {
+  /** @type {HTMLElement} */ (mustQuery(document, '#loading')).classList.add('d-none');
+  const el = /** @type {HTMLElement} */ (mustQuery(document, '#error-alert'));
+  el.textContent = message;
+  el.classList.remove('d-none');
+}
+
+/**
+ * 数値カードへ件数を反映する。
+ * @param {string} id
+ * @param {number} value
+ */
+function setCard(id, value) {
+  /** @type {HTMLElement} */ (mustQuery(document, id)).textContent = String(value);
+}
+
+/**
+ * 1 タスクを表すリスト項目を生成する。タイトルクリックで該当タスクの詳細
+ * (tasks.html のドロワー)へ遷移する。期限・担当・ステータス・優先度を併記する。
+ * @param {Task} task
+ * @returns {HTMLLIElement}
+ */
+function taskItem(task) {
+  const li = document.createElement('li');
+  li.className = 'dash-task-item d-flex align-items-center flex-wrap gap-2 py-2 border-bottom';
+
+  const link = document.createElement('a');
+  link.href = `/tasks/${task.id}`;
+  link.className = 'dash-task-title text-truncate fw-medium me-auto';
+  link.textContent = task.title;
+  li.append(link);
+
+  const status = document.createElement('app-status-badge');
+  status.setAttribute('status', task.status);
+  li.append(status);
+
+  const priority = document.createElement('app-priority-badge');
+  priority.setAttribute('priority', task.priority);
+  li.append(priority);
+
+  const due = document.createElement('span');
+  due.className = 'small text-muted';
+  due.innerHTML = '<i class="bi bi-calendar3 me-1" aria-hidden="true"></i>';
+  due.append(document.createTextNode(task.dueDate));
+  li.append(due);
+
+  const assignee = document.createElement('span');
+  assignee.className = 'small text-muted';
+  assignee.innerHTML = '<i class="bi bi-person me-1" aria-hidden="true"></i>';
+  assignee.append(document.createTextNode(task.assignee?.fullName || '未割当'));
+  li.append(assignee);
+
+  return li;
+}
+
+/**
+ * タスクセクション(リスト + 件数バッジ)を描画する。空セクションは控えめな案内を出す。
+ * @param {string} listId
+ * @param {string} countId
+ * @param {Task[]} tasks
+ * @param {string} emptyMessage
+ */
+function renderSection(listId, countId, tasks, emptyMessage) {
+  /** @type {HTMLElement} */ (mustQuery(document, countId)).textContent = String(tasks.length);
+  const list = /** @type {HTMLElement} */ (mustQuery(document, listId));
+  list.replaceChildren();
+  if (tasks.length === 0) {
+    const li = document.createElement('li');
+    li.className = 'text-muted small py-2';
+    li.textContent = emptyMessage;
+    list.append(li);
+    return;
+  }
+  for (const task of tasks) {
+    list.append(taskItem(task));
+  }
+}
+
+/**
+ * @param {DashboardSummary} summary
+ * @param {DashboardTaskSections} sections
+ */
+function render(summary, sections) {
+  setCard('#card-today-due', summary.todayDueCount);
+  setCard('#card-overdue', summary.overdueCount);
+  setCard('#card-completed-today', summary.completedTodayCount);
+  setCard('#card-my-open', summary.myOpenCount);
+
+  renderSection(
+    '#list-overdue',
+    '#count-overdue',
+    sections.overdue,
+    '期限切れのタスクはありません。',
+  );
+  renderSection('#list-today', '#count-today', sections.today, '今日対応のタスクはありません。');
+  renderSection('#list-upcoming', '#count-upcoming', sections.upcoming, '直近の予定はありません。');
+  renderSection(
+    '#list-completed',
+    '#count-completed',
+    sections.completedToday,
+    '本日完了したタスクはありません。',
+  );
+
+  /** @type {HTMLElement} */ (mustQuery(document, '#loading')).classList.add('d-none');
+  /** @type {HTMLElement} */ (mustQuery(document, '#content')).classList.remove('d-none');
+}
+
+async function main() {
+  const authenticated = await Auth.init();
+  if (!authenticated) {
+    return;
+  }
+
+  // SaaS Admin(APP_ADMIN)は業務ダッシュボードの対象外 → プラットフォーム監視へ誘導(S-12)。
+  if (Auth.isAppAdmin()) {
+    window.location.replace('admin.html');
+    return;
+  }
+
+  const user = Auth.getUser();
+  const displayName = user?.name || user?.preferred_username || '';
+  /** @type {HTMLElement} */ (mustQuery(document, '#nav-username')).textContent = displayName;
+  /** @type {HTMLElement} */ (mustQuery(document, '#user-avatar')).textContent =
+    displayName.slice(0, 1) || '?';
+
+  /** @type {MeResponse} */
+  let me;
+  try {
+    me = await Api.getMe();
+  } catch (err) {
+    showError(`ユーザー情報の取得に失敗しました: ${/** @type {any} */ (err).message}`);
+    return;
+  }
+
+  const activeTenantId = Api.resolveActiveTenant(me.tenants);
+  if (activeTenantId === null) {
+    window.location.replace('index.html');
+    return;
+  }
+
+  /** @type {AppTenantSwitcherElement} */ (mustQuery(document, '#tenant-switcher')).setData(
+    me.tenants,
+    activeTenantId,
+  );
+
+  const activeTenant = me.tenants?.find((t) => t.id === activeTenantId);
+  if (activeTenant?.role === 'TENANT_ADMIN') {
+    document.body.classList.add('role-admin');
+  }
+
+  try {
+    const [summary, sections] = await Promise.all([
+      Api.getDashboardSummary(),
+      Api.getDashboardTasks(DUE_WITHIN_DAYS),
+    ]);
+    render(summary, sections);
+  } catch (err) {
+    showError(`ダッシュボードの取得に失敗しました: ${/** @type {any} */ (err).message}`);
+  }
+}
+
+main();

--- a/web/js/index.js
+++ b/web/js/index.js
@@ -28,7 +28,8 @@ async function main() {
     const activeTenantId = Api.resolveActiveTenant(me.tenants);
 
     if (activeTenantId !== null) {
-      window.location.replace('tasks.html');
+      // ログイン後の既定表示は個人ダッシュボード(S-03、基本設計書 §3.2)。
+      window.location.replace('dashboard.html');
       return;
     }
 

--- a/web/notification-settings.html
+++ b/web/notification-settings.html
@@ -37,7 +37,7 @@
   <!-- ===== Sidebar ===== -->
   <aside class="app-sidebar d-none d-lg-block" aria-label="サイドナビゲーション">
     <div class="nav-group-label" aria-hidden="true">メイン</div>
-    <a class="side-link" href="index.html">
+    <a class="side-link" href="dashboard.html">
       <i class="bi bi-speedometer2" aria-hidden="true"></i>ダッシュボード
     </a>
     <a class="side-link" href="tasks.html">

--- a/web/package.json
+++ b/web/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "copy-vendor": "node scripts/copy-vendor.js",
-    "html-validate": "html-validate index.html tasks.html tenants-new.html tenant-dashboard.html notification-settings.html profile.html tenant-users.html admin.html admin-tenants.html admin-tenant-detail.html",
+    "html-validate": "html-validate index.html dashboard.html tasks.html tenants-new.html tenant-dashboard.html notification-settings.html profile.html tenant-users.html admin.html admin-tenants.html admin-tenant-detail.html",
     "serve": "node serve.mjs"
   },
   "engines": {

--- a/web/profile.html
+++ b/web/profile.html
@@ -37,7 +37,7 @@
   <!-- ===== Sidebar ===== -->
   <aside class="app-sidebar d-none d-lg-block" aria-label="サイドナビゲーション">
     <div class="nav-group-label" aria-hidden="true">メイン</div>
-    <a class="side-link" href="index.html">
+    <a class="side-link" href="dashboard.html">
       <i class="bi bi-speedometer2" aria-hidden="true"></i>ダッシュボード
     </a>
     <a class="side-link" href="tasks.html">

--- a/web/tasks.html
+++ b/web/tasks.html
@@ -37,7 +37,7 @@
   <!-- ===== Sidebar ===== -->
   <aside class="app-sidebar d-none d-lg-block" aria-label="サイドナビゲーション">
     <div class="nav-group-label" aria-hidden="true">メイン</div>
-    <a class="side-link" href="index.html">
+    <a class="side-link" href="dashboard.html">
       <i class="bi bi-speedometer2" aria-hidden="true"></i>ダッシュボード
     </a>
     <a class="side-link active" href="tasks.html" aria-current="page">

--- a/web/tenant-users.html
+++ b/web/tenant-users.html
@@ -37,7 +37,7 @@
   <!-- ===== Sidebar ===== -->
   <aside class="app-sidebar d-none d-lg-block" aria-label="サイドナビゲーション">
     <div class="nav-group-label" aria-hidden="true">メイン</div>
-    <a class="side-link" href="index.html">
+    <a class="side-link" href="dashboard.html">
       <i class="bi bi-speedometer2" aria-hidden="true"></i>ダッシュボード
     </a>
     <a class="side-link" href="tasks.html">


### PR DESCRIPTION
## 概要

バックエンド (`/api/dashboard/summary`・`/api/dashboard/tasks`) は実装済だがフロントが消費していなかった **S-03 個人ダッシュボード**を独立画面として実装する(#813)。S-12/13/14 と同じ「バックエンド完・フロント欠落」パターンの解消。

## 変更点

- **`web/dashboard.html` + `web/js/dashboard.js`(新規)**
  - 数値カード: 当日期限 / 期限切れ / 本日完了 / 未完了(自分) ← `GET /api/dashboard/summary`
  - 4 セクション(期限切れ / 今日対応 / 今後 / 本日完了)のタスクリスト ← `GET /api/dashboard/tasks?dueWithinDays=3`
  - タスク行は `/tasks/{id}` ディープリンク(CloudFront SPA フォールバック経由で詳細ドロワー表示)
  - 共通シェル(ナビ / テナントスイッチャ / サイドバー / `role-admin`)は既存画面と同型
- **`web/js/api.js`**: `getDashboardSummary()` / `getDashboardTasks(dueWithinDays)` + `DashboardSummary` / `DashboardTaskSections` typedef を追加
- **ランディング変更**: ログイン後の既定表示を `tasks.html` → `dashboard.html` に変更(`index.js`)。`index.html` はテナント解決ルーターとして存置
- **サイドバー張替**: 全メンバー画面(tasks / tenant-dashboard / tenant-users / profile / notification-settings)の「ダッシュボード」を `index.html` → `dashboard.html`
- **CSS**: flex 子要素での `text-truncate` 用に `.dash-task-title { min-width: 0 }` 等を追加

## テスト

- `e2e/tests/dashboard.spec.ts`(新規): 数値カード + 4 セクション表示、タスク一覧への遷移
- ランディング変更に伴い `loginAs` フィクスチャ・`auth` / `tasks` / `a11y-task-table` spec を dashboard 経由へ更新
- `dashboard.html` を html-validate 対象に追加
- ✅ `biome ci` / `tsc --noEmit`(web・e2e)/ `html-validate` すべて green

## 補足

- 参照専用のため #810(native `@RequestBody` 書込 500)の影響を受けず dev で動作する想定。
- NIST AC-4: 集計・リストとも参照可能タスクのみを対象(バックエンド既存ロジック)。

Closes #813

🤖 Generated with [Claude Code](https://claude.com/claude-code)