### PR TITLE
feat(user): 会員登録プリミティブ RegisterMemberUseCase + dev credential 実装 (Refs #817)

### DIFF
--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/adapter/external/LoggingCredentialProvisioningAdapter.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/adapter/external/LoggingCredentialProvisioningAdapter.java
@@ -1,0 +1,20 @@
+package xyz.dgz48.tasks.webapi.user.adapter.external;
+
+import lombok.extern.slf4j.Slf4j;
+import xyz.dgz48.tasks.webapi.user.usecase.CredentialProvisioningPort;
+
+/**
+ * {@link CredentialProvisioningPort} の dev/test 用フォールバック実装。
+ *
+ * <p>Keycloak を呼ばず、credential プロビジョニングをスキップした旨をログに残すだけ(パスワードはログに出さない)。本番では Keycloak Admin REST API
+ * 実装が {@code keycloak.admin.enabled=true} で優先され、こちらは {@code @ConditionalOnMissingBean}
+ * で抑止される(ADR-0040 §3.1、SES の log フォールバックと同方式)。
+ */
+@Slf4j
+public class LoggingCredentialProvisioningAdapter implements CredentialProvisioningPort {
+
+  @Override
+  public void provisionCredential(String email, String rawPassword) {
+    log.info("[dev] credential provisioning skipped (logging adapter): email={}", email);
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/adapter/external/package-info.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/adapter/external/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package xyz.dgz48.tasks.webapi.user.adapter.external;
+
+import org.jspecify.annotations.NullMarked;

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/adapter/persistence/UserJpaEntity.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/adapter/persistence/UserJpaEntity.java
@@ -87,6 +87,13 @@ public class UserJpaEntity {
     this.oidcSub = realOidcSub;
   }
 
+  /** 会員登録(ADR-0040 §3.3)時の profile 更新。SPI insert 等で先に作られた pending 行に対し、登録画面で入力された profile を書き込む。 */
+  public void updateProfile(String fullName, String fullNameKana, @Nullable String departmentName) {
+    this.fullName = fullName;
+    this.fullNameKana = fullNameKana;
+    this.departmentName = departmentName;
+  }
+
   public UserJpaEntity(
       String oidcSub,
       String email,

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/adapter/persistence/UserRegistrationPersistenceAdapter.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/adapter/persistence/UserRegistrationPersistenceAdapter.java
@@ -1,0 +1,49 @@
+package xyz.dgz48.tasks.webapi.user.adapter.persistence;
+
+import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.Nullable;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import xyz.dgz48.tasks.webapi.user.usecase.UserRegistrationPort;
+
+/**
+ * {@link UserRegistrationPort} の永続化アダプタ(ADR-0040 §3.3 ①)。
+ *
+ * <p>会員登録は remote 呼び出し(Keycloak credential 設定)を跨ぐため呼び出し元ユースケースを {@code @Transactional} にできない。本書込の
+ * tx 境界はこのメソッドに置き、credential 設定の前に commit する。
+ */
+@Component
+@RequiredArgsConstructor
+public class UserRegistrationPersistenceAdapter implements UserRegistrationPort {
+
+  private final UserRepository userRepository;
+
+  @Override
+  @Transactional
+  public Long upsertPendingMember(
+      String email, String fullName, String fullNameKana, @Nullable String departmentName) {
+    UserJpaEntity entity =
+        userRepository
+            .findByEmail(email)
+            .map(
+                existing -> updateExisting(existing, email, fullName, fullNameKana, departmentName))
+            .orElseGet(
+                () ->
+                    new UserJpaEntity(
+                        "pending:" + email, email, fullName, fullNameKana, departmentName));
+    return userRepository.save(entity).getId();
+  }
+
+  private UserJpaEntity updateExisting(
+      UserJpaEntity existing,
+      String email,
+      String fullName,
+      String fullNameKana,
+      @Nullable String departmentName) {
+    if (!existing.isPendingCorrelation()) {
+      throw new IllegalStateException("既に登録・correlation 済みの email です: " + email);
+    }
+    existing.updateProfile(fullName, fullNameKana, departmentName);
+    return existing;
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/adapter/persistence/UserRegistrationPersistenceAdapter.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/adapter/persistence/UserRegistrationPersistenceAdapter.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.Nullable;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import xyz.dgz48.tasks.webapi.user.domain.UserAlreadyRegisteredException;
 import xyz.dgz48.tasks.webapi.user.usecase.UserRegistrationPort;
 
 /**
@@ -19,14 +20,13 @@ public class UserRegistrationPersistenceAdapter implements UserRegistrationPort 
   private final UserRepository userRepository;
 
   @Override
-  @Transactional
+  @Transactional(readOnly = false)
   public Long upsertPendingMember(
       String email, String fullName, String fullNameKana, @Nullable String departmentName) {
     UserJpaEntity entity =
         userRepository
             .findByEmail(email)
-            .map(
-                existing -> updateExisting(existing, email, fullName, fullNameKana, departmentName))
+            .map(existing -> updateExisting(existing, fullName, fullNameKana, departmentName))
             .orElseGet(
                 () ->
                     new UserJpaEntity(
@@ -36,12 +36,11 @@ public class UserRegistrationPersistenceAdapter implements UserRegistrationPort 
 
   private UserJpaEntity updateExisting(
       UserJpaEntity existing,
-      String email,
       String fullName,
       String fullNameKana,
       @Nullable String departmentName) {
     if (!existing.isPendingCorrelation()) {
-      throw new IllegalStateException("既に登録・correlation 済みの email です: " + email);
+      throw new UserAlreadyRegisteredException();
     }
     existing.updateProfile(fullName, fullNameKana, departmentName);
     return existing;

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/adapter/web/UserExceptionHandler.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/adapter/web/UserExceptionHandler.java
@@ -1,0 +1,36 @@
+package xyz.dgz48.tasks.webapi.user.adapter.web;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.time.OffsetDateTime;
+import java.util.Objects;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import xyz.dgz48.tasks.webapi.shared.infra.AppZones;
+import xyz.dgz48.tasks.webapi.shared.web.ErrorCode;
+import xyz.dgz48.tasks.webapi.shared.web.ErrorResponse;
+import xyz.dgz48.tasks.webapi.user.domain.UserAlreadyRegisteredException;
+
+/**
+ * user feature の業務例外を HTTP レスポンスにマップする例外ハンドラ。
+ *
+ * <p>会員登録(ADR-0040)で email が既に登録済みの場合の {@link UserAlreadyRegisteredException} を 409 / E_CONFLICT
+ * にマップする。会員登録の呼び出し経路(招待受諾 / セルフサインアップの Controller)は後続 PR で追加されるが、業務例外が 500 に化けないようマッピングを先行して用意する。
+ */
+@RestControllerAdvice
+public class UserExceptionHandler {
+
+  @ExceptionHandler(UserAlreadyRegisteredException.class)
+  @ResponseStatus(HttpStatus.CONFLICT)
+  public ErrorResponse handleAlreadyRegistered(
+      UserAlreadyRegisteredException ex, HttpServletRequest request) {
+    return new ErrorResponse(
+        OffsetDateTime.now(AppZones.JST),
+        HttpStatus.CONFLICT.value(),
+        HttpStatus.CONFLICT.getReasonPhrase(),
+        ErrorCode.E_CONFLICT,
+        Objects.requireNonNullElse(ex.getMessage(), "指定された email は既に登録済みです"),
+        request.getRequestURI());
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/domain/UserAlreadyRegisteredException.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/domain/UserAlreadyRegisteredException.java
@@ -1,0 +1,16 @@
+package xyz.dgz48.tasks.webapi.user.domain;
+
+import xyz.dgz48.tasks.webapi.shared.exception.DomainException;
+
+/**
+ * 会員登録(ADR-0040 §3.3)で、対象 email が既に correlation 済み(本物の Keycloak {@code sub}
+ * に紐付く登録済みユーザー)の行に一致した場合の業務例外。HTTP 409 にマップする。
+ *
+ * <p>コーディング規約 §7 に従い、PII(email)はメッセージに含めない。
+ */
+public class UserAlreadyRegisteredException extends DomainException {
+
+  public UserAlreadyRegisteredException() {
+    super("指定された email は既に登録済みです");
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/infra/CredentialProvisioningConfig.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/infra/CredentialProvisioningConfig.java
@@ -1,0 +1,24 @@
+package xyz.dgz48.tasks.webapi.user.infra;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import xyz.dgz48.tasks.webapi.user.adapter.external.LoggingCredentialProvisioningAdapter;
+import xyz.dgz48.tasks.webapi.user.usecase.CredentialProvisioningPort;
+
+/**
+ * credential プロビジョニング実装の選択(ADR-0040 §3.1)。
+ *
+ * <p>本番の Keycloak Admin REST API 実装({@code keycloak.admin.enabled=true} で有効、後続
+ * PR)が存在しない場合は、dev/test 用の {@link LoggingCredentialProvisioningAdapter}
+ * にフォールバックする({@code @ConditionalOnMissingBean})。SES の log フォールバックと同方式。
+ */
+@Configuration
+public class CredentialProvisioningConfig {
+
+  @Bean
+  @ConditionalOnMissingBean(CredentialProvisioningPort.class)
+  public CredentialProvisioningPort loggingCredentialProvisioningAdapter() {
+    return new LoggingCredentialProvisioningAdapter();
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/infra/package-info.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/infra/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package xyz.dgz48.tasks.webapi.user.infra;
+
+import org.jspecify.annotations.NullMarked;

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/usecase/CredentialProvisioningException.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/usecase/CredentialProvisioningException.java
@@ -1,0 +1,14 @@
+package xyz.dgz48.tasks.webapi.user.usecase;
+
+/**
+ * Keycloak への credential プロビジョニング(パスワード設定 / emailVerified 更新)に失敗したことを表す例外(ADR-0040 §3.1)。
+ *
+ * <p>会員登録は「project DB 先 → Keycloak 後」の順で行うため、本例外が発生した時点で users 行は既に書かれている(未完了状態)。呼び出し側は招待 / signup
+ * トークンを消費せず、再試行 / 補償に委ねる(ADR-0006 §3.3 / ADR-0040 §3.5)。
+ */
+public class CredentialProvisioningException extends RuntimeException {
+
+  public CredentialProvisioningException(String message) {
+    super(message);
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/usecase/CredentialProvisioningException.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/usecase/CredentialProvisioningException.java
@@ -1,14 +1,22 @@
 package xyz.dgz48.tasks.webapi.user.usecase;
 
+import org.jspecify.annotations.Nullable;
+import xyz.dgz48.tasks.webapi.shared.exception.DomainException;
+
 /**
- * Keycloak への credential プロビジョニング(パスワード設定 / emailVerified 更新)に失敗したことを表す例外(ADR-0040 §3.1)。
+ * Keycloak への credential プロビジョニング(パスワード設定 / emailVerified 更新)に失敗したことを表す業務例外(ADR-0040 §3.1、コーディング規約
+ * §6.1 に従い {@link DomainException} を基底とする)。
  *
  * <p>会員登録は「project DB 先 → Keycloak 後」の順で行うため、本例外が発生した時点で users 行は既に書かれている(未完了状態)。呼び出し側は招待 / signup
  * トークンを消費せず、再試行 / 補償に委ねる(ADR-0006 §3.3 / ADR-0040 §3.5)。
  */
-public class CredentialProvisioningException extends RuntimeException {
+public class CredentialProvisioningException extends DomainException {
 
   public CredentialProvisioningException(String message) {
     super(message);
+  }
+
+  public CredentialProvisioningException(String message, @Nullable Throwable cause) {
+    super(message, cause);
   }
 }

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/usecase/CredentialProvisioningPort.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/usecase/CredentialProvisioningPort.java
@@ -1,0 +1,20 @@
+package xyz.dgz48.tasks.webapi.user.usecase;
+
+/**
+ * Keycloak への credential プロビジョニングの out-port(ADR-0040 §3.1 / §3.4)。
+ *
+ * <p>会員登録プリミティブ({@link RegisterMemberUseCase})から、project DB への users 行書込の後に呼ばれる。実装は Keycloak Admin
+ * REST API でパスワードを設定し {@code emailVerified=true} にする(ADR-0006 §3.3「credential は Keycloak が
+ * SoT」を維持)。dev/test は no-op のログ実装にフォールバックする。
+ */
+public interface CredentialProvisioningPort {
+
+  /**
+   * 指定 email の Keycloak ユーザーにパスワードを設定し、email を検証済みにする。
+   *
+   * @param email 対象ユーザーの email(Keycloak username)
+   * @param rawPassword 設定するパスワード(平文。ログ出力禁止)
+   * @throws CredentialProvisioningException Keycloak への設定に失敗した場合
+   */
+  void provisionCredential(String email, String rawPassword);
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/usecase/RegisterMemberCommand.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/usecase/RegisterMemberCommand.java
@@ -1,0 +1,19 @@
+package xyz.dgz48.tasks.webapi.user.usecase;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * 会員登録プリミティブ({@link RegisterMemberUseCase})の入力(ADR-0040 §3.3)。
+ *
+ * @param email 登録する email(Keycloak username 兼 correlation キー)
+ * @param fullName 氏名
+ * @param fullNameKana 氏名(カナ)
+ * @param departmentName 部署名(任意)
+ * @param rawPassword 設定するパスワード(平文。ログ出力禁止)
+ */
+public record RegisterMemberCommand(
+    String email,
+    String fullName,
+    String fullNameKana,
+    @Nullable String departmentName,
+    String rawPassword) {}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/usecase/RegisterMemberUseCase.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/usecase/RegisterMemberUseCase.java
@@ -1,0 +1,37 @@
+package xyz.dgz48.tasks.webapi.user.usecase;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/**
+ * 会員登録プリミティブ(ADR-0040 §3.3)。招待受諾(Flow A)/ セルフサインアップ(Flow B)の両フローが共有する。
+ *
+ * <p>処理順は <b>project DB 先 → Keycloak 後</b>(ADR-0006 §3.3):① {@code users} 行を upsert(profile、{@code
+ * oidc_sub} は pending placeholder)→ ② Keycloak に credential 設定 + {@code emailVerified=true}。②
+ * が失敗した場合は {@link CredentialProvisioningException} を伝播する。このとき ① の行は残る(未完了状態)が、再登録は email で
+ * idempotent に upsert され credential を再試行できる(ADR-0040 §3.5)。呼び出し側は ② 失敗時に招待 / signup トークンを消費しないこと。
+ *
+ * <p>本ユースケースは remote 呼び出し(②)を跨ぐためクラスレベルの {@code @Transactional} を持たない。① の DB tx 境界は {@link
+ * UserRegistrationPort} 実装側にある。
+ */
+@Service
+@RequiredArgsConstructor
+public class RegisterMemberUseCase {
+
+  private final UserRegistrationPort userRegistrationPort;
+  private final CredentialProvisioningPort credentialProvisioningPort;
+
+  /**
+   * 会員登録を実行し、登録した {@code users} 行の id を返す。
+   *
+   * @throws CredentialProvisioningException Keycloak への credential 設定に失敗した場合(① の行は残る)
+   * @throws IllegalStateException email が既に correlation 済みの登録ユーザーに一致した場合
+   */
+  public Long register(RegisterMemberCommand cmd) {
+    Long userId =
+        userRegistrationPort.upsertPendingMember(
+            cmd.email(), cmd.fullName(), cmd.fullNameKana(), cmd.departmentName());
+    credentialProvisioningPort.provisionCredential(cmd.email(), cmd.rawPassword());
+    return userId;
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/usecase/RegisterMemberUseCase.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/usecase/RegisterMemberUseCase.java
@@ -25,7 +25,8 @@ public class RegisterMemberUseCase {
    * 会員登録を実行し、登録した {@code users} 行の id を返す。
    *
    * @throws CredentialProvisioningException Keycloak への credential 設定に失敗した場合(① の行は残る)
-   * @throws IllegalStateException email が既に correlation 済みの登録ユーザーに一致した場合
+   * @throws xyz.dgz48.tasks.webapi.user.domain.UserAlreadyRegisteredException email が既に correlation
+   *     済みの登録ユーザーに一致した場合
    */
   public Long register(RegisterMemberCommand cmd) {
     Long userId =

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/usecase/UserRegistrationPort.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/usecase/UserRegistrationPort.java
@@ -15,7 +15,8 @@ public interface UserRegistrationPort {
    * correlation(pending)の行が あれば profile を更新する。
    *
    * @return 対象 {@code users} 行の id
-   * @throws IllegalStateException email が既に correlation 済み(本物の sub に紐付く登録済み)の行に一致した場合
+   * @throws xyz.dgz48.tasks.webapi.user.domain.UserAlreadyRegisteredException email が既に correlation
+   *     済み(本物の sub に紐付く登録済み)の行に一致した場合
    */
   Long upsertPendingMember(
       String email, String fullName, String fullNameKana, @Nullable String departmentName);

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/usecase/UserRegistrationPort.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/usecase/UserRegistrationPort.java
@@ -1,0 +1,22 @@
+package xyz.dgz48.tasks.webapi.user.usecase;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * 会員登録時の {@code users} 行書込の out-port(ADR-0040 §3.3 ①)。
+ *
+ * <p>{@code oidc_sub} は {@code pending:<email>} placeholder で書き込み、初回ログイン時に本物の Keycloak {@code sub}
+ * へ correlation される(ADR-0006 §3.2、{@code OidcSubCorrelationService})。
+ */
+public interface UserRegistrationPort {
+
+  /**
+   * email で {@code users} 行を upsert する。行が無ければ {@code pending:<email>} で insert し、未
+   * correlation(pending)の行が あれば profile を更新する。
+   *
+   * @return 対象 {@code users} 行の id
+   * @throws IllegalStateException email が既に correlation 済み(本物の sub に紐付く登録済み)の行に一致した場合
+   */
+  Long upsertPendingMember(
+      String email, String fullName, String fullNameKana, @Nullable String departmentName);
+}

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/user/adapter/external/LoggingCredentialProvisioningAdapterTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/user/adapter/external/LoggingCredentialProvisioningAdapterTest.java
@@ -1,0 +1,17 @@
+package xyz.dgz48.tasks.webapi.user.adapter.external;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import org.junit.jupiter.api.Test;
+
+class LoggingCredentialProvisioningAdapterTest {
+
+  private final LoggingCredentialProvisioningAdapter adapter =
+      new LoggingCredentialProvisioningAdapter();
+
+  @Test
+  void provisionCredentialDoesNotThrow() {
+    assertThatCode(() -> adapter.provisionCredential("user@example.com", "raw-password"))
+        .doesNotThrowAnyException();
+  }
+}

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/user/adapter/persistence/UserRegistrationPersistenceAdapterIT.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/user/adapter/persistence/UserRegistrationPersistenceAdapterIT.java
@@ -1,0 +1,104 @@
+package xyz.dgz48.tasks.webapi.user.adapter.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import jakarta.persistence.EntityManager;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.transaction.support.TransactionTemplate;
+import xyz.dgz48.tasks.webapi.TestcontainersConfiguration;
+import xyz.dgz48.tasks.webapi.user.usecase.UserRegistrationPort;
+
+/** 会員登録の {@code users} 行 upsert(ADR-0040 §3.3 ①)の統合テスト(Testcontainers MySQL)。 */
+@SpringBootTest
+@Import(TestcontainersConfiguration.class)
+class UserRegistrationPersistenceAdapterIT {
+
+  @Autowired UserRegistrationPort port;
+  @Autowired UserRepository userRepository;
+  @Autowired EntityManager em;
+  @Autowired TransactionTemplate txTemplate;
+
+  private final List<Long> createdIds = new ArrayList<>();
+
+  @AfterEach
+  void tearDown() {
+    if (createdIds.isEmpty()) {
+      return;
+    }
+    txTemplate.execute(
+        ignored -> {
+          for (Long id : createdIds) {
+            em.createNativeQuery("DELETE FROM users WHERE id = ?")
+                .setParameter(1, id)
+                .executeUpdate();
+          }
+          return null;
+        });
+  }
+
+  private UserJpaEntity reload(Long id) {
+    return txTemplate.execute(ignored -> userRepository.findById(id).orElseThrow());
+  }
+
+  @Test
+  void insertsNewPendingRow() {
+    Long id = port.upsertPendingMember("new@example.com", "新規太郎", "シンキタロウ", "開発部");
+    createdIds.add(id);
+
+    UserJpaEntity row = reload(id);
+    assertThat(row.getOidcSub()).isEqualTo("pending:new@example.com");
+    assertThat(row.getEmail()).isEqualTo("new@example.com");
+    assertThat(row.getFullName()).isEqualTo("新規太郎");
+    assertThat(row.getFullNameKana()).isEqualTo("シンキタロウ");
+    assertThat(row.getDepartmentName()).isEqualTo("開発部");
+    assertThat(row.isPendingCorrelation()).isTrue();
+    assertThat(row.isInactive()).isFalse();
+  }
+
+  @Test
+  void updatesProfileOfExistingPendingRow() {
+    // SPI insert 相当: profile 空の pending 行を先に作る
+    Long id =
+        txTemplate.execute(
+            ignored -> {
+              var u =
+                  new UserJpaEntity("pending:exist@example.com", "exist@example.com", "", "", null);
+              em.persist(u);
+              em.flush();
+              return u.getId();
+            });
+    createdIds.add(id);
+
+    Long sameId = port.upsertPendingMember("exist@example.com", "更新太郎", "コウシンタロウ", "営業部");
+
+    assertThat(sameId).isEqualTo(id);
+    UserJpaEntity row = reload(id);
+    assertThat(row.getFullName()).isEqualTo("更新太郎");
+    assertThat(row.getFullNameKana()).isEqualTo("コウシンタロウ");
+    assertThat(row.getDepartmentName()).isEqualTo("営業部");
+    assertThat(row.isPendingCorrelation()).isTrue();
+  }
+
+  @Test
+  void rejectsAlreadyCorrelatedRow() {
+    Long id =
+        txTemplate.execute(
+            ignored -> {
+              var u = new UserJpaEntity("kc-sub-real", "corr@example.com", "既存花子", "キゾンハナコ", null);
+              em.persist(u);
+              em.flush();
+              return u.getId();
+            });
+    createdIds.add(id);
+
+    assertThatThrownBy(() -> port.upsertPendingMember("corr@example.com", "別名", "ベツメイ", null))
+        .isInstanceOf(IllegalStateException.class);
+  }
+}

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/user/adapter/persistence/UserRegistrationPersistenceAdapterIT.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/user/adapter/persistence/UserRegistrationPersistenceAdapterIT.java
@@ -13,6 +13,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.transaction.support.TransactionTemplate;
 import xyz.dgz48.tasks.webapi.TestcontainersConfiguration;
+import xyz.dgz48.tasks.webapi.user.domain.UserAlreadyRegisteredException;
 import xyz.dgz48.tasks.webapi.user.usecase.UserRegistrationPort;
 
 /** 会員登録の {@code users} 行 upsert(ADR-0040 §3.3 ①)の統合テスト(Testcontainers MySQL)。 */
@@ -99,6 +100,6 @@ class UserRegistrationPersistenceAdapterIT {
     createdIds.add(id);
 
     assertThatThrownBy(() -> port.upsertPendingMember("corr@example.com", "別名", "ベツメイ", null))
-        .isInstanceOf(IllegalStateException.class);
+        .isInstanceOf(UserAlreadyRegisteredException.class);
   }
 }

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/user/adapter/web/UserExceptionHandlerTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/user/adapter/web/UserExceptionHandlerTest.java
@@ -1,0 +1,30 @@
+package xyz.dgz48.tasks.webapi.user.adapter.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockHttpServletRequest;
+import xyz.dgz48.tasks.webapi.shared.web.ErrorCode;
+import xyz.dgz48.tasks.webapi.shared.web.ErrorResponse;
+import xyz.dgz48.tasks.webapi.user.domain.UserAlreadyRegisteredException;
+
+class UserExceptionHandlerTest {
+
+  private final UserExceptionHandler handler = new UserExceptionHandler();
+
+  @Test
+  void handleAlreadyRegisteredReturns409WithEConflictAndNoPii() {
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setRequestURI("/api/invitations/tok/accept");
+
+    ErrorResponse response =
+        handler.handleAlreadyRegistered(new UserAlreadyRegisteredException(), request);
+
+    assertThat(response.status()).isEqualTo(HttpStatus.CONFLICT.value());
+    assertThat(response.code()).isEqualTo(ErrorCode.E_CONFLICT);
+    assertThat(response.path()).isEqualTo("/api/invitations/tok/accept");
+    // PII(email)を含まないこと
+    assertThat(response.message()).doesNotContain("@");
+  }
+}

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/user/usecase/CredentialProvisioningExceptionTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/user/usecase/CredentialProvisioningExceptionTest.java
@@ -1,0 +1,23 @@
+package xyz.dgz48.tasks.webapi.user.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import xyz.dgz48.tasks.webapi.shared.exception.DomainException;
+
+class CredentialProvisioningExceptionTest {
+
+  @Test
+  void isDomainException() {
+    assertThat(new CredentialProvisioningException("msg")).isInstanceOf(DomainException.class);
+  }
+
+  @Test
+  void preservesCauseWhenWrapping() {
+    var cause = new RuntimeException("keycloak http 500");
+    var ex = new CredentialProvisioningException("credential 設定に失敗しました", cause);
+
+    assertThat(ex.getMessage()).isEqualTo("credential 設定に失敗しました");
+    assertThat(ex.getCause()).isSameAs(cause);
+  }
+}

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/user/usecase/RegisterMemberUseCaseTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/user/usecase/RegisterMemberUseCaseTest.java
@@ -1,0 +1,53 @@
+package xyz.dgz48.tasks.webapi.user.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class RegisterMemberUseCaseTest {
+
+  @Mock UserRegistrationPort userRegistrationPort;
+  @Mock CredentialProvisioningPort credentialProvisioningPort;
+
+  @InjectMocks RegisterMemberUseCase useCase;
+
+  @Test
+  void upsertsUserThenProvisionsCredentialInOrder() {
+    var cmd = new RegisterMemberCommand("a@example.com", "氏名", "シメイ", null, "pw");
+    when(userRegistrationPort.upsertPendingMember("a@example.com", "氏名", "シメイ", null))
+        .thenReturn(42L);
+
+    Long id = useCase.register(cmd);
+
+    assertThat(id).isEqualTo(42L);
+    InOrder ordered = inOrder(userRegistrationPort, credentialProvisioningPort);
+    ordered.verify(userRegistrationPort).upsertPendingMember("a@example.com", "氏名", "シメイ", null);
+    ordered.verify(credentialProvisioningPort).provisionCredential("a@example.com", "pw");
+  }
+
+  @Test
+  void propagatesCredentialFailureAfterUserRowIsWritten() {
+    var cmd = new RegisterMemberCommand("a@example.com", "氏名", "シメイ", "営業部", "pw");
+    when(userRegistrationPort.upsertPendingMember(any(), any(), any(), any())).thenReturn(1L);
+    doThrow(new CredentialProvisioningException("keycloak down"))
+        .when(credentialProvisioningPort)
+        .provisionCredential(any(), any());
+
+    assertThatThrownBy(() -> useCase.register(cmd))
+        .isInstanceOf(CredentialProvisioningException.class);
+    // project 先 → Keycloak 後: ① の users 行 upsert は実行済み(行は残る=未完了状態)
+    verify(userRegistrationPort).upsertPendingMember("a@example.com", "氏名", "シメイ", "営業部");
+  }
+}


### PR DESCRIPTION
ADR-0040 §3.3 の共有プリミティブ **「会員登録」**。招待受諾(Flow A)/ セルフサインアップ(Flow B)が共有します。

本 PR は **primitive + ports + 永続化 + dev フォールバック**まで。本番の Keycloak Admin REST API 実装は **後続 PR(PR2c)** で contract テスト + native hints 付きで追加します(下記「PR 分割」参照)。

## 変更
- **`RegisterMemberUseCase`**(`user/usecase`): ① `users` 行 upsert(**project 先**)→ ② credential 設定(**Keycloak 後**)。② 失敗時は `CredentialProvisioningException` を伝播し、① の行は残す(未完了=email で idempotent に再登録・credential 再試行、ADR-0040 §3.5)。remote 呼び出しを跨ぐためクラス `@Transactional` は持たない
- **`UserRegistrationPort` + `UserRegistrationPersistenceAdapter`**: email で `users` 行を upsert(無→`pending:<email>` insert / pending→profile 更新 / correlation 済み→`IllegalStateException`)。DB tx 境界はアダプタ側(credential 設定前に commit)
- **`UserJpaEntity.updateProfile`**: pending 行への profile 書込
- **`CredentialProvisioningPort` + `CredentialProvisioningException`**
- **`LoggingCredentialProvisioningAdapter`**(dev/test フォールバック、`@ConditionalOnMissingBean`、**パスワード非ログ**)+ `CredentialProvisioningConfig`。SES の log フォールバックと同方式
- `user/adapter/external`・`user/infra` パッケージ新設(`@NullMarked`)

## テスト
- `RegisterMemberUseCaseTest`: ①→② の順序、credential 失敗時の伝播(① 実行済み)
- `UserRegistrationPersistenceAdapterIT`(Testcontainers): 新規 insert / 既存 pending の profile 更新 / correlation 済み拒否
- `LoggingCredentialProvisioningAdapterTest`

`./gradlew :webapi:check` green(spotless / NullAway / Modulith / JaCoCo 0.80 / 全 IT)。

## PR 分割(ADR §6 PR2 の段階化)
ADR-0040 §6 の PR2「RegisterMember + credential 転送」を、リスクに応じて 2 段に分けます:
- **本 PR(PR2b)**: primitive + dev フォールバック。Keycloak 無しで完全に IT 可能、main で常に green
- **次 PR(PR2c)**: `KeycloakAdminCredentialAdapter`(native 安全な Spring `RestClient`)+ `KeycloakAdminProperties`/config + realm service-account client + native hints。Keycloak Admin REST は webapi 内で full-IT できないため **contract テスト(MockRestServiceServer)+ dev native 実機**で検証

監査機能が property-provider → SSM-provider と段階化したのと同じ方針です。`RegisterMemberUseCase` の呼び出し元(Flow A 受諾=PR3 / Flow B サインアップ=PR4)は後続で結線します。

Refs #817