### PR TITLE
feat(web): 破壊的操作の確認を共通モーダルに統一 (Closes #811)

### DIFF
--- a/e2e/tests/admin-tenant-detail.spec.ts
+++ b/e2e/tests/admin-tenant-detail.spec.ts
@@ -17,10 +17,16 @@ async function openFirstTenantDetail(page: Page): Promise<void> {
   await expect(page.locator('#detail')).toBeVisible({ timeout: 15_000 });
 }
 
+// 状態切替は共通確認モーダル(#811)で確認する。ボタン押下 → モーダルの確認ボタンを押す。
+async function toggleStatus(page: Page): Promise<void> {
+  await page.click('#btn-toggle-status');
+  const confirmBtn = page.locator('#confirm-dialog [data-role="confirm"]');
+  await expect(confirmBtn).toBeVisible({ timeout: 10_000 });
+  await confirmBtn.click();
+}
+
 test.describe('S-14 テナント詳細・状態切替', () => {
   test.beforeEach(async ({ page }) => {
-    // confirm ダイアログ(状態切替)は常に自動承認する。ハンドラは 1 度だけ登録する。
-    page.on('dialog', (d) => d.accept());
     await loginAsSaasAdmin(page, SAAS_ADMIN.username, SAAS_ADMIN.password);
   });
 
@@ -30,7 +36,7 @@ test.describe('S-14 テナント詳細・状態切替', () => {
     await expect(page.locator('#detail')).toBeVisible({ timeout: 15_000 });
     const badge = page.locator('#d-status');
     if ((await badge.textContent())?.trim() === 'SUSPENDED') {
-      await page.click('#btn-toggle-status');
+      await toggleStatus(page);
       await expect(badge).toHaveText('ACTIVE', { timeout: 10_000 });
     }
   });
@@ -59,12 +65,12 @@ test.describe('S-14 テナント詳細・状態切替', () => {
     await expect(page.locator('#page-title')).toHaveText(original, { timeout: 10_000 });
 
     // 状態切替: Suspend → 反映。
-    await page.click('#btn-toggle-status');
+    await toggleStatus(page);
     await expect(page.locator('#d-status')).toHaveText('SUSPENDED', { timeout: 10_000 });
     await expect(page.locator('#status-feedback')).toContainText('Suspend');
 
     // Reactivate → 反映(ACTIVE に戻す)。
-    await page.click('#btn-toggle-status');
+    await toggleStatus(page);
     await expect(page.locator('#d-status')).toHaveText('ACTIVE', { timeout: 10_000 });
     await expect(page.locator('#status-feedback')).toContainText('Reactivate');
   });

--- a/e2e/tests/tenant-users.spec.ts
+++ b/e2e/tests/tenant-users.spec.ts
@@ -21,6 +21,24 @@ test.describe('S-08 ユーザー管理', () => {
     await expect(page.locator('#users-tbody')).toContainText('自分');
   });
 
+  test('メンバー削除はブラウザ標準ダイアログでなく共通確認モーダルで確認する (#811)', async ({
+    page,
+  }) => {
+    const row = page.locator('#users-tbody tr', { hasText: 'tenant1-member1@example.com' });
+    await expect(row).toBeVisible();
+    await row.getByRole('button', { name: /削除/ }).click();
+
+    // 共通確認モーダルが表示され、対象メンバーの文言を含む(window.confirm ではない)。
+    const dialog = page.locator('#confirm-dialog .modal');
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toContainText('tenant1-member1@example.com');
+
+    // キャンセルすると削除されず行が残る(非破壊)。
+    await page.locator('#confirm-dialog [data-role="cancel"]').click();
+    await expect(dialog).toBeHidden();
+    await expect(row).toBeVisible();
+  });
+
   test('ユーザーを招待できる', async ({ page }) => {
     const email = `invitee-${Date.now()}@example.com`;
     await page.fill('#invite-email', email);

--- a/web/.htmlvalidate.json
+++ b/web/.htmlvalidate.json
@@ -119,6 +119,9 @@
           }
         }
       },
+      "app-confirm-dialog": {
+        "flow": true
+      },
       "app-conflict-banner": {
         "flow": true
       },

--- a/web/admin-tenant-detail.html
+++ b/web/admin-tenant-detail.html
@@ -130,11 +130,14 @@
   </main>
 </div>
 
+<app-confirm-dialog id="confirm-dialog"></app-confirm-dialog>
+
 <script src="vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
 <script src="vendor/keycloak-js/keycloak.min.js"></script>
 <script src="js/dom.js"></script>
 <script src="js/auth.js"></script>
 <script src="js/api.js"></script>
+<script src="js/components/app-confirm-dialog.js"></script>
 <script src="js/admin-tenant-detail.js"></script>
 </body>
 </html>

--- a/web/js/admin-tenant-detail.js
+++ b/web/js/admin-tenant-detail.js
@@ -156,7 +156,15 @@ function wireStatusToggle() {
     if (!detailTenant) return;
     const next = detailTenant.status === 'ACTIVE' ? 'SUSPENDED' : 'ACTIVE';
     const verb = next === 'SUSPENDED' ? 'Suspend' : 'Reactivate';
-    if (!window.confirm(`テナント「${detailTenant.name}」を ${verb} しますか?`)) return;
+    const ok = await /** @type {AppConfirmDialogElement} */ (
+      mustQuery(document, '#confirm-dialog')
+    ).open({
+      title: `テナントを ${verb}`,
+      body: `テナント「${detailTenant.name}」を ${verb} しますか?`,
+      confirmLabel: verb,
+      confirmVariant: next === 'SUSPENDED' ? 'danger' : 'primary',
+    });
+    if (!ok) return;
     btn.disabled = true;
     try {
       const updated = await Api.updateTenantStatus(detailTenantId, next);

--- a/web/js/components/app-confirm-dialog.js
+++ b/web/js/components/app-confirm-dialog.js
@@ -1,0 +1,83 @@
+// <app-confirm-dialog id="confirm-dialog"></app-confirm-dialog>
+// 破壊的操作(削除・状態変更等)の確認に使う共通 Bootstrap モーダル。
+// ブラウザ標準 window.confirm の代替で、アプリ UI と見た目・文言を統一する(#811)。
+//
+// 使い方:
+//   const ok = await /** @type {AppConfirmDialogElement} */ (mustQuery(document, '#confirm-dialog'))
+//     .open({ title: 'メンバーを削除', body: '…削除しますか?', confirmLabel: '削除', confirmVariant: 'danger' });
+//   if (!ok) return;
+//
+// 確認ボタンで true、キャンセル / ESC / 背景クリック / × で false に解決する。
+class AppConfirmDialog extends HTMLElement {
+  /** @type {BootstrapModal | null} */
+  #modal = null;
+  /** @type {((ok: boolean) => void) | null} */
+  #resolve = null;
+  #confirmed = false;
+
+  connectedCallback() {
+    if (this.#modal) return;
+    const titleId = `${this.id || 'app-confirm'}-title`;
+    this.innerHTML = `
+      <div class="modal fade" tabindex="-1" aria-labelledby="${titleId}" aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered">
+          <div class="modal-content">
+            <div class="modal-header">
+              <h2 id="${titleId}" class="modal-title h5"></h2>
+              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="閉じる"></button>
+            </div>
+            <div class="modal-body"></div>
+            <div class="modal-footer">
+              <button type="button" class="btn btn-outline-secondary" data-role="cancel" data-bs-dismiss="modal"></button>
+              <button type="button" class="btn" data-role="confirm"></button>
+            </div>
+          </div>
+        </div>
+      </div>`;
+
+    const modalEl = /** @type {HTMLElement} */ (mustQuery(this, '.modal'));
+    this.#modal = bootstrap.Modal.getOrCreateInstance(modalEl);
+
+    /** @type {HTMLButtonElement} */ (mustQuery(this, '[data-role="confirm"]')).addEventListener(
+      'click',
+      () => {
+        this.#confirmed = true;
+        this.#modal?.hide();
+      },
+    );
+
+    // ESC / 背景クリック / キャンセル / × はいずれも hidden を発火 → confirmed=false のまま解決。
+    modalEl.addEventListener('hidden.bs.modal', () => {
+      const resolve = this.#resolve;
+      this.#resolve = null;
+      if (resolve) resolve(this.#confirmed);
+    });
+  }
+
+  /**
+   * 確認モーダルを開く。
+   * @param {{ title: string, body: string, confirmLabel?: string, cancelLabel?: string, confirmVariant?: string }} opts
+   * @returns {Promise<boolean>}
+   */
+  open({
+    title,
+    body,
+    confirmLabel = 'OK',
+    cancelLabel = 'キャンセル',
+    confirmVariant = 'primary',
+  }) {
+    /** @type {HTMLElement} */ (mustQuery(this, '.modal-title')).textContent = title;
+    /** @type {HTMLElement} */ (mustQuery(this, '.modal-body')).textContent = body;
+    /** @type {HTMLElement} */ (mustQuery(this, '[data-role="cancel"]')).textContent = cancelLabel;
+    const confirmBtn = /** @type {HTMLButtonElement} */ (mustQuery(this, '[data-role="confirm"]'));
+    confirmBtn.textContent = confirmLabel;
+    confirmBtn.className = `btn btn-${confirmVariant}`;
+
+    this.#confirmed = false;
+    return new Promise((resolve) => {
+      this.#resolve = resolve;
+      this.#modal?.show();
+    });
+  }
+}
+customElements.define('app-confirm-dialog', AppConfirmDialog);

--- a/web/js/tenant-users.js
+++ b/web/js/tenant-users.js
@@ -118,7 +118,15 @@ function buildRow(u) {
   delBtn.append(icon);
   delBtn.disabled = isSelf;
   delBtn.addEventListener('click', async () => {
-    if (!window.confirm(`${u.fullName}(${u.email})をテナントから削除しますか?`)) return;
+    const ok = await /** @type {AppConfirmDialogElement} */ (
+      mustQuery(document, '#confirm-dialog')
+    ).open({
+      title: 'メンバーを削除',
+      body: `${u.fullName}(${u.email})をテナントから削除しますか?`,
+      confirmLabel: '削除',
+      confirmVariant: 'danger',
+    });
+    if (!ok) return;
     delBtn.disabled = true;
     try {
       await Api.removeMember(u.userId);

--- a/web/tenant-users.html
+++ b/web/tenant-users.html
@@ -128,12 +128,15 @@
   </main>
 </div>
 
+<app-confirm-dialog id="confirm-dialog"></app-confirm-dialog>
+
 <script src="vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
 <script src="vendor/keycloak-js/keycloak.min.js"></script>
 <script src="js/dom.js"></script>
 <script src="js/auth.js"></script>
 <script src="js/api.js"></script>
 <script src="js/components/app-tenant-switcher.js"></script>
+<script src="js/components/app-confirm-dialog.js"></script>
 <script src="js/tenant-users.js"></script>
 </body>
 </html>

--- a/web/types/globals.d.ts
+++ b/web/types/globals.d.ts
@@ -57,6 +57,12 @@ interface BootstrapToast {
   dispose(): void;
 }
 
+interface BootstrapModal {
+  show(): void;
+  hide(): void;
+  dispose(): void;
+}
+
 declare const bootstrap: {
   Offcanvas: {
     new (element: Element, options?: Record<string, unknown>): BootstrapOffcanvas;
@@ -65,6 +71,11 @@ declare const bootstrap: {
   };
   Toast: {
     new (element: Element, options?: Record<string, unknown>): BootstrapToast;
+  };
+  Modal: {
+    new (element: Element, options?: Record<string, unknown>): BootstrapModal;
+    getInstance(element: Element | null): BootstrapModal | null;
+    getOrCreateInstance(element: Element): BootstrapModal;
   };
 };
 
@@ -78,6 +89,16 @@ interface AppErrorBannerElement extends HTMLElement {
 interface AppConflictBannerElement extends HTMLElement {
   show(): void;
   hide(): void;
+}
+
+interface AppConfirmDialogElement extends HTMLElement {
+  open(opts: {
+    title: string;
+    body: string;
+    confirmLabel?: string;
+    cancelLabel?: string;
+    confirmVariant?: string;
+  }): Promise<boolean>;
 }
 
 interface AppDescPopoverElement extends HTMLElement {


### PR DESCRIPTION
## 概要

メンバー削除・テナント状態切替の確認がブラウザ標準 `window.confirm()` で、アプリの Bootstrap UI と見た目・文言が不統一だった(#811)。共通の確認モーダルコンポーネントを追加し、破壊的操作の確認 UX を統一する。

## 変更点

- **`web/js/components/app-confirm-dialog.js`(新規)**: Bootstrap Modal を包む `app-*` カスタム要素。`open({ title, body, confirmLabel, cancelLabel, confirmVariant })` が `Promise<boolean>` を返す(確認=`true` / キャンセル・ESC・背景クリック・×=`false`)。CSP 安全(インラインハンドラなし、ADR-0022 準拠)
- `tenant-users.js`(メンバー削除)・`admin-tenant-detail.js`(テナント Suspend/Reactivate)の `window.confirm` を共通モーダルへ置換
- `tenant-users.html` / `admin-tenant-detail.html` に `<app-confirm-dialog>` 要素 + script を追加
- `.htmlvalidate.json` に `app-confirm-dialog` を登録、`types/globals.d.ts` に `BootstrapModal` / `AppConfirmDialogElement` を追加

## テスト

- `admin-tenant-detail.spec.ts`: 状態切替テストを `page.on('dialog')` 自動承認からモーダルの確認ボタンクリックに更新
- `tenant-users.spec.ts`: メンバー削除でモーダルが表示され対象文言を含むこと、キャンセルで削除されない(非破壊)ことを追加
- ✅ `biome ci` / `tsc --noEmit`(web・e2e)/ `html-validate` すべて green

Closes #811

🤖 Generated with [Claude Code](https://claude.com/claude-code)