### PR TITLE
feat(web): 通知設定を即時自動保存に統一し保存ボタンを廃止 (Closes #815)

### DIFF
--- a/e2e/tests/notification-settings.spec.ts
+++ b/e2e/tests/notification-settings.spec.ts
@@ -1,0 +1,32 @@
+import { loginAs, MEMBER1 } from '../fixtures/auth';
+import { expect, test } from '../fixtures/test';
+
+// S-10 通知設定(#815)— 保存ボタンを廃し、トグル変更で即時自動保存する。
+// 変更後に「保存しました」が一時表示され、エラーが出ないことを確認する。
+
+test.describe('S-10 通知設定 即時自動保存 (#815)', () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAs(page, MEMBER1.username, MEMBER1.password);
+    await page.goto('/notification-settings.html');
+    await expect(page.locator('#settings-form')).toBeVisible({ timeout: 15_000 });
+  });
+
+  test('保存ボタンが無く、トグル変更で自動保存される', async ({ page }) => {
+    // 明示保存ボタンは廃止されている。
+    await expect(page.locator('#btn-save')).toHaveCount(0);
+
+    const toggle = page.locator('#email-due-today');
+    const before = await toggle.isChecked();
+
+    // トグルを反転 → 自動保存 →「保存しました」が表示される。
+    await toggle.click();
+    await expect(page.locator('#saved-alert')).toBeVisible({ timeout: 10_000 });
+    await expect(page.locator('#error-alert')).toBeHidden();
+    expect(await toggle.isChecked()).toBe(!before);
+
+    // 元の状態へ戻す(後続への影響を避ける)。
+    await toggle.click();
+    await expect(page.locator('#saved-alert')).toBeVisible({ timeout: 10_000 });
+    expect(await toggle.isChecked()).toBe(before);
+  });
+});

--- a/web/js/notification-settings.js
+++ b/web/js/notification-settings.js
@@ -25,6 +25,16 @@ function checkbox(id) {
 /**
  * @param {NotificationSettings} settings
  */
+// 最後に保存に成功した設定。即時保存が失敗したときのロールバック先(#815)。
+/** @type {NotificationSettings} */
+let lastSaved = { emailDueToday: false, emailOverdue: false, emailStakeholder: false };
+
+/** @type {ReturnType<typeof setTimeout> | undefined} */
+let savedHintTimer;
+
+/**
+ * @param {NotificationSettings} settings
+ */
 function fillForm(settings) {
   checkbox('#email-due-today').checked = settings.emailDueToday;
   checkbox('#email-overdue').checked = settings.emailOverdue;
@@ -32,27 +42,46 @@ function fillForm(settings) {
 }
 
 /**
- * @param {SubmitEvent} event
+ * 全トグルの活性/非活性を切り替える(保存中の二重操作・競合を防ぐ)。
+ * @param {boolean} disabled
  */
-async function onSubmit(event) {
-  event.preventDefault();
-  /** @type {HTMLElement} */ (mustQuery(document, '#saved-alert')).classList.add('d-none');
-  /** @type {HTMLElement} */ (mustQuery(document, '#error-alert')).classList.add('d-none');
+function setTogglesDisabled(disabled) {
+  for (const id of ['#email-due-today', '#email-overdue', '#email-stakeholder']) {
+    checkbox(id).disabled = disabled;
+  }
+}
 
-  const button = /** @type {HTMLButtonElement} */ (mustQuery(document, '#btn-save'));
-  button.disabled = true;
+/** 「保存しました」を一時表示し、しばらくして自動的に隠す。 */
+function flashSaved() {
+  const hint = /** @type {HTMLElement} */ (mustQuery(document, '#saved-alert'));
+  hint.classList.remove('d-none');
+  clearTimeout(savedHintTimer);
+  savedHintTimer = setTimeout(() => hint.classList.add('d-none'), 2000);
+}
+
+/**
+ * トグル変更時に現在の全状態を即時保存する(明示保存ボタンは廃止、#815)。
+ * 楽観的更新(UI は既に反映済み)+ 失敗時は最後の保存状態へロールバックする。
+ */
+async function onToggleChange() {
+  /** @type {HTMLElement} */ (mustQuery(document, '#error-alert')).classList.add('d-none');
+  /** @type {NotificationSettings} */
+  const desired = {
+    emailDueToday: checkbox('#email-due-today').checked,
+    emailOverdue: checkbox('#email-overdue').checked,
+    emailStakeholder: checkbox('#email-stakeholder').checked,
+  };
+  setTogglesDisabled(true);
   try {
-    const saved = await Api.updateNotificationSettings({
-      emailDueToday: checkbox('#email-due-today').checked,
-      emailOverdue: checkbox('#email-overdue').checked,
-      emailStakeholder: checkbox('#email-stakeholder').checked,
-    });
+    const saved = await Api.updateNotificationSettings(desired);
+    lastSaved = saved;
     fillForm(saved);
-    /** @type {HTMLElement} */ (mustQuery(document, '#saved-alert')).classList.remove('d-none');
+    flashSaved();
   } catch (err) {
+    fillForm(lastSaved); // ロールバック
     showError(`保存に失敗しました: ${/** @type {any} */ (err).message}`);
   } finally {
-    button.disabled = false;
+    setTogglesDisabled(false);
   }
 }
 
@@ -101,11 +130,14 @@ async function main() {
 
   try {
     const settings = await Api.getNotificationSettings();
+    lastSaved = settings;
     fillForm(settings);
     /** @type {HTMLElement} */ (mustQuery(document, '#loading')).classList.add('d-none');
-    const form = /** @type {HTMLFormElement} */ (mustQuery(document, '#settings-form'));
-    form.classList.remove('d-none');
-    form.addEventListener('submit', onSubmit);
+    /** @type {HTMLElement} */ (mustQuery(document, '#settings-form')).classList.remove('d-none');
+    // 明示保存ボタンは廃止。各トグルの変更で即時保存する(#815)。
+    for (const id of ['#email-due-today', '#email-overdue', '#email-stakeholder']) {
+      checkbox(id).addEventListener('change', onToggleChange);
+    }
   } catch (err) {
     showError(`設定の取得に失敗しました: ${/** @type {any} */ (err).message}`);
   }

--- a/web/notification-settings.html
+++ b/web/notification-settings.html
@@ -64,10 +64,14 @@
     <div class="d-flex align-items-center flex-wrap gap-3 mb-3">
       <h1 class="page-title">通知設定</h1>
     </div>
-    <p class="text-muted small mb-3">現在のテナントにおける、自分宛てのメール通知の ON/OFF を設定します。</p>
+    <p class="text-muted small mb-3">
+      現在のテナントにおける、自分宛てのメール通知の ON/OFF を設定します。変更は自動で保存されます。
+    </p>
 
     <div id="error-alert" class="alert alert-danger d-none" role="alert"></div>
-    <div id="saved-alert" class="alert alert-success d-none" role="status">保存しました。</div>
+    <div id="saved-alert" class="text-success small d-none" role="status" aria-live="polite">
+      <i class="bi bi-check2 me-1" aria-hidden="true"></i>保存しました
+    </div>
 
     <div id="loading" class="text-center py-5">
       <div class="spinner-border text-primary" role="status">
@@ -78,7 +82,7 @@
 
     <div class="row justify-content-center">
       <div class="col-12 col-md-9 col-lg-7">
-        <form id="settings-form" class="card d-none">
+        <div id="settings-form" class="card d-none">
           <div class="card-body">
             <div class="form-check form-switch mb-3">
               <input class="form-check-input" type="checkbox" role="switch" id="email-due-today">
@@ -101,9 +105,8 @@
                 <span class="d-block text-muted small">タスクの関係者として登録されたときに通知します。</span>
               </label>
             </div>
-            <button id="btn-save" type="submit" class="btn btn-primary">保存</button>
           </div>
-        </form>
+        </div>
       </div>
     </div>
   </main>


### PR DESCRIPTION
## 概要

通知設定(S-10)はトグル変更後に明示「保存」ボタンを押す方式で、ロール変更(S-08、即時自動保存)と操作モデルが不統一だった(#815)。**即時自動保存に統一**する。

## 変更点

- 各トグルの `change` で即時 `PUT`(楽観的更新)。**失敗時は最後の保存成功状態へロールバック**してエラー表示。保存中は全トグルを無効化し競合を防ぐ
- 保存ボタンを撤去。submit ボタンが無くなった `<form>` は `wcag/h32` 違反になるため `<div>` 化(`#settings-form` の JS 参照も `HTMLElement` に修正)
- 「保存しました」はアラートではなく控えめな一時表示(2 秒で自動消去、`aria-live="polite"`)
- E2E `notification-settings.spec.ts`(新規): 保存ボタンが無いこと + トグル変更で「保存しました」表示・エラー無し・状態反転を検証(変更は元に戻す)

## 検証

- ✅ `biome ci` / `tsc --noEmit`(web・e2e)/ `html-validate` green
- 保存失敗時のハンドリングは #810(native 書込 500)修正済を前提

Closes #815

🤖 Generated with [Claude Code](https://claude.com/claude-code)