### PR TITLE
fix(security): ユーザー切替時の stale X-Tenant-Id 漏れを塞ぐ (Closes #816)

### DIFF
--- a/e2e/tests/admin.spec.ts
+++ b/e2e/tests/admin.spec.ts
@@ -47,3 +47,18 @@ test.describe('S-12 ロール境界 (#812)', () => {
     await expect(page.getByRole('heading', { name: 'プラットフォーム監視' })).toHaveCount(0);
   });
 });
+
+// #816 役割不適合ページ着地のガード — SaaS Admin(テナント未所属)がテナントスコープの
+// メンバー画面を直接開いても、テナント不要枠以外の API を叩く前に admin.html へ退避する。
+test.describe('S-12 ロール境界 (#816)', () => {
+  test('SaaS Admin が通知設定(メンバー画面)を直接開くと admin.html へ退避する', async ({
+    page,
+  }) => {
+    await loginAsSaasAdmin(page, SAAS_ADMIN.username, SAAS_ADMIN.password);
+
+    await page.goto('/notification-settings.html');
+
+    await page.waitForURL(/\/admin\.html/, { timeout: 15_000 });
+    await expect(page.getByRole('heading', { name: 'プラットフォーム監視' })).toBeVisible();
+  });
+});

--- a/web/js/auth.js
+++ b/web/js/auth.js
@@ -106,8 +106,12 @@ const Auth = (() => {
 
   /**
    * Keycloak ログアウトエンドポイントへリダイレクト。
+   *
+   * <p>退会前にアクティブテナント(sessionStorage.tenantId)をクリアする。次にログインする
+   * ユーザーへ前ユーザーの X-Tenant-Id が漏れて越境・403 になる事象を防ぐ(#816)。
    */
   function logout() {
+    sessionStorage.removeItem('tenantId');
     if (_keycloak) {
       _keycloak.logout({ redirectUri: window.location.origin + window.location.pathname });
     }

--- a/web/js/notification-settings.js
+++ b/web/js/notification-settings.js
@@ -62,6 +62,13 @@ async function main() {
     return;
   }
 
+  // SaaS Admin(APP_ADMIN)は業務画面の対象外。テナント未所属のため /api/auth/me 等が 403 になる前に
+  // プラットフォーム監視へ誘導する(#816 役割不適合ページ着地のガード)。
+  if (Auth.isAppAdmin()) {
+    window.location.replace('admin.html');
+    return;
+  }
+
   const user = Auth.getUser();
   const displayName = user?.name || user?.preferred_username || '';
   /** @type {HTMLElement} */ (mustQuery(document, '#nav-username')).textContent = displayName;

--- a/web/js/profile.js
+++ b/web/js/profile.js
@@ -41,6 +41,13 @@ async function main() {
     return;
   }
 
+  // SaaS Admin(APP_ADMIN)は業務画面の対象外。テナント未所属のため /api/auth/me 等が 403 になる前に
+  // プラットフォーム監視へ誘導する(#816 役割不適合ページ着地のガード)。
+  if (Auth.isAppAdmin()) {
+    window.location.replace('admin.html');
+    return;
+  }
+
   const user = Auth.getUser();
   const displayName = user?.name || user?.preferred_username || '';
   /** @type {HTMLElement} */ (mustQuery(document, '#nav-username')).textContent = displayName;

--- a/web/js/tasks.js
+++ b/web/js/tasks.js
@@ -514,6 +514,13 @@ async function main() {
   const authenticated = await Auth.init();
   if (!authenticated) return;
 
+  // SaaS Admin(APP_ADMIN)は業務画面の対象外。テナント未所属のため /api/auth/me 等が 403 になる前に
+  // プラットフォーム監視へ誘導する(#816 役割不適合ページ着地のガード)。
+  if (Auth.isAppAdmin()) {
+    window.location.replace('admin.html');
+    return;
+  }
+
   /** @type {MeResponse} */
   let me;
   try {

--- a/web/js/tenant-dashboard.js
+++ b/web/js/tenant-dashboard.js
@@ -70,6 +70,13 @@ async function main() {
     return;
   }
 
+  // SaaS Admin(APP_ADMIN)は業務画面の対象外。テナント未所属のため /api/auth/me 等が 403 になる前に
+  // プラットフォーム監視へ誘導する(#816 役割不適合ページ着地のガード)。
+  if (Auth.isAppAdmin()) {
+    window.location.replace('admin.html');
+    return;
+  }
+
   const user = Auth.getUser();
   const displayName = user?.name || user?.preferred_username || '';
   /** @type {HTMLElement} */ (mustQuery(document, '#nav-username')).textContent = displayName;

--- a/web/js/tenant-users.js
+++ b/web/js/tenant-users.js
@@ -219,6 +219,13 @@ async function main() {
     return;
   }
 
+  // SaaS Admin(APP_ADMIN)は業務画面の対象外。テナント未所属のため /api/auth/me 等が 403 になる前に
+  // プラットフォーム監視へ誘導する(#816 役割不適合ページ着地のガード)。
+  if (Auth.isAppAdmin()) {
+    window.location.replace('admin.html');
+    return;
+  }
+
   const user = Auth.getUser();
   const displayName = user?.name || user?.preferred_username || '';
   /** @type {HTMLElement} */ (mustQuery(document, '#nav-username')).textContent = displayName;

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/security/adapter/web/TenantContextFilter.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/security/adapter/web/TenantContextFilter.java
@@ -32,8 +32,12 @@ import xyz.dgz48.tasks.webapi.tenant.usecase.UserTenantsResolverService;
 /**
  * X-Tenant-Id ヘッダを読み取り、user_tenants を検証して TenantContext を設定する。
  *
- * <p>ヘッダ指定時: 認証済みユーザーが指定テナントの ACTIVE メンバーでない場合は 403 を返す。メンバーの場合は ROLE_TENANT_ADMIN または ROLE_MEMBER
- * を SecurityContext に付与する。
+ * <p>免除パス({@code /api/auth/**}, {@code /api/tenants/**}, {@code /api/platform/**}, {@code
+ * /actuator/**}, {@code /api/users/me})はヘッダの有無に関わらず素通りさせる。stale な X-Tenant-Id が付いていても membership
+ * 検証しない(#816)。これらはテナントスコープの業務データを読まないため安全。
+ *
+ * <p>ヘッダ指定時(非免除パス): 認証済みユーザーが指定テナントの ACTIVE メンバーでない場合は 403 を返す。メンバーの場合は ROLE_TENANT_ADMIN または
+ * ROLE_MEMBER を SecurityContext に付与する。
  *
  * <p>ヘッダ未指定時: 免除パス({@code /api/auth/**}, {@code /api/tenants/**}, {@code /api/platform/**}, {@code
  * /actuator/**})および非認証リクエストはそのまま通過。それ以外の認証済みリクエストは {@link UserTenantsResolverService}
@@ -56,10 +60,19 @@ public class TenantContextFilter extends OncePerRequestFilter {
       HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
       throws ServletException, IOException {
 
+    // テナント不要枠(基本設計書 §5.2)は X-Tenant-Id ヘッダの有無に関わらず素通りさせる。
+    // ヘッダが付いていても membership 検証しないことで、ユーザー切替時に前ユーザーの stale な
+    // X-Tenant-Id が残っても /api/auth/me 等が 403 にならない(#816)。これら経路はテナント
+    // スコープの業務データを読まない(自分の identity / 所属一覧 / プラットフォーム API)ため安全。
+    if (isExemptPath(request)) {
+      filterChain.doFilter(request, response);
+      return;
+    }
+
     String tenantIdHeader = request.getHeader(HEADER_X_TENANT_ID);
     if (tenantIdHeader == null) {
       Authentication preAuth = SecurityContextHolder.getContext().getAuthentication();
-      if (!(preAuth instanceof TasksAuthenticationToken preToken) || isExemptPath(request)) {
+      if (!(preAuth instanceof TasksAuthenticationToken preToken)) {
         filterChain.doFilter(request, response);
         return;
       }

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/TenantContextFilterTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/TenantContextFilterTest.java
@@ -271,6 +271,18 @@ class TenantContextFilterTest {
   }
 
   @Test
+  @WithMockMember
+  void staleHeader_exemptPath_membershipNotValidated() throws Exception {
+    // ユーザー切替で残った非メンバーの X-Tenant-Id が付いていても、免除パスは membership 検証せず
+    // 素通りさせ /api/auth/me 等が 403 にならない(#816)。フィルタが findActiveRole を呼ばないことを検証する。
+    mockMvc.perform(
+        get("/api/auth/tenants/1/select").header(TenantContextFilter.HEADER_X_TENANT_ID, "999"));
+    org.mockito.Mockito.verify(tenantMembershipPort, org.mockito.Mockito.never())
+        .findActiveRole(
+            org.mockito.ArgumentMatchers.anyLong(), org.mockito.ArgumentMatchers.anyLong());
+  }
+
+  @Test
   @WithMockSaasAdmin
   void noHeader_exemptPlatformPath_reachesController_withoutTenantResolution() throws Exception {
     // SaaS Admin はテナント未所属が通常。/api/platform は免除パスのため初期テナント解決を行わず到達できる(A-27)。


### PR DESCRIPTION
## 概要

TenantMember ログアウト → SaaS Admin ログイン時に、前ユーザーの `sessionStorage.tenantId` が残って `X-Tenant-Id: 1` が付与され、**テナント不要枠の `/api/auth/me` が 403**(「指定テナントのメンバーではありません」)になる P1 セキュリティバグ(#816)。ユーザー切替で前ユーザーのテナントコンテキストが漏れる多層の問題で、3 層で対処する。

## サーバー(契約の自己整合 / 多層防御)

- `TenantContextFilter`: 免除パス(`/api/auth/**`・`/api/tenants*`・`/api/platform*`・`/actuator/**`・完全一致 `/api/users/me`)を `doFilterInternal` 冒頭で短絡し、**X-Tenant-Id ヘッダが付いていても membership 検証せず素通り**させる。これら経路はテナントスコープの業務データを読まない(自分の identity / 所属一覧 / プラットフォーム API)ため安全
- これにより「所属を知るために呼ぶ `/api/auth/me` が、所属していないと 403 になる」循環した契約不整合を解消。クライアント挙動に依存せず契約が常に正しくなる
- 既存の `/probe`(非免除)テスト・免除パスの 403(`@PreAuthorize` / ユースケース由来)は不変
- 回帰テスト追加: 免除パス + 非メンバー stale ヘッダで `findActiveRole` が呼ばれないこと

## クライアント(根本原因の衛生)

- `Auth.logout()` で `sessionStorage.tenantId` をクリア。次にログインするユーザーへのテナントコンテキスト漏れを断つ
- **役割不適合ページ着地のガード**: `tasks` / `profile` / `notification-settings` / `tenant-users` / `tenant-dashboard` の各 `main()` 冒頭で APP_ADMIN を検出したら `admin.html` へ退避(`dashboard` は実装済)。テナントスコープ API を叩く前に誘導
- E2E: SaaS Admin が通知設定(メンバー画面)を直接開くと `admin.html` へ退避することを追加

## スコープ外

レルム分離(SaaS Admin を別 IdP に物理分離)は本 PR に含めない。単一レルム + realm ロール `APP_ADMIN` で識別する現設計(ADR-0006)を維持し、必要なら別 ADR で検討する。

## 検証

- ✅ `TenantContextFilterTest`(15)/ `spotlessCheck` green
- ✅ `biome ci` / `tsc --noEmit`(web・e2e)/ `html-validate` green
- IT(免除パス周辺)は CI に委ねる

Closes #816

🤖 Generated with [Claude Code](https://claude.com/claude-code)