### PR TITLE
fix(security): 非 APP_ADMIN に admin シェルを描画せず即時退避する (Closes #812)

### DIFF
--- a/e2e/tests/admin.spec.ts
+++ b/e2e/tests/admin.spec.ts
@@ -1,4 +1,4 @@
-import { loginAsSaasAdmin, SAAS_ADMIN } from '../fixtures/auth';
+import { ADMIN1, loginAs, loginAsSaasAdmin, SAAS_ADMIN } from '../fixtures/auth';
 import { expect, test } from '../fixtures/test';
 
 // S-12 プラットフォーム監視 — SaaS 運営者(APP_ADMIN)専用画面のハッピーパス(コーディング規約 §9.7)。
@@ -27,5 +27,23 @@ test.describe('S-12 プラットフォーム監視', () => {
 
     // SaaS Admin 画面はテナントスイッチャを持たない。
     await expect(page.locator('#app-tenant-switcher')).toHaveCount(0);
+  });
+});
+
+// #812 情報露出対策 — 非 APP_ADMIN が admin.html を直接開いてもシェルを描画せず
+// 自分のホーム(dashboard.html)へ即時リダイレクトする(NIST AC-4 / 多層防御)。
+test.describe('S-12 ロール境界 (#812)', () => {
+  test('Tenant Admin が admin.html を直接開くと dashboard へ退避し admin シェルを見ない', async ({
+    page,
+  }) => {
+    await loginAs(page, ADMIN1.username, ADMIN1.password);
+
+    await page.goto('/admin.html');
+
+    // シェルを描画せず dashboard.html へリダイレクトされる。
+    await page.waitForURL(/\/dashboard\.html/, { timeout: 15_000 });
+    // SaaS Admin 専用のメトリクス領域・見出しは見えない。
+    await expect(page.locator('#metrics')).toHaveCount(0);
+    await expect(page.getByRole('heading', { name: 'プラットフォーム監視' })).toHaveCount(0);
   });
 });

--- a/web/admin-tenant-detail.html
+++ b/web/admin-tenant-detail.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" href="vendor/bootstrap-icons/bootstrap-icons.min.css">
   <link rel="stylesheet" href="css/app.css">
 </head>
-<body>
+<body class="admin-gated">
 <a href="#main-content" class="visually-hidden-focusable position-absolute p-2 m-2 bg-primary text-white rounded">
   メインコンテンツへスキップ
 </a>

--- a/web/admin-tenants.html
+++ b/web/admin-tenants.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" href="vendor/bootstrap-icons/bootstrap-icons.min.css">
   <link rel="stylesheet" href="css/app.css">
 </head>
-<body>
+<body class="admin-gated">
 <a href="#main-content" class="visually-hidden-focusable position-absolute p-2 m-2 bg-primary text-white rounded">
   メインコンテンツへスキップ
 </a>

--- a/web/admin.html
+++ b/web/admin.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" href="vendor/bootstrap-icons/bootstrap-icons.min.css">
   <link rel="stylesheet" href="css/app.css">
 </head>
-<body>
+<body class="admin-gated">
 <a href="#main-content" class="visually-hidden-focusable position-absolute p-2 m-2 bg-primary text-white rounded">
   メインコンテンツへスキップ
 </a>

--- a/web/css/app.css
+++ b/web/css/app.css
@@ -575,6 +575,15 @@ app-task-row {
   color: #c92a2a;
 }
 
+/* ===== SaaS Admin ゲート (#812) =====
+   認可確定(Auth.isAppAdmin)までシェルを隠し、非 APP_ADMIN への
+   casual disclosure を防ぐ。admin.js 等が認可後に admin-gated を外す。
+   非権限ユーザーはシェルを表示する前に dashboard.html へリダイレクトされる。 */
+body.admin-gated .app-navbar,
+body.admin-gated .app-layout {
+  visibility: hidden;
+}
+
 /* ===== Dashboard / 個人ダッシュボード (S-03) ===== */
 .dash-task-item:last-child {
   border-bottom: 0 !important;

--- a/web/js/admin-tenant-detail.js
+++ b/web/js/admin-tenant-detail.js
@@ -184,16 +184,20 @@ async function main() {
     return;
   }
 
+  // 非 APP_ADMIN にはシェルを一切描画せず、自分のホーム(個人ダッシュボード)へ即時退避する。
+  // 静的 SPA のためファイル存在自体は隠せないが、ログイン中ユーザーへの casual disclosure を防ぐ
+  // (#812, NIST AC-4)。認可確定後にゲート(admin-gated)を解除してシェルを表示する。
+  if (!Auth.isAppAdmin()) {
+    window.location.replace('dashboard.html');
+    return;
+  }
+  document.body.classList.remove('admin-gated');
+
   const user = Auth.getUser();
   const displayName = user?.name || user?.preferred_username || '';
   /** @type {HTMLElement} */ (mustQuery(document, '#nav-username')).textContent = displayName;
   /** @type {HTMLElement} */ (mustQuery(document, '#user-avatar')).textContent =
     displayName.slice(0, 1) || '?';
-
-  if (!Auth.isAppAdmin()) {
-    showError('このページは SaaS 運営者(APP_ADMIN)のみ利用できます。');
-    return;
-  }
 
   if (!Number.isInteger(detailTenantId) || detailTenantId <= 0) {
     showError('テナント ID が指定されていません。');

--- a/web/js/admin-tenants.js
+++ b/web/js/admin-tenants.js
@@ -175,16 +175,20 @@ async function main() {
     return;
   }
 
+  // 非 APP_ADMIN にはシェルを一切描画せず、自分のホーム(個人ダッシュボード)へ即時退避する。
+  // 静的 SPA のためファイル存在自体は隠せないが、ログイン中ユーザーへの casual disclosure を防ぐ
+  // (#812, NIST AC-4)。認可確定後にゲート(admin-gated)を解除してシェルを表示する。
+  if (!Auth.isAppAdmin()) {
+    window.location.replace('dashboard.html');
+    return;
+  }
+  document.body.classList.remove('admin-gated');
+
   const user = Auth.getUser();
   const displayName = user?.name || user?.preferred_username || '';
   /** @type {HTMLElement} */ (mustQuery(document, '#nav-username')).textContent = displayName;
   /** @type {HTMLElement} */ (mustQuery(document, '#user-avatar')).textContent =
     displayName.slice(0, 1) || '?';
-
-  if (!Auth.isAppAdmin()) {
-    showError('このページは SaaS 運営者(APP_ADMIN)のみ利用できます。');
-    return;
-  }
 
   // プラットフォーム API はテナント非依存。残存する X-Tenant-Id を送らないようクリアする。
   Api.setTenantId(null);

--- a/web/js/admin.js
+++ b/web/js/admin.js
@@ -45,16 +45,20 @@ async function main() {
     return;
   }
 
+  // 非 APP_ADMIN にはシェルを一切描画せず、自分のホーム(個人ダッシュボード)へ即時退避する。
+  // 静的 SPA のためファイル存在自体は隠せないが、ログイン中ユーザーへの casual disclosure を防ぐ
+  // (#812, NIST AC-4)。認可確定後にゲート(admin-gated)を解除してシェルを表示する。
+  if (!Auth.isAppAdmin()) {
+    window.location.replace('dashboard.html');
+    return;
+  }
+  document.body.classList.remove('admin-gated');
+
   const user = Auth.getUser();
   const displayName = user?.name || user?.preferred_username || '';
   /** @type {HTMLElement} */ (mustQuery(document, '#nav-username')).textContent = displayName;
   /** @type {HTMLElement} */ (mustQuery(document, '#user-avatar')).textContent =
     displayName.slice(0, 1) || '?';
-
-  if (!Auth.isAppAdmin()) {
-    showError('このページは SaaS 運営者(APP_ADMIN)のみ利用できます。');
-    return;
-  }
 
   // プラットフォーム API はテナント非依存。残存する X-Tenant-Id を送らないようクリアする。
   Api.setTenantId(null);


### PR DESCRIPTION
## 概要

非 APP_ADMIN(例: Tenant Admin)が `admin.html` / `admin-tenants.html` / `admin-tenant-detail.html` を直接開くと、SaaS Admin 画面のシェル(ナビ・サイドバー・見出し)を一度描画してから「APP_ADMIN のみ」エラーを表示していた。実データは API 側で遮断済(403)だが、画面の存在・構造・導線が露出し、本プロジェクトの AC-4 方針(参照不可は存在を漏らさない)と不整合だった(#812)。

## 変更点

- **認可ゲートを `main()` 冒頭へ移動**: 各 admin.js で `Auth.init()` 直後・DOM 書込前に `isAppAdmin()` を判定。非 APP_ADMIN は `showError` ではなく自分のホーム `dashboard.html` へ `location.replace` で即時退避
- **シェルのフラッシュ防止**: `body.admin-gated` で `.app-navbar` / `.app-layout` を既定 `visibility:hidden` にし、認可確定後に admin.js がクラスを外して表示。casual disclosure を防ぐ多層防御
- 静的 SPA のため `admin.html` 等のファイル存在自体は CloudFront 経由で隠せない点は設計上の限界として許容(#812 本文の通り)。本 PR の論点は「ログイン中の非 APP_ADMIN に admin UI を描画しない」こと

## テスト

- `e2e/tests/admin.spec.ts` に role 境界テストを追加: Tenant Admin が `admin.html` を直接開くと `dashboard.html` へ退避し、`#metrics` / 「プラットフォーム監視」見出しを見ないことを検証
- 既存の SaaS Admin ハッピーパス(S-12/13/14)は認可後にゲート解除されるため不変
- ✅ `biome ci` / `tsc --noEmit`(web・e2e)/ `html-validate` すべて green

Closes #812

🤖 Generated with [Claude Code](https://claude.com/claude-code)