### PR TITLE
fix(native): Hibernate Validator 組込バリデータを reflection 登録 (Closes #810)

### DIFF
--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/shared/infra/NativeImageHintsConfig.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/shared/infra/NativeImageHintsConfig.java
@@ -13,6 +13,43 @@ class NativeImageHintsConfig {
 
   static class Registrar implements RuntimeHintsRegistrar {
 
+    // Hibernate Validator の組込 ConstraintValidator 実装。Spring Boot AOT は検証対象 Bean
+    // 経由でしか hints を登録せず、これら実装クラスの no-arg コンストラクタが native image に
+    // 残らない。結果 @RequestBody/@RequestParam を @NotNull/@Size 等で検証する全経路が
+    // BeanCreationException("No default constructor found")で 500 になる(#810)。
+    // 利用中の制約(@NotNull/@NotBlank/@Size/@Min/@Max/@Pattern/@Email)に対応する実装を
+    // 明示登録する。型ごとに分かれる Min/Max は将来のフィールド型変更に備え数値 variant を網羅。
+    private static final String[] HV_CONSTRAINT_VALIDATORS = {
+      "org.hibernate.validator.internal.constraintvalidators.bv.NotNullValidator",
+      "org.hibernate.validator.internal.constraintvalidators.bv.NotBlankValidator",
+      "org.hibernate.validator.internal.constraintvalidators.bv.EmailValidator",
+      "org.hibernate.validator.internal.constraintvalidators.bv.PatternValidator",
+      "org.hibernate.validator.internal.constraintvalidators.bv.size.SizeValidatorForCharSequence",
+      "org.hibernate.validator.internal.constraintvalidators.bv.size.SizeValidatorForCollection",
+      "org.hibernate.validator.internal.constraintvalidators.bv.size.SizeValidatorForMap",
+      "org.hibernate.validator.internal.constraintvalidators.bv.size.SizeValidatorForArray",
+      "org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MinValidatorForBigDecimal",
+      "org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MinValidatorForBigInteger",
+      "org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MinValidatorForByte",
+      "org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MinValidatorForDouble",
+      "org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MinValidatorForFloat",
+      "org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MinValidatorForInteger",
+      "org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MinValidatorForLong",
+      "org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MinValidatorForShort",
+      "org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MinValidatorForNumber",
+      "org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MinValidatorForCharSequence",
+      "org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MaxValidatorForBigDecimal",
+      "org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MaxValidatorForBigInteger",
+      "org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MaxValidatorForByte",
+      "org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MaxValidatorForDouble",
+      "org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MaxValidatorForFloat",
+      "org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MaxValidatorForInteger",
+      "org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MaxValidatorForLong",
+      "org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MaxValidatorForShort",
+      "org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MaxValidatorForNumber",
+      "org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MaxValidatorForCharSequence",
+    };
+
     @Override
     public void registerHints(RuntimeHints hints, @Nullable ClassLoader classLoader) {
       // JBoss Logging annotation-generated impls; not reached by Spring Boot AOT hints
@@ -25,6 +62,14 @@ class NativeImageHintsConfig {
           hints.reflection().registerType(Class.forName(cls), MemberCategory.values());
         } catch (ClassNotFoundException ignored) {
           // Class absent on this classpath; nothing to register, skip intentionally.
+        }
+      }
+      // 組込 ConstraintValidator(no-arg コンストラクタ)を reflection 登録する(#810)。
+      for (String cls : HV_CONSTRAINT_VALIDATORS) {
+        try {
+          hints.reflection().registerType(Class.forName(cls), MemberCategory.values());
+        } catch (ClassNotFoundException ignored) {
+          // 当該バージョンに存在しない validator は登録不要。意図的にスキップする。
         }
       }
       // Flyway classpath scanner cannot enumerate directories under the native-image resource:

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/shared/infra/NativeImageHintsConfigTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/shared/infra/NativeImageHintsConfigTest.java
@@ -1,0 +1,46 @@
+package xyz.dgz48.tasks.webapi.shared.infra;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.aot.hint.MemberCategory;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.TypeReference;
+import org.springframework.aot.hint.predicate.RuntimeHintsPredicates;
+
+/**
+ * Hibernate Validator 組込 ConstraintValidator の native-image reflection 登録を回帰固定する (#810)。
+ *
+ * <p>これらヒントが失われると native-image でのみ {@code @RequestBody}/{@code @RequestParam} を
+ * {@code @NotNull}/{@code @Size}/{@code @Min} 等で検証する経路が {@code BeanCreationException("No default
+ * constructor found")} により 500 になる(JVM テストでは検出できない退行)。本テストはヒント登録そのものを検証する。
+ */
+class NativeImageHintsConfigTest {
+
+  private static final String BV = "org.hibernate.validator.internal.constraintvalidators.bv.";
+
+  @Test
+  void registersBuiltInConstraintValidatorsForReflection() {
+    RuntimeHints hints = new RuntimeHints();
+
+    new NativeImageHintsConfig.Registrar().registerHints(hints, getClass().getClassLoader());
+
+    for (String validator :
+        new String[] {
+          BV + "NotNullValidator",
+          BV + "NotBlankValidator",
+          BV + "EmailValidator",
+          BV + "PatternValidator",
+          BV + "size.SizeValidatorForCharSequence",
+          BV + "number.bound.MinValidatorForInteger",
+          BV + "number.bound.MaxValidatorForInteger",
+        }) {
+      assertThat(
+              RuntimeHintsPredicates.reflection()
+                  .onType(TypeReference.of(validator))
+                  .withMemberCategory(MemberCategory.INVOKE_PUBLIC_CONSTRUCTORS))
+          .as("native hint for %s", validator)
+          .accepts(hints);
+    }
+  }
+}


### PR DESCRIPTION
## 概要

dev(GraalVM native image)で **招待・ロール変更・通知設定 PUT 等の write 経路が一律 500** になる P1 バグ(#810)。CloudWatch `/tasks/dev/webapi` のスタックトレースで根本原因を特定した。

## 根本原因

```
org.springframework.beans.factory.BeanCreationException:
  Error creating bean 'NotNullValidator' / 'SizeValidatorForCharSequence':
  No default constructor found
```

native image に **Hibernate Validator の組込 `ConstraintValidator` 実装の no-arg コンストラクタが残らず**、Spring が `BeanUtils.instantiateClass` で生成しようとして失敗していた。結果、`@RequestBody` / `@RequestParam` を `@NotNull` / `@Size` / `@Min` 等で検証する **全経路が 500**(GET / DELETE は body 検証が無いため成功 → 切り分けと一致)。

影響範囲は招待・ロール変更・通知設定だけでなく **`POST /api/tasks`(作成)や `@Min`/`@Max` を持つ `GET /api/dashboard/tasks` も同根**。JVM で走る CI テストでは再現しないため見逃されていた(ADR-0008)。

## 修正

- `NativeImageHintsConfig` に、利用中の制約(`@NotNull`/`@NotBlank`/`@Size`/`@Min`/`@Max`/`@Pattern`/`@Email`)に対応する組込 validator を明示 reflection 登録
- 型ごとに分かれる Min/Max は数値 variant(Integer/Long/Short/Byte/Double/Float/BigDecimal/BigInteger/Number/CharSequence)を網羅し、将来のフィールド型変更に備える
- 既存パターン(`Class.forName` + `MemberCategory.values()` + try/catch)を踏襲。当該バージョンに無い validator は安全にスキップ
- `NativeImageHintsConfigTest` で登録を回帰固定(`SecurityRuntimeHintsTest` と同方針 — native 退行は JVM テストで検出不能なのでヒント登録自体を検証)

## 検証

- ✅ JVM 単体テスト green(`spotlessCheck` 含む)
- ✅ CI `webapi-native-build`(native image ビルド成立)
- ⏳ **実機(dev native)の write 復旧はマージ後デプロイで最終確認**(招待/作成/通知 PUT が 200 になること)

Closes #810

🤖 Generated with [Claude Code](https://claude.com/claude-code)