### PR TITLE
feat(security): 初回ログイン時の oidc_sub correlation (Refs #817)

### DIFF
--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/security/adapter/web/TasksJwtAuthenticationConverter.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/security/adapter/web/TasksJwtAuthenticationConverter.java
@@ -1,7 +1,6 @@
 package xyz.dgz48.tasks.webapi.security.adapter.web;
 
 import java.util.List;
-import java.util.Optional;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.core.GrantedAuthority;
@@ -11,19 +10,19 @@ import org.springframework.security.oauth2.server.resource.InvalidBearerTokenExc
 import org.springframework.stereotype.Component;
 import xyz.dgz48.tasks.webapi.security.adapter.persistence.AppAdminUserRepository;
 import xyz.dgz48.tasks.webapi.security.domain.TasksPrincipal;
+import xyz.dgz48.tasks.webapi.security.usecase.OidcSubCorrelationService;
 import xyz.dgz48.tasks.webapi.user.adapter.persistence.UserJpaEntity;
-import xyz.dgz48.tasks.webapi.user.adapter.persistence.UserRepository;
 
 @Component
 public class TasksJwtAuthenticationConverter
     implements Converter<Jwt, AbstractAuthenticationToken> {
 
-  private final UserRepository userRepository;
+  private final OidcSubCorrelationService correlationService;
   private final AppAdminUserRepository appAdminUserRepository;
 
   public TasksJwtAuthenticationConverter(
-      UserRepository userRepository, AppAdminUserRepository appAdminUserRepository) {
-    this.userRepository = userRepository;
+      OidcSubCorrelationService correlationService, AppAdminUserRepository appAdminUserRepository) {
+    this.correlationService = correlationService;
     this.appAdminUserRepository = appAdminUserRepository;
   }
 
@@ -33,7 +32,10 @@ public class TasksJwtAuthenticationConverter
     if (sub == null) {
       throw new InvalidBearerTokenException("JWT missing sub claim");
     }
-    UserJpaEntity user = resolveUser(sub, jwt).orElseThrow(UserNotRegisteredException::new);
+    // sub で解決。未ヒット時は email クレームで pending 行を突合し sub を書き戻す(初回ログイン correlation、ADR-0040 §3.2)。
+    String email = jwt.getClaimAsString("email");
+    UserJpaEntity user =
+        correlationService.resolve(sub, email).orElseThrow(UserNotRegisteredException::new);
     if (user.isAnonymized()) {
       throw new UserAnonymizedException();
     }
@@ -49,32 +51,6 @@ public class TasksJwtAuthenticationConverter
             user.getFullNameKana(),
             user.getDepartmentName());
     return new TasksAuthenticationToken(principal, appAdminAuthorities(sub));
-  }
-
-  /**
-   * sub で登録ユーザーを解決する。{@code findByOidcSub} がヒットすれば correlation 済み(通常ログイン)。ヒットしない場合は 初回ログインの
-   * oidc_sub correlation(ADR-0040 §3.2 / ADR-0006 §3.2)を試みる: email クレームで pending placeholder
-   * 行を突合し、本物の {@code sub} を書き戻す。会員登録(ADR-0040)/SPI insert で作られた行はこの経路で初めてログイン可能になる。
-   *
-   * <p>email が一致しても correlation 済み(別 Keycloak アカウントの sub に紐付く)/匿名化済みの行は突合しない(なりすまし防止)。
-   */
-  private Optional<UserJpaEntity> resolveUser(String sub, Jwt jwt) {
-    Optional<UserJpaEntity> bySub = userRepository.findByOidcSub(sub);
-    if (bySub.isPresent()) {
-      return bySub;
-    }
-    String email = jwt.getClaimAsString("email");
-    if (email == null || email.isBlank()) {
-      return Optional.empty();
-    }
-    return userRepository
-        .findByEmail(email)
-        .filter(UserJpaEntity::isPendingCorrelation)
-        .map(
-            user -> {
-              user.correlateOidcSub(sub);
-              return userRepository.save(user);
-            });
   }
 
   private List<GrantedAuthority> appAdminAuthorities(String sub) {

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/security/adapter/web/TasksJwtAuthenticationConverter.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/security/adapter/web/TasksJwtAuthenticationConverter.java
@@ -1,6 +1,7 @@
 package xyz.dgz48.tasks.webapi.security.adapter.web;
 
 import java.util.List;
+import java.util.Optional;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.core.GrantedAuthority;
@@ -32,8 +33,7 @@ public class TasksJwtAuthenticationConverter
     if (sub == null) {
       throw new InvalidBearerTokenException("JWT missing sub claim");
     }
-    UserJpaEntity user =
-        userRepository.findByOidcSub(sub).orElseThrow(UserNotRegisteredException::new);
+    UserJpaEntity user = resolveUser(sub, jwt).orElseThrow(UserNotRegisteredException::new);
     if (user.isAnonymized()) {
       throw new UserAnonymizedException();
     }
@@ -49,6 +49,32 @@ public class TasksJwtAuthenticationConverter
             user.getFullNameKana(),
             user.getDepartmentName());
     return new TasksAuthenticationToken(principal, appAdminAuthorities(sub));
+  }
+
+  /**
+   * sub で登録ユーザーを解決する。{@code findByOidcSub} がヒットすれば correlation 済み(通常ログイン)。ヒットしない場合は 初回ログインの
+   * oidc_sub correlation(ADR-0040 §3.2 / ADR-0006 §3.2)を試みる: email クレームで pending placeholder
+   * 行を突合し、本物の {@code sub} を書き戻す。会員登録(ADR-0040)/SPI insert で作られた行はこの経路で初めてログイン可能になる。
+   *
+   * <p>email が一致しても correlation 済み(別 Keycloak アカウントの sub に紐付く)/匿名化済みの行は突合しない(なりすまし防止)。
+   */
+  private Optional<UserJpaEntity> resolveUser(String sub, Jwt jwt) {
+    Optional<UserJpaEntity> bySub = userRepository.findByOidcSub(sub);
+    if (bySub.isPresent()) {
+      return bySub;
+    }
+    String email = jwt.getClaimAsString("email");
+    if (email == null || email.isBlank()) {
+      return Optional.empty();
+    }
+    return userRepository
+        .findByEmail(email)
+        .filter(UserJpaEntity::isPendingCorrelation)
+        .map(
+            user -> {
+              user.correlateOidcSub(sub);
+              return userRepository.save(user);
+            });
   }
 
   private List<GrantedAuthority> appAdminAuthorities(String sub) {

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/security/usecase/OidcSubCorrelationService.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/security/usecase/OidcSubCorrelationService.java
@@ -1,0 +1,53 @@
+package xyz.dgz48.tasks.webapi.security.usecase;
+
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.Nullable;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import xyz.dgz48.tasks.webapi.user.adapter.persistence.UserJpaEntity;
+import xyz.dgz48.tasks.webapi.user.adapter.persistence.UserRepository;
+
+/**
+ * JWT の {@code sub} から登録ユーザーを解決し、必要なら初回ログインの oidc_sub correlation を行う(ADR-0040 §3.2 / ADR-0006
+ * §3.2)。
+ *
+ * <p>{@code findByOidcSub} がヒットすれば correlation 済み(通常ログイン)。未ヒット時は {@code email} クレームで {@code
+ * pending:<email>} placeholder 行を突合し、本物の {@code sub} を書き戻す。read-modify-write
+ * は単一トランザクションで保護し、同一ユーザーの並行初回ログイン(同一 JWT の二重送信など)で発生し得る楽観ロック競合は、相手の commit 後に {@code sub} で再 lookup
+ * することで透過的に解決する(認証経路に {@code OptimisticLockingFailureException} を素通りさせて HTTP 500 にしない)。
+ *
+ * <p>email が一致しても correlation 済み(別 Keycloak アカウントの {@code sub} に紐付く)/匿名化済みの行は突合しない(なりすまし防止)。
+ */
+@Service
+@RequiredArgsConstructor
+public class OidcSubCorrelationService {
+
+  private final UserRepository userRepository;
+
+  @Transactional
+  public Optional<UserJpaEntity> resolve(String sub, @Nullable String email) {
+    Optional<UserJpaEntity> bySub = userRepository.findByOidcSub(sub);
+    if (bySub.isPresent()) {
+      return bySub;
+    }
+    if (email == null || email.isBlank()) {
+      return Optional.empty();
+    }
+    Optional<UserJpaEntity> byEmail = userRepository.findByEmail(email);
+    if (byEmail.isEmpty() || !byEmail.get().isPendingCorrelation()) {
+      return Optional.empty();
+    }
+    UserJpaEntity user = byEmail.get();
+    user.correlateOidcSub(sub);
+    try {
+      // saveAndFlush でこのメソッド内に flush を強制し、競合をここで捕捉する(commit 時に逃がさない)。
+      return Optional.of(userRepository.saveAndFlush(user));
+    } catch (OptimisticLockingFailureException | DataIntegrityViolationException e) {
+      // 並行初回ログイン: 競合相手が先に同じ sub へ correlation 済み。再 lookup で解決する。
+      return userRepository.findByOidcSub(sub);
+    }
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/adapter/persistence/UserJpaEntity.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/adapter/persistence/UserJpaEntity.java
@@ -55,12 +55,36 @@ public class UserJpaEntity {
   @Column(name = "deleted_at")
   private LocalDateTime deletedAt;
 
+  /** 初回ログイン correlation 待ちの oidc_sub placeholder の接頭辞(SPI insert と共通、ADR-0006 §3.2)。 */
+  private static final String PENDING_OIDC_SUB_PREFIX = "pending:";
+
   public boolean isAnonymized() {
     return this.deletedAt != null;
   }
 
   public boolean isInactive() {
     return this.status == UserStatus.INACTIVE;
+  }
+
+  /**
+   * oidc_sub が初回ログイン correlation 待ちの placeholder({@code pending:<email>})かを返す。会員登録(ADR-0040)や SPI の
+   * admin/recovery insert で作られた行は、初回ログインで本物の Keycloak {@code sub} に突合されるまでこの状態になる。
+   */
+  public boolean isPendingCorrelation() {
+    return this.oidcSub.startsWith(PENDING_OIDC_SUB_PREFIX);
+  }
+
+  /**
+   * 初回ログイン時の oidc_sub correlation(ADR-0006 §3.2 / ADR-0040 §3.2):pending placeholder を Keycloak
+   * の本物の {@code sub} に書き戻す。pending 状態の行に対してのみ呼ぶこと。
+   *
+   * @throws IllegalStateException 既に correlation 済み(pending でない)の行に対して呼ばれた場合
+   */
+  public void correlateOidcSub(String realOidcSub) {
+    if (!isPendingCorrelation()) {
+      throw new IllegalStateException("oidc_sub correlation は pending 行に対してのみ許可される");
+    }
+    this.oidcSub = realOidcSub;
   }
 
   public UserJpaEntity(

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/dashboard/adapter/web/DashboardControllerWebMvcTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/dashboard/adapter/web/DashboardControllerWebMvcTest.java
@@ -34,6 +34,7 @@ import xyz.dgz48.tasks.webapi.security.adapter.web.TasksJwtAuthenticationConvert
 import xyz.dgz48.tasks.webapi.security.adapter.web.WithMockMember;
 import xyz.dgz48.tasks.webapi.security.adapter.web.WithMockSaasAdmin;
 import xyz.dgz48.tasks.webapi.security.adapter.web.WithMockTenantAdmin;
+import xyz.dgz48.tasks.webapi.security.usecase.OidcSubCorrelationService;
 import xyz.dgz48.tasks.webapi.tenant.domain.TenantMembership;
 import xyz.dgz48.tasks.webapi.tenant.domain.TenantRole;
 import xyz.dgz48.tasks.webapi.tenant.usecase.TenantMembershipPort;
@@ -54,6 +55,7 @@ class DashboardControllerWebMvcTest {
   @MockitoBean AuditLogPort auditLogPort;
   @MockitoBean AuthorizationDeniedAuditService authorizationDeniedAuditService;
   @MockitoBean UserRepository userRepository;
+  @MockitoBean OidcSubCorrelationService oidcSubCorrelationService;
   @MockitoBean AppAdminUserRepository appAdminUserRepository;
   @MockitoBean TenantMembershipPort tenantMembershipPort;
   @MockitoBean UserTenantsResolverService userTenantsResolverService;

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/LogoutControllerTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/LogoutControllerTest.java
@@ -17,9 +17,9 @@ import xyz.dgz48.tasks.webapi.audit.usecase.AuditLogPort;
 import xyz.dgz48.tasks.webapi.audit.usecase.AuthorizationDeniedAuditService;
 import xyz.dgz48.tasks.webapi.security.adapter.persistence.AppAdminUserRepository;
 import xyz.dgz48.tasks.webapi.security.usecase.LogoutUseCase;
+import xyz.dgz48.tasks.webapi.security.usecase.OidcSubCorrelationService;
 import xyz.dgz48.tasks.webapi.tenant.usecase.TenantMembershipPort;
 import xyz.dgz48.tasks.webapi.tenant.usecase.UserTenantsResolverService;
-import xyz.dgz48.tasks.webapi.user.adapter.persistence.UserRepository;
 
 @WebMvcTest(LogoutController.class)
 @Import({
@@ -41,7 +41,7 @@ class LogoutControllerTest {
   @MockitoBean JwtDecoder jwtDecoder;
   @MockitoBean AuditLogPort auditLogPort;
   @MockitoBean AuthorizationDeniedAuditService authorizationDeniedAuditService;
-  @MockitoBean UserRepository userRepository;
+  @MockitoBean OidcSubCorrelationService oidcSubCorrelationService;
   @MockitoBean AppAdminUserRepository appAdminUserRepository;
   @MockitoBean TenantMembershipPort tenantMembershipPort;
   @MockitoBean UserTenantsResolverService userTenantsResolverService;

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/MeControllerWebMvcTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/MeControllerWebMvcTest.java
@@ -17,11 +17,11 @@ import xyz.dgz48.tasks.webapi.audit.usecase.AuditLogPort;
 import xyz.dgz48.tasks.webapi.audit.usecase.AuthorizationDeniedAuditService;
 import xyz.dgz48.tasks.webapi.security.adapter.persistence.AppAdminUserRepository;
 import xyz.dgz48.tasks.webapi.security.usecase.GetMeUseCase;
+import xyz.dgz48.tasks.webapi.security.usecase.OidcSubCorrelationService;
 import xyz.dgz48.tasks.webapi.tenant.domain.TenantRole;
 import xyz.dgz48.tasks.webapi.tenant.domain.TenantSummaryInfo;
 import xyz.dgz48.tasks.webapi.tenant.usecase.TenantMembershipPort;
 import xyz.dgz48.tasks.webapi.tenant.usecase.UserTenantsResolverService;
-import xyz.dgz48.tasks.webapi.user.adapter.persistence.UserRepository;
 
 @WebMvcTest(MeController.class)
 @Import({
@@ -35,7 +35,7 @@ class MeControllerWebMvcTest {
   @MockitoBean JwtDecoder jwtDecoder;
   @MockitoBean AuditLogPort auditLogPort;
   @MockitoBean AuthorizationDeniedAuditService authorizationDeniedAuditService;
-  @MockitoBean UserRepository userRepository;
+  @MockitoBean OidcSubCorrelationService oidcSubCorrelationService;
   @MockitoBean AppAdminUserRepository appAdminUserRepository;
   @MockitoBean TenantMembershipPort tenantMembershipPort;
   @MockitoBean UserTenantsResolverService userTenantsResolverService;

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/OidcSubCorrelationIT.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/OidcSubCorrelationIT.java
@@ -1,0 +1,109 @@
+package xyz.dgz48.tasks.webapi.security.adapter.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import jakarta.persistence.EntityManager;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.transaction.support.TransactionTemplate;
+import xyz.dgz48.tasks.webapi.TestcontainersConfiguration;
+import xyz.dgz48.tasks.webapi.security.domain.TasksPrincipal;
+import xyz.dgz48.tasks.webapi.user.adapter.persistence.UserJpaEntity;
+import xyz.dgz48.tasks.webapi.user.adapter.persistence.UserRepository;
+
+/**
+ * 初回ログイン時の oidc_sub correlation(ADR-0040 §3.2 / ADR-0006 §3.2)の統合テスト。
+ *
+ * <p>会員登録 / SPI insert で作られた {@code pending:<email>} 行が、初回ログイン(本物の Keycloak {@code sub} を持つ JWT)で
+ * email により突合され、本物の sub が書き戻されて以降ログイン可能になることを実 DB(Testcontainers)で検証する。
+ */
+@SpringBootTest
+@Import(TestcontainersConfiguration.class)
+class OidcSubCorrelationIT {
+
+  @Autowired TasksJwtAuthenticationConverter converter;
+  @Autowired EntityManager em;
+  @Autowired TransactionTemplate txTemplate;
+  @Autowired UserRepository userRepository;
+
+  private Long userId;
+
+  @AfterEach
+  void tearDown() {
+    if (userId == null) {
+      return;
+    }
+    txTemplate.execute(
+        ignored -> {
+          em.createNativeQuery("DELETE FROM users WHERE id = ?")
+              .setParameter(1, userId)
+              .executeUpdate();
+          return null;
+        });
+  }
+
+  private Long insertPendingUser(String email) {
+    return txTemplate.execute(
+        ignored -> {
+          var u = new UserJpaEntity("pending:" + email, email, "田中一郎", "タナカイチロウ", null);
+          em.persist(u);
+          em.flush();
+          return u.getId();
+        });
+  }
+
+  private static Jwt jwtWith(String sub, String email) {
+    var builder = Jwt.withTokenValue("token").header("alg", "none").subject(sub);
+    if (email != null) {
+      builder = builder.claim("email", email);
+    }
+    return builder.build();
+  }
+
+  @Test
+  void firstLoginCorrelatesPendingRowAndAllowsSubsequentLookupBySub() {
+    userId = insertPendingUser("corr@example.com");
+
+    var token = converter.convert(jwtWith("kc-sub-real", "corr@example.com"));
+
+    // principal は突合した行を指す
+    var principal = (TasksPrincipal) token.getPrincipal();
+    assertThat(principal.getId()).isEqualTo(userId);
+    assertThat(principal.getSub()).isEqualTo("kc-sub-real");
+
+    // DB の oidc_sub は本物の sub に書き戻され、以降 sub で直接ヒットする
+    Optional<UserJpaEntity> bySub =
+        txTemplate.execute(ignored -> userRepository.findByOidcSub("kc-sub-real"));
+    assertThat(bySub).isPresent();
+    assertThat(bySub.orElseThrow().getId()).isEqualTo(userId);
+    assertThat(bySub.orElseThrow().isPendingCorrelation()).isFalse();
+  }
+
+  @Test
+  void rejectsWhenEmailMatchesAlreadyCorrelatedRow() {
+    // 既に本物の sub に correlation 済みの行(別 Keycloak アカウントの sub を持つ JWT)はなりすまし防止のため弾く
+    userId =
+        txTemplate.execute(
+            ignored -> {
+              var u = new UserJpaEntity("kc-sub-owner", "owned@example.com", "本田", "ホンダ", null);
+              em.persist(u);
+              em.flush();
+              return u.getId();
+            });
+
+    assertThatThrownBy(() -> converter.convert(jwtWith("kc-sub-attacker", "owned@example.com")))
+        .isInstanceOf(UserNotRegisteredException.class);
+  }
+
+  @Test
+  void rejectsWhenNoRowMatches() {
+    assertThatThrownBy(() -> converter.convert(jwtWith("kc-sub-unknown", "nobody@example.com")))
+        .isInstanceOf(UserNotRegisteredException.class);
+  }
+}

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/SecurityConfigTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/SecurityConfigTest.java
@@ -44,6 +44,7 @@ import xyz.dgz48.tasks.webapi.notification.usecase.UpdateNotificationSettingsUse
 import xyz.dgz48.tasks.webapi.security.adapter.persistence.AppAdminUserRepository;
 import xyz.dgz48.tasks.webapi.security.usecase.GetMeUseCase;
 import xyz.dgz48.tasks.webapi.security.usecase.LogoutUseCase;
+import xyz.dgz48.tasks.webapi.security.usecase.OidcSubCorrelationService;
 import xyz.dgz48.tasks.webapi.task.usecase.AddStakeholderUseCase;
 import xyz.dgz48.tasks.webapi.task.usecase.ChangeTaskStatusUseCase;
 import xyz.dgz48.tasks.webapi.task.usecase.ChangeVisibilityUseCase;
@@ -85,6 +86,7 @@ class SecurityConfigTest {
   @MockitoBean JwtDecoder jwtDecoder;
   @MockitoBean AuditLogPort auditLogPort;
   @MockitoBean AuthorizationDeniedAuditService authorizationDeniedAuditService;
+  @MockitoBean OidcSubCorrelationService oidcSubCorrelationService;
   @MockitoBean UserRepository userRepository;
   @MockitoBean AppAdminUserRepository appAdminUserRepository;
   @MockitoBean LogoutUseCase logoutUseCase;
@@ -219,7 +221,7 @@ class SecurityConfigTest {
   @Test
   void userNotRegisteredReturns401() throws Exception {
     given(jwtDecoder.decode(any())).willReturn(buildMockJwt("unregistered-sub"));
-    given(userRepository.findByOidcSub("unregistered-sub")).willReturn(Optional.empty());
+    given(oidcSubCorrelationService.resolve("unregistered-sub", null)).willReturn(Optional.empty());
 
     mockMvc
         .perform(get("/api/tasks").header(HttpHeaders.AUTHORIZATION, "Bearer mock.token"))
@@ -237,7 +239,8 @@ class SecurityConfigTest {
     Mockito.when(inactiveUser.isInactive()).thenReturn(true);
 
     given(jwtDecoder.decode(any())).willReturn(buildMockJwt("inactive-sub"));
-    given(userRepository.findByOidcSub("inactive-sub")).willReturn(Optional.of(inactiveUser));
+    given(oidcSubCorrelationService.resolve("inactive-sub", null))
+        .willReturn(Optional.of(inactiveUser));
 
     mockMvc
         .perform(get("/api/tasks").header(HttpHeaders.AUTHORIZATION, "Bearer mock.token"))
@@ -254,7 +257,8 @@ class SecurityConfigTest {
     Mockito.when(anonymizedUser.isAnonymized()).thenReturn(true);
 
     given(jwtDecoder.decode(any())).willReturn(buildMockJwt("anonymized-sub"));
-    given(userRepository.findByOidcSub("anonymized-sub")).willReturn(Optional.of(anonymizedUser));
+    given(oidcSubCorrelationService.resolve("anonymized-sub", null))
+        .willReturn(Optional.of(anonymizedUser));
 
     mockMvc
         .perform(get("/api/tasks").header(HttpHeaders.AUTHORIZATION, "Bearer mock.token"))

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/TasksJwtAuthenticationConverterTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/TasksJwtAuthenticationConverterTest.java
@@ -2,6 +2,8 @@ package xyz.dgz48.tasks.webapi.security.adapter.web;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Optional;
@@ -85,6 +87,68 @@ class TasksJwtAuthenticationConverterTest {
     when(userRepository.findByOidcSub("unknown-sub")).thenReturn(Optional.empty());
 
     assertThatThrownBy(() -> converter.convert(jwt)).isInstanceOf(UserNotRegisteredException.class);
+  }
+
+  @Test
+  void correlatesPendingRowByEmailOnFirstLogin() {
+    // 初回ログイン: 本物の sub では未ヒット → email クレームで pending placeholder 行を突合し sub を書き戻す。
+    when(jwt.getSubject()).thenReturn("kc-sub-real");
+    when(userRepository.findByOidcSub("kc-sub-real")).thenReturn(Optional.empty());
+    when(jwt.getClaimAsString("email")).thenReturn("corr@example.com");
+    when(userRepository.findByEmail("corr@example.com")).thenReturn(Optional.of(user));
+    when(user.isPendingCorrelation()).thenReturn(true);
+    when(userRepository.save(user)).thenReturn(user);
+    when(user.isAnonymized()).thenReturn(false);
+    when(user.isInactive()).thenReturn(false);
+    when(user.getId()).thenReturn(7L);
+    when(user.getOidcSub()).thenReturn("kc-sub-real");
+    when(user.getEmail()).thenReturn("corr@example.com");
+    when(user.getFullName()).thenReturn("田中一郎");
+    when(user.getFullNameKana()).thenReturn("タナカイチロウ");
+    when(user.getDepartmentName()).thenReturn(null);
+    when(appAdminUserRepository.existsByOidcSub("kc-sub-real")).thenReturn(false);
+
+    AbstractAuthenticationToken token = converter.convert(jwt);
+
+    verify(user).correlateOidcSub("kc-sub-real");
+    verify(userRepository).save(user);
+    TasksPrincipal principal = (TasksPrincipal) token.getPrincipal();
+    assertThat(principal.getId()).isEqualTo(7L);
+    assertThat(principal.getSub()).isEqualTo("kc-sub-real");
+  }
+
+  @Test
+  void doesNotCorrelateWhenEmailMatchesAlreadyCorrelatedRow() {
+    // email は一致するが pending でない(別 Keycloak アカウントの sub に紐付く)行はなりすまし防止のため突合しない。
+    when(jwt.getSubject()).thenReturn("kc-sub-attacker");
+    when(userRepository.findByOidcSub("kc-sub-attacker")).thenReturn(Optional.empty());
+    when(jwt.getClaimAsString("email")).thenReturn("victim@example.com");
+    when(userRepository.findByEmail("victim@example.com")).thenReturn(Optional.of(user));
+    when(user.isPendingCorrelation()).thenReturn(false);
+
+    assertThatThrownBy(() -> converter.convert(jwt)).isInstanceOf(UserNotRegisteredException.class);
+    verify(userRepository, never()).save(user);
+  }
+
+  @Test
+  void doesNotCorrelateWhenEmailClaimMissing() {
+    when(jwt.getSubject()).thenReturn("kc-sub-noemail");
+    when(userRepository.findByOidcSub("kc-sub-noemail")).thenReturn(Optional.empty());
+    when(jwt.getClaimAsString("email")).thenReturn(null);
+
+    assertThatThrownBy(() -> converter.convert(jwt)).isInstanceOf(UserNotRegisteredException.class);
+    verify(userRepository, never()).findByEmail(org.mockito.ArgumentMatchers.anyString());
+  }
+
+  @Test
+  void doesNotCorrelateWhenNoRowMatchesEmail() {
+    when(jwt.getSubject()).thenReturn("kc-sub-orphan");
+    when(userRepository.findByOidcSub("kc-sub-orphan")).thenReturn(Optional.empty());
+    when(jwt.getClaimAsString("email")).thenReturn("orphan@example.com");
+    when(userRepository.findByEmail("orphan@example.com")).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> converter.convert(jwt)).isInstanceOf(UserNotRegisteredException.class);
+    verify(userRepository, never()).save(org.mockito.ArgumentMatchers.any());
   }
 
   @Test

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/TasksJwtAuthenticationConverterTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/TasksJwtAuthenticationConverterTest.java
@@ -2,8 +2,7 @@ package xyz.dgz48.tasks.webapi.security.adapter.web;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import java.util.Optional;
@@ -17,13 +16,13 @@ import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.server.resource.InvalidBearerTokenException;
 import xyz.dgz48.tasks.webapi.security.adapter.persistence.AppAdminUserRepository;
 import xyz.dgz48.tasks.webapi.security.domain.TasksPrincipal;
+import xyz.dgz48.tasks.webapi.security.usecase.OidcSubCorrelationService;
 import xyz.dgz48.tasks.webapi.user.adapter.persistence.UserJpaEntity;
-import xyz.dgz48.tasks.webapi.user.adapter.persistence.UserRepository;
 
 @ExtendWith(MockitoExtension.class)
 class TasksJwtAuthenticationConverterTest {
 
-  @Mock UserRepository userRepository;
+  @Mock OidcSubCorrelationService correlationService;
   @Mock AppAdminUserRepository appAdminUserRepository;
   @Mock Jwt jwt;
   @Mock UserJpaEntity user;
@@ -32,7 +31,8 @@ class TasksJwtAuthenticationConverterTest {
 
   private void stubValidUser() {
     when(jwt.getSubject()).thenReturn("sub123");
-    when(userRepository.findByOidcSub("sub123")).thenReturn(Optional.of(user));
+    when(jwt.getClaimAsString("email")).thenReturn("user@example.com");
+    when(correlationService.resolve("sub123", "user@example.com")).thenReturn(Optional.of(user));
     when(user.isAnonymized()).thenReturn(false);
     when(user.isInactive()).thenReturn(false);
     when(user.getId()).thenReturn(1L);
@@ -82,73 +82,12 @@ class TasksJwtAuthenticationConverterTest {
   }
 
   @Test
-  void throwsUserNotRegisteredWhenUserNotFound() {
+  void throwsUserNotRegisteredWhenResolveReturnsEmpty() {
     when(jwt.getSubject()).thenReturn("unknown-sub");
-    when(userRepository.findByOidcSub("unknown-sub")).thenReturn(Optional.empty());
-
-    assertThatThrownBy(() -> converter.convert(jwt)).isInstanceOf(UserNotRegisteredException.class);
-  }
-
-  @Test
-  void correlatesPendingRowByEmailOnFirstLogin() {
-    // 初回ログイン: 本物の sub では未ヒット → email クレームで pending placeholder 行を突合し sub を書き戻す。
-    when(jwt.getSubject()).thenReturn("kc-sub-real");
-    when(userRepository.findByOidcSub("kc-sub-real")).thenReturn(Optional.empty());
-    when(jwt.getClaimAsString("email")).thenReturn("corr@example.com");
-    when(userRepository.findByEmail("corr@example.com")).thenReturn(Optional.of(user));
-    when(user.isPendingCorrelation()).thenReturn(true);
-    when(userRepository.save(user)).thenReturn(user);
-    when(user.isAnonymized()).thenReturn(false);
-    when(user.isInactive()).thenReturn(false);
-    when(user.getId()).thenReturn(7L);
-    when(user.getOidcSub()).thenReturn("kc-sub-real");
-    when(user.getEmail()).thenReturn("corr@example.com");
-    when(user.getFullName()).thenReturn("田中一郎");
-    when(user.getFullNameKana()).thenReturn("タナカイチロウ");
-    when(user.getDepartmentName()).thenReturn(null);
-    when(appAdminUserRepository.existsByOidcSub("kc-sub-real")).thenReturn(false);
-
-    AbstractAuthenticationToken token = converter.convert(jwt);
-
-    verify(user).correlateOidcSub("kc-sub-real");
-    verify(userRepository).save(user);
-    TasksPrincipal principal = (TasksPrincipal) token.getPrincipal();
-    assertThat(principal.getId()).isEqualTo(7L);
-    assertThat(principal.getSub()).isEqualTo("kc-sub-real");
-  }
-
-  @Test
-  void doesNotCorrelateWhenEmailMatchesAlreadyCorrelatedRow() {
-    // email は一致するが pending でない(別 Keycloak アカウントの sub に紐付く)行はなりすまし防止のため突合しない。
-    when(jwt.getSubject()).thenReturn("kc-sub-attacker");
-    when(userRepository.findByOidcSub("kc-sub-attacker")).thenReturn(Optional.empty());
-    when(jwt.getClaimAsString("email")).thenReturn("victim@example.com");
-    when(userRepository.findByEmail("victim@example.com")).thenReturn(Optional.of(user));
-    when(user.isPendingCorrelation()).thenReturn(false);
-
-    assertThatThrownBy(() -> converter.convert(jwt)).isInstanceOf(UserNotRegisteredException.class);
-    verify(userRepository, never()).save(user);
-  }
-
-  @Test
-  void doesNotCorrelateWhenEmailClaimMissing() {
-    when(jwt.getSubject()).thenReturn("kc-sub-noemail");
-    when(userRepository.findByOidcSub("kc-sub-noemail")).thenReturn(Optional.empty());
     when(jwt.getClaimAsString("email")).thenReturn(null);
+    when(correlationService.resolve("unknown-sub", null)).thenReturn(Optional.empty());
 
     assertThatThrownBy(() -> converter.convert(jwt)).isInstanceOf(UserNotRegisteredException.class);
-    verify(userRepository, never()).findByEmail(org.mockito.ArgumentMatchers.anyString());
-  }
-
-  @Test
-  void doesNotCorrelateWhenNoRowMatchesEmail() {
-    when(jwt.getSubject()).thenReturn("kc-sub-orphan");
-    when(userRepository.findByOidcSub("kc-sub-orphan")).thenReturn(Optional.empty());
-    when(jwt.getClaimAsString("email")).thenReturn("orphan@example.com");
-    when(userRepository.findByEmail("orphan@example.com")).thenReturn(Optional.empty());
-
-    assertThatThrownBy(() -> converter.convert(jwt)).isInstanceOf(UserNotRegisteredException.class);
-    verify(userRepository, never()).save(org.mockito.ArgumentMatchers.any());
   }
 
   @Test
@@ -162,7 +101,8 @@ class TasksJwtAuthenticationConverterTest {
   @Test
   void throwsUserAnonymizedWhenDeletedAtIsSet() {
     when(jwt.getSubject()).thenReturn("sub-anon");
-    when(userRepository.findByOidcSub("sub-anon")).thenReturn(Optional.of(user));
+    when(jwt.getClaimAsString("email")).thenReturn("anon@example.com");
+    when(correlationService.resolve(any(), any())).thenReturn(Optional.of(user));
     when(user.isAnonymized()).thenReturn(true);
 
     assertThatThrownBy(() -> converter.convert(jwt))
@@ -173,7 +113,8 @@ class TasksJwtAuthenticationConverterTest {
   @Test
   void throwsUserInactiveWhenStatusIsInactive() {
     when(jwt.getSubject()).thenReturn("sub-inactive");
-    when(userRepository.findByOidcSub("sub-inactive")).thenReturn(Optional.of(user));
+    when(jwt.getClaimAsString("email")).thenReturn("inactive@example.com");
+    when(correlationService.resolve(any(), any())).thenReturn(Optional.of(user));
     when(user.isAnonymized()).thenReturn(false);
     when(user.isInactive()).thenReturn(true);
 
@@ -185,7 +126,8 @@ class TasksJwtAuthenticationConverterTest {
   @Test
   void anonymizedCheckTakesPriorityOverInactiveCheck() {
     when(jwt.getSubject()).thenReturn("sub-both");
-    when(userRepository.findByOidcSub("sub-both")).thenReturn(Optional.of(user));
+    when(jwt.getClaimAsString("email")).thenReturn("both@example.com");
+    when(correlationService.resolve(any(), any())).thenReturn(Optional.of(user));
     when(user.isAnonymized()).thenReturn(true);
 
     assertThatThrownBy(() -> converter.convert(jwt)).isInstanceOf(UserAnonymizedException.class);

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/TenantContextFilterTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/adapter/web/TenantContextFilterTest.java
@@ -32,6 +32,7 @@ import xyz.dgz48.tasks.webapi.notification.usecase.UpdateNotificationSettingsUse
 import xyz.dgz48.tasks.webapi.security.adapter.persistence.AppAdminUserRepository;
 import xyz.dgz48.tasks.webapi.security.usecase.GetMeUseCase;
 import xyz.dgz48.tasks.webapi.security.usecase.LogoutUseCase;
+import xyz.dgz48.tasks.webapi.security.usecase.OidcSubCorrelationService;
 import xyz.dgz48.tasks.webapi.shared.domain.TenantContext;
 import xyz.dgz48.tasks.webapi.task.usecase.AddStakeholderUseCase;
 import xyz.dgz48.tasks.webapi.task.usecase.ChangeTaskStatusUseCase;
@@ -101,6 +102,7 @@ class TenantContextFilterTest {
   @MockitoBean JwtDecoder jwtDecoder;
   @MockitoBean AuditLogPort auditLogPort;
   @MockitoBean AuthorizationDeniedAuditService authorizationDeniedAuditService;
+  @MockitoBean OidcSubCorrelationService oidcSubCorrelationService;
   @MockitoBean UserRepository userRepository;
   @MockitoBean AppAdminUserRepository appAdminUserRepository;
   @MockitoBean LogoutUseCase logoutUseCase;

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/usecase/OidcSubCorrelationServiceTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/security/usecase/OidcSubCorrelationServiceTest.java
@@ -1,0 +1,102 @@
+package xyz.dgz48.tasks.webapi.security.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.OptimisticLockingFailureException;
+import xyz.dgz48.tasks.webapi.user.adapter.persistence.UserJpaEntity;
+import xyz.dgz48.tasks.webapi.user.adapter.persistence.UserRepository;
+
+@ExtendWith(MockitoExtension.class)
+class OidcSubCorrelationServiceTest {
+
+  @Mock UserRepository userRepository;
+  @Mock UserJpaEntity user;
+
+  @InjectMocks OidcSubCorrelationService service;
+
+  @Test
+  void returnsUserDirectlyWhenSubAlreadyCorrelated() {
+    when(userRepository.findByOidcSub("sub-real")).thenReturn(Optional.of(user));
+
+    Optional<UserJpaEntity> result = service.resolve("sub-real", "user@example.com");
+
+    assertThat(result).containsSame(user);
+    verify(userRepository, never()).findByEmail(org.mockito.ArgumentMatchers.anyString());
+  }
+
+  @Test
+  void correlatesPendingRowByEmailOnFirstLogin() {
+    when(userRepository.findByOidcSub("sub-real")).thenReturn(Optional.empty());
+    when(userRepository.findByEmail("corr@example.com")).thenReturn(Optional.of(user));
+    when(user.isPendingCorrelation()).thenReturn(true);
+    when(userRepository.saveAndFlush(user)).thenReturn(user);
+
+    Optional<UserJpaEntity> result = service.resolve("sub-real", "corr@example.com");
+
+    assertThat(result).containsSame(user);
+    verify(user).correlateOidcSub("sub-real");
+    verify(userRepository).saveAndFlush(user);
+  }
+
+  @Test
+  void returnsEmptyWhenEmailClaimMissing() {
+    when(userRepository.findByOidcSub("sub-x")).thenReturn(Optional.empty());
+
+    assertThat(service.resolve("sub-x", null)).isEmpty();
+    verify(userRepository, never()).findByEmail(org.mockito.ArgumentMatchers.anyString());
+  }
+
+  @Test
+  void returnsEmptyWhenEmailClaimBlank() {
+    when(userRepository.findByOidcSub("sub-x")).thenReturn(Optional.empty());
+
+    assertThat(service.resolve("sub-x", "   ")).isEmpty();
+    verify(userRepository, never()).findByEmail(org.mockito.ArgumentMatchers.anyString());
+  }
+
+  @Test
+  void returnsEmptyWhenNoRowMatchesEmail() {
+    when(userRepository.findByOidcSub("sub-x")).thenReturn(Optional.empty());
+    when(userRepository.findByEmail("orphan@example.com")).thenReturn(Optional.empty());
+
+    assertThat(service.resolve("sub-x", "orphan@example.com")).isEmpty();
+    verify(userRepository, never()).saveAndFlush(org.mockito.ArgumentMatchers.any());
+  }
+
+  @Test
+  void doesNotCorrelateWhenEmailMatchesAlreadyCorrelatedRow() {
+    // email は一致するが pending でない(別 Keycloak アカウントの sub に紐付く)行は突合しない(なりすまし防止)。
+    when(userRepository.findByOidcSub("sub-attacker")).thenReturn(Optional.empty());
+    when(userRepository.findByEmail("victim@example.com")).thenReturn(Optional.of(user));
+    when(user.isPendingCorrelation()).thenReturn(false);
+
+    assertThat(service.resolve("sub-attacker", "victim@example.com")).isEmpty();
+    verify(userRepository, never()).saveAndFlush(org.mockito.ArgumentMatchers.any());
+  }
+
+  @Test
+  void resolvesBySubOnOptimisticLockConflict() {
+    // 並行初回ログイン: 競合相手が先に同じ sub へ correlation 済み → saveAndFlush が失敗 → sub 再 lookup で解決。
+    UserJpaEntity correlatedByPeer = org.mockito.Mockito.mock(UserJpaEntity.class);
+    when(userRepository.findByOidcSub("sub-real"))
+        .thenReturn(Optional.empty())
+        .thenReturn(Optional.of(correlatedByPeer));
+    when(userRepository.findByEmail("race@example.com")).thenReturn(Optional.of(user));
+    when(user.isPendingCorrelation()).thenReturn(true);
+    when(userRepository.saveAndFlush(user))
+        .thenThrow(new OptimisticLockingFailureException("conflict"));
+
+    Optional<UserJpaEntity> result = service.resolve("sub-real", "race@example.com");
+
+    assertThat(result).containsSame(correlatedByPeer);
+  }
+}

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/adapter/web/TaskControllerWebMvcTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/adapter/web/TaskControllerWebMvcTest.java
@@ -35,6 +35,7 @@ import xyz.dgz48.tasks.webapi.security.adapter.web.TasksJwtAuthenticationConvert
 import xyz.dgz48.tasks.webapi.security.adapter.web.WithMockMember;
 import xyz.dgz48.tasks.webapi.security.adapter.web.WithMockSaasAdmin;
 import xyz.dgz48.tasks.webapi.security.adapter.web.WithMockTenantAdmin;
+import xyz.dgz48.tasks.webapi.security.usecase.OidcSubCorrelationService;
 import xyz.dgz48.tasks.webapi.task.domain.Priority;
 import xyz.dgz48.tasks.webapi.task.domain.Task;
 import xyz.dgz48.tasks.webapi.task.domain.TaskNotFoundException;
@@ -73,6 +74,7 @@ class TaskControllerWebMvcTest {
   @MockitoBean AuditLogPort auditLogPort;
   @MockitoBean AuthorizationDeniedAuditService authorizationDeniedAuditService;
   @MockitoBean UserRepository userRepository;
+  @MockitoBean OidcSubCorrelationService oidcSubCorrelationService;
   @MockitoBean AppAdminUserRepository appAdminUserRepository;
   @MockitoBean TenantMembershipPort tenantMembershipPort;
   @MockitoBean UserTenantsResolverService userTenantsResolverService;

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/tenant/adapter/web/SelectTenantControllerWebMvcTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/tenant/adapter/web/SelectTenantControllerWebMvcTest.java
@@ -21,11 +21,11 @@ import xyz.dgz48.tasks.webapi.security.adapter.web.TasksAccessDeniedHandler;
 import xyz.dgz48.tasks.webapi.security.adapter.web.TasksAuthenticationEntryPoint;
 import xyz.dgz48.tasks.webapi.security.adapter.web.TasksJwtAuthenticationConverter;
 import xyz.dgz48.tasks.webapi.security.adapter.web.WithMockMember;
+import xyz.dgz48.tasks.webapi.security.usecase.OidcSubCorrelationService;
 import xyz.dgz48.tasks.webapi.tenant.domain.TenantNotMemberException;
 import xyz.dgz48.tasks.webapi.tenant.usecase.SwitchTenantUseCase;
 import xyz.dgz48.tasks.webapi.tenant.usecase.TenantMembershipPort;
 import xyz.dgz48.tasks.webapi.tenant.usecase.UserTenantsResolverService;
-import xyz.dgz48.tasks.webapi.user.adapter.persistence.UserRepository;
 
 @WebMvcTest(SelectTenantController.class)
 @Import({
@@ -40,7 +40,7 @@ class SelectTenantControllerWebMvcTest {
   @MockitoBean JwtDecoder jwtDecoder;
   @MockitoBean AuditLogPort auditLogPort;
   @MockitoBean AuthorizationDeniedAuditService authorizationDeniedAuditService;
-  @MockitoBean UserRepository userRepository;
+  @MockitoBean OidcSubCorrelationService oidcSubCorrelationService;
   @MockitoBean AppAdminUserRepository appAdminUserRepository;
   @MockitoBean TenantMembershipPort tenantMembershipPort;
   @MockitoBean UserTenantsResolverService userTenantsResolverService;

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/tenant/adapter/web/TenantMemberControllerWebMvcTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/tenant/adapter/web/TenantMemberControllerWebMvcTest.java
@@ -33,6 +33,7 @@ import xyz.dgz48.tasks.webapi.security.adapter.web.TasksJwtAuthenticationConvert
 import xyz.dgz48.tasks.webapi.security.adapter.web.WithMockMember;
 import xyz.dgz48.tasks.webapi.security.adapter.web.WithMockSaasAdmin;
 import xyz.dgz48.tasks.webapi.security.adapter.web.WithMockTenantAdmin;
+import xyz.dgz48.tasks.webapi.security.usecase.OidcSubCorrelationService;
 import xyz.dgz48.tasks.webapi.tenant.domain.TenantRole;
 import xyz.dgz48.tasks.webapi.tenant.domain.TenantUserInfo;
 import xyz.dgz48.tasks.webapi.tenant.domain.UserAlreadyMemberException;
@@ -44,7 +45,6 @@ import xyz.dgz48.tasks.webapi.tenant.usecase.InviteUserUseCase;
 import xyz.dgz48.tasks.webapi.tenant.usecase.RemoveMemberUseCase;
 import xyz.dgz48.tasks.webapi.tenant.usecase.TenantMembershipPort;
 import xyz.dgz48.tasks.webapi.tenant.usecase.UserTenantsResolverService;
-import xyz.dgz48.tasks.webapi.user.adapter.persistence.UserRepository;
 
 /**
  * メンバー管理 API(DELETE /api/tenant/users/{userId}・PUT /api/tenant/users/{userId}/role)のスライステスト。
@@ -65,7 +65,7 @@ class TenantMemberControllerWebMvcTest {
   @MockitoBean JwtDecoder jwtDecoder;
   @MockitoBean AuditLogPort auditLogPort;
   @MockitoBean AuthorizationDeniedAuditService authorizationDeniedAuditService;
-  @MockitoBean UserRepository userRepository;
+  @MockitoBean OidcSubCorrelationService oidcSubCorrelationService;
   @MockitoBean AppAdminUserRepository appAdminUserRepository;
   @MockitoBean TenantMembershipPort tenantMembershipPort;
   @MockitoBean UserTenantsResolverService userTenantsResolverService;

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/tenant/adapter/web/TenantUserControllerWebMvcTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/tenant/adapter/web/TenantUserControllerWebMvcTest.java
@@ -27,13 +27,13 @@ import xyz.dgz48.tasks.webapi.security.adapter.web.TasksJwtAuthenticationConvert
 import xyz.dgz48.tasks.webapi.security.adapter.web.WithMockMember;
 import xyz.dgz48.tasks.webapi.security.adapter.web.WithMockSaasAdmin;
 import xyz.dgz48.tasks.webapi.security.adapter.web.WithMockTenantAdmin;
+import xyz.dgz48.tasks.webapi.security.usecase.OidcSubCorrelationService;
 import xyz.dgz48.tasks.webapi.tenant.domain.TenantRole;
 import xyz.dgz48.tasks.webapi.tenant.domain.TenantUserInfo;
 import xyz.dgz48.tasks.webapi.tenant.domain.UserTenantStatus;
 import xyz.dgz48.tasks.webapi.tenant.usecase.ListTenantUsersUseCase;
 import xyz.dgz48.tasks.webapi.tenant.usecase.TenantMembershipPort;
 import xyz.dgz48.tasks.webapi.tenant.usecase.UserTenantsResolverService;
-import xyz.dgz48.tasks.webapi.user.adapter.persistence.UserRepository;
 
 @WebMvcTest(TenantUserController.class)
 @Import({
@@ -47,7 +47,7 @@ class TenantUserControllerWebMvcTest {
   @MockitoBean JwtDecoder jwtDecoder;
   @MockitoBean AuditLogPort auditLogPort;
   @MockitoBean AuthorizationDeniedAuditService authorizationDeniedAuditService;
-  @MockitoBean UserRepository userRepository;
+  @MockitoBean OidcSubCorrelationService oidcSubCorrelationService;
   @MockitoBean AppAdminUserRepository appAdminUserRepository;
   @MockitoBean TenantMembershipPort tenantMembershipPort;
   @MockitoBean UserTenantsResolverService userTenantsResolverService;

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/user/adapter/persistence/UserJpaEntityCorrelationTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/user/adapter/persistence/UserJpaEntityCorrelationTest.java
@@ -1,0 +1,40 @@
+package xyz.dgz48.tasks.webapi.user.adapter.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+/** {@link UserJpaEntity} の oidc_sub correlation ロジック(ADR-0040 §3.2 / ADR-0006 §3.2)の単体テスト。 */
+class UserJpaEntityCorrelationTest {
+
+  @Test
+  void isPendingCorrelationTrueForPendingPlaceholder() {
+    var user = new UserJpaEntity("pending:a@example.com", "a@example.com", "氏名", "シメイ", null);
+    assertThat(user.isPendingCorrelation()).isTrue();
+  }
+
+  @Test
+  void isPendingCorrelationFalseForRealSub() {
+    var user = new UserJpaEntity("kc-sub-real", "a@example.com", "氏名", "シメイ", null);
+    assertThat(user.isPendingCorrelation()).isFalse();
+  }
+
+  @Test
+  void correlateOidcSubRewritesPendingPlaceholderToRealSub() {
+    var user = new UserJpaEntity("pending:a@example.com", "a@example.com", "氏名", "シメイ", null);
+
+    user.correlateOidcSub("kc-sub-real");
+
+    assertThat(user.getOidcSub()).isEqualTo("kc-sub-real");
+    assertThat(user.isPendingCorrelation()).isFalse();
+  }
+
+  @Test
+  void correlateOidcSubRejectsAlreadyCorrelatedRow() {
+    var user = new UserJpaEntity("kc-sub-existing", "a@example.com", "氏名", "シメイ", null);
+
+    assertThatThrownBy(() -> user.correlateOidcSub("kc-sub-new"))
+        .isInstanceOf(IllegalStateException.class);
+  }
+}


### PR DESCRIPTION
ADR-0040 §3.2 / ADR-0006 §3.2 の前提となる **初回ログイン時の `oidc_sub` correlation** を実装します。

## 背景(発見した欠落)
`TasksJwtAuthenticationConverter` は `findByOidcSub(sub)` のみで解決しており、**correlation が未実装**でした。会員登録(ADR-0040)や SPI の admin/recovery insert で作られる行は `oidc_sub = pending:<email>` の placeholder を持つため、本物の Keycloak `sub` では未ヒット → `UserNotRegisteredException` となり **ログイン不能**。これはオンボーディング全体の前提となる foundational gap です。

## 変更
- **`UserJpaEntity`**
  - `isPendingCorrelation()` — `pending:` 接頭辞の判定
  - `correlateOidcSub(realSub)` — pending 行のみ本物の `sub` へ書き戻し。correlation 済みの行に対しては `IllegalStateException`
- **`TasksJwtAuthenticationConverter`**
  - `findByOidcSub` 未ヒット時に `email` クレームで pending 行を突合し `sub` を書き戻す `resolveUser()` を追加
  - email が一致しても **correlation 済み(別 Keycloak アカウント)/ 匿名化済み**の行は突合しない(なりすまし防止)
  - 既存 SPI insert ユーザーもこの経路でログイン可能に

## テスト
- 単体(`TasksJwtAuthenticationConverterTest`): sub ヒット / email 突合で correlation / email 欠落 / 未ヒット / 既 correlation 行は弾く
- 単体(`UserJpaEntityCorrelationTest`): pending 判定・書き戻し・ガード例外
- IT(`OidcSubCorrelationIT`、Testcontainers MySQL): pending 行 → 初回ログインで実 DB へ `sub` 書き戻し → 以降 `sub` で直接ヒット。なりすまし / 未登録は `UserNotRegistered`

`./gradlew :webapi:check` green(spotless / NullAway / JaCoCo 0.80 / 全 IT)。

## PR 分割
ADR-0040 §6 の PR2 は大きいため、その前提となる correlation を本 PR に分離しました。後続で **`RegisterMemberUseCase` + credential 転送(Keycloak Admin REST API、native 安全な Spring RestClient 利用)+ realm service-account client** を別 PR にします。

Refs #817