### PR TITLE
feat(user): Keycloak Admin REST credential 実装(RestClient)+ realm service-account (Refs #817)

### DIFF
--- a/keycloak/realm-export/tasks-realm.json
+++ b/keycloak/realm-export/tasks-realm.json
@@ -80,9 +80,35 @@
         "pkce.code.challenge.method": "S256"
       },
       "fullScopeAllowed": true
+    },
+    {
+      "clientId": "tasks-webapi-admin",
+      "name": "Tasks WebAPI Admin (service account)",
+      "description": "会員登録の credential プロビジョニング用 service-account クライアント(ADR-0040 §3.1)。realm-management の manage-users 限定。",
+      "enabled": true,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "dev-admin-secret",
+      "publicClient": false,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": true,
+      "authorizationServicesEnabled": false,
+      "protocol": "openid-connect",
+      "fullScopeAllowed": false
     }
   ],
   "users": [
+    {
+      "username": "service-account-tasks-webapi-admin",
+      "enabled": true,
+      "serviceAccountClientId": "tasks-webapi-admin",
+      "clientRoles": {
+        "realm-management": ["manage-users", "view-users"]
+      }
+    },
     {
       "id": "69649e2f-63a3-4b75-ae2e-2916ee22e1b5",
       "username": "admin@example.com",

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/adapter/external/KeycloakAdminCredentialAdapter.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/adapter/external/KeycloakAdminCredentialAdapter.java
@@ -1,0 +1,146 @@
+package xyz.dgz48.tasks.webapi.user.adapter.external;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.jspecify.annotations.Nullable;
+import org.springframework.aot.hint.MemberCategory;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.RuntimeHintsRegistrar;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+import xyz.dgz48.tasks.webapi.user.infra.KeycloakAdminProperties;
+import xyz.dgz48.tasks.webapi.user.usecase.CredentialProvisioningException;
+import xyz.dgz48.tasks.webapi.user.usecase.CredentialProvisioningPort;
+
+/**
+ * Keycloak Admin REST API による credential プロビジョニング実装(ADR-0040 §3.1)。{@code
+ * keycloak.admin.enabled=true} で有効。
+ *
+ * <p>service-account クライアントの client_credentials grant で admin トークンを取得し、email でユーザーを引いて ①
+ * パスワード設定(reset-password) → ② {@code emailVerified=true} を設定する(ADR-0040 §3.4)。credential 自体は
+ * Keycloak が SoT(ADR-0006 §3.3)。Spring {@link RestClient} を用い、native image(ADR-0008)で重い
+ * JAX-RS/RESTEasy 依存(keycloak-admin-client)を避ける。
+ */
+public class KeycloakAdminCredentialAdapter implements CredentialProvisioningPort {
+
+  private final RestClient restClient;
+  private final KeycloakAdminProperties props;
+
+  public KeycloakAdminCredentialAdapter(RestClient restClient, KeycloakAdminProperties props) {
+    this.restClient = restClient;
+    this.props = props;
+  }
+
+  @Override
+  public void provisionCredential(String email, String rawPassword) {
+    try {
+      String token = fetchAdminToken();
+      String userId = findUserIdByEmail(email, token);
+      resetPassword(userId, rawPassword, token);
+      markEmailVerified(userId, token);
+    } catch (RestClientException e) {
+      // PII / パスワードは含めない(規約 §7)
+      throw new CredentialProvisioningException("Keycloak Admin API 呼び出しに失敗しました", e);
+    }
+  }
+
+  private String fetchAdminToken() {
+    MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
+    form.add("grant_type", "client_credentials");
+    form.add("client_id", props.clientId());
+    form.add("client_secret", props.clientSecret());
+    TokenResponse resp =
+        restClient
+            .post()
+            .uri("/realms/{realm}/protocol/openid-connect/token", props.realm())
+            .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+            .body(form)
+            .retrieve()
+            .body(TokenResponse.class);
+    if (resp == null || resp.accessToken() == null || resp.accessToken().isBlank()) {
+      throw new CredentialProvisioningException("Keycloak admin トークンの取得に失敗しました");
+    }
+    return resp.accessToken();
+  }
+
+  private String findUserIdByEmail(String email, String token) {
+    KeycloakUserRef[] users =
+        restClient
+            .get()
+            .uri(
+                builder ->
+                    builder
+                        .path("/admin/realms/{realm}/users")
+                        .queryParam("email", email)
+                        .queryParam("exact", true)
+                        .build(props.realm()))
+            .header(HttpHeaders.AUTHORIZATION, bearer(token))
+            .retrieve()
+            .body(KeycloakUserRef[].class);
+    if (users == null || users.length == 0 || users[0].id() == null) {
+      throw new CredentialProvisioningException("Keycloak に対象ユーザーが見つかりません");
+    }
+    return users[0].id();
+  }
+
+  private void resetPassword(String userId, String rawPassword, String token) {
+    restClient
+        .put()
+        .uri("/admin/realms/{realm}/users/{id}/reset-password", props.realm(), userId)
+        .header(HttpHeaders.AUTHORIZATION, bearer(token))
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(new PasswordCredential("password", rawPassword, false))
+        .retrieve()
+        .toBodilessEntity();
+  }
+
+  private void markEmailVerified(String userId, String token) {
+    restClient
+        .put()
+        .uri("/admin/realms/{realm}/users/{id}", props.realm(), userId)
+        .header(HttpHeaders.AUTHORIZATION, bearer(token))
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(new EmailVerifiedUpdate(true))
+        .retrieve()
+        .toBodilessEntity();
+  }
+
+  private static String bearer(String token) {
+    return "Bearer " + token;
+  }
+
+  /** client_credentials トークン応答(必要なフィールドのみ)。 */
+  public record TokenResponse(@JsonProperty("access_token") @Nullable String accessToken) {}
+
+  /** Admin API のユーザー検索結果(id のみ参照)。 */
+  public record KeycloakUserRef(@Nullable String id) {}
+
+  /** reset-password の credential 表現。 */
+  public record PasswordCredential(String type, String value, boolean temporary) {}
+
+  /** ユーザー更新(emailVerified のみ)。 */
+  public record EmailVerifiedUpdate(boolean emailVerified) {}
+
+  /**
+   * Keycloak Admin API の JSON DTO を native image で reflection 可能にする hints(ADR-0008)。RestClient +
+   * Jackson の record シリアライズ/デシリアライズは Spring Boot AOT に自動登録されないため明示する({@code @JsonProperty} の
+   * access_token マッピングを含む)。JVM CI では非検出のため登録自体を {@code KeycloakAdminRuntimeHintsTest} で固定。
+   */
+  public static class Hints implements RuntimeHintsRegistrar {
+    @Override
+    public void registerHints(RuntimeHints hints, @Nullable ClassLoader classLoader) {
+      for (Class<?> dto :
+          new Class<?>[] {
+            TokenResponse.class,
+            KeycloakUserRef.class,
+            PasswordCredential.class,
+            EmailVerifiedUpdate.class
+          }) {
+        hints.reflection().registerType(dto, MemberCategory.values());
+      }
+    }
+  }
+}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/infra/CredentialProvisioningConfig.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/infra/CredentialProvisioningConfig.java
@@ -1,20 +1,35 @@
 package xyz.dgz48.tasks.webapi.user.infra;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.ImportRuntimeHints;
+import org.springframework.web.client.RestClient;
+import xyz.dgz48.tasks.webapi.user.adapter.external.KeycloakAdminCredentialAdapter;
 import xyz.dgz48.tasks.webapi.user.adapter.external.LoggingCredentialProvisioningAdapter;
 import xyz.dgz48.tasks.webapi.user.usecase.CredentialProvisioningPort;
 
 /**
  * credential プロビジョニング実装の選択(ADR-0040 §3.1)。
  *
- * <p>本番の Keycloak Admin REST API 実装({@code keycloak.admin.enabled=true} で有効、後続
- * PR)が存在しない場合は、dev/test 用の {@link LoggingCredentialProvisioningAdapter}
- * にフォールバックする({@code @ConditionalOnMissingBean})。SES の log フォールバックと同方式。
+ * <p>{@code keycloak.admin.enabled=true}(本番)では Keycloak Admin REST API 実装({@link
+ * KeycloakAdminCredentialAdapter})を用い、未設定(dev/test)では {@code @ConditionalOnMissingBean} で {@link
+ * LoggingCredentialProvisioningAdapter} にフォールバックする。SES の log フォールバックと同方式。
  */
 @Configuration
+@EnableConfigurationProperties(KeycloakAdminProperties.class)
+@ImportRuntimeHints(KeycloakAdminCredentialAdapter.Hints.class)
 public class CredentialProvisioningConfig {
+
+  @Bean
+  @ConditionalOnProperty(name = "keycloak.admin.enabled", havingValue = "true")
+  public CredentialProvisioningPort keycloakAdminCredentialProvisioningAdapter(
+      KeycloakAdminProperties props) {
+    RestClient restClient = RestClient.builder().baseUrl(props.serverUrl()).build();
+    return new KeycloakAdminCredentialAdapter(restClient, props);
+  }
 
   @Bean
   @ConditionalOnMissingBean(CredentialProvisioningPort.class)

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/infra/KeycloakAdminProperties.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/infra/KeycloakAdminProperties.java
@@ -1,0 +1,28 @@
+package xyz.dgz48.tasks.webapi.user.infra;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.bind.DefaultValue;
+
+/**
+ * Keycloak Admin REST API による credential プロビジョニングの設定(application.yml の {@code
+ * keycloak.admin.*}、ADR-0040 §3.1)。
+ *
+ * <p>{@code enabled=false}(既定)では Keycloak を呼ばず {@link
+ * xyz.dgz48.tasks.webapi.user.adapter.external.LoggingCredentialProvisioningAdapter}
+ * にフォールバックする(dev/test)。 {@code enabled=true}(本番)では service-account クライアント({@code clientId} / {@code
+ * clientSecret})で Admin API を呼ぶ(realm-management の {@code manage-users} 限定権限)。
+ *
+ * @param enabled Keycloak Admin REST API 実装を有効化するか
+ * @param serverUrl Keycloak のベース URL(例 {@code https://auth-dev.dgz48.xyz})。{@code /realms/...} と
+ *     {@code /admin/realms/...} の共通プレフィックス
+ * @param realm 対象 realm(例 {@code tasks})
+ * @param clientId service-account confidential クライアントの clientId
+ * @param clientSecret service-account クライアントシークレット(本番は SSM 由来。ログ出力禁止)
+ */
+@ConfigurationProperties("keycloak.admin")
+public record KeycloakAdminProperties(
+    @DefaultValue("false") boolean enabled,
+    @DefaultValue("http://localhost:8080") String serverUrl,
+    @DefaultValue("tasks") String realm,
+    @DefaultValue("tasks-webapi-admin") String clientId,
+    @DefaultValue("") String clientSecret) {}

--- a/webapi/src/main/resources/application.yml
+++ b/webapi/src/main/resources/application.yml
@@ -103,3 +103,15 @@ notification:
 tenant:
   invite:
     accept-url-base: ${TENANT_INVITE_ACCEPT_URL_BASE:http://localhost:8080/invitations/accept}
+
+# 会員登録の credential プロビジョニング(ADR-0040 §3.1)。
+# enabled=false(既定)は dev/test のログフォールバック(Keycloak を呼ばない)。
+# 本番は enabled=true + service-account クライアント(realm-management の manage-users 限定)。
+# client-secret は PR1 で用意した SSM SecureString(/tasks/<env>/app/keycloak-admin-client-secret)由来。
+keycloak:
+  admin:
+    enabled: ${KEYCLOAK_ADMIN_ENABLED:false}
+    server-url: ${KEYCLOAK_ADMIN_SERVER_URL:http://localhost:8080}
+    realm: ${KEYCLOAK_ADMIN_REALM:tasks}
+    client-id: ${KEYCLOAK_ADMIN_CLIENT_ID:tasks-webapi-admin}
+    client-secret: ${KEYCLOAK_ADMIN_CLIENT_SECRET:}

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/user/adapter/external/KeycloakAdminCredentialAdapterTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/user/adapter/external/KeycloakAdminCredentialAdapterTest.java
@@ -1,0 +1,91 @@
+package xyz.dgz48.tasks.webapi.user.adapter.external;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.queryParam;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+import xyz.dgz48.tasks.webapi.user.infra.KeycloakAdminProperties;
+import xyz.dgz48.tasks.webapi.user.usecase.CredentialProvisioningException;
+
+/**
+ * {@link KeycloakAdminCredentialAdapter} の contract テスト(MockRestServiceServer)。Keycloak Admin REST
+ * API への HTTP 呼び出し列(トークン取得 → ユーザー検索 → reset-password → emailVerified 更新)を検証する。ADR-0040 §6 に従い、実
+ * Keycloak を用いる full-IT の代替として contract で固定し、実機疎通は dev native で確認する。
+ */
+class KeycloakAdminCredentialAdapterTest {
+
+  private static final String BASE = "http://kc.local";
+
+  private MockRestServiceServer server;
+  private KeycloakAdminCredentialAdapter adapter;
+
+  @BeforeEach
+  void setUp() {
+    RestClient.Builder builder = RestClient.builder().baseUrl(BASE);
+    server = MockRestServiceServer.bindTo(builder).build();
+    var props = new KeycloakAdminProperties(true, BASE, "tasks", "tasks-webapi-admin", "secret");
+    adapter = new KeycloakAdminCredentialAdapter(builder.build(), props);
+  }
+
+  @Test
+  void provisionsPasswordThenMarksEmailVerifiedInOrder() {
+    server
+        .expect(requestTo(BASE + "/realms/tasks/protocol/openid-connect/token"))
+        .andExpect(method(HttpMethod.POST))
+        .andRespond(withSuccess("{\"access_token\":\"tok-123\"}", MediaType.APPLICATION_JSON));
+    server
+        .expect(requestTo(Matchers.startsWith(BASE + "/admin/realms/tasks/users?")))
+        .andExpect(method(HttpMethod.GET))
+        .andExpect(queryParam("email", "a@example.com"))
+        .andExpect(queryParam("exact", "true"))
+        .andExpect(header("Authorization", "Bearer tok-123"))
+        .andRespond(withSuccess("[{\"id\":\"42\"}]", MediaType.APPLICATION_JSON));
+    server
+        .expect(requestTo(BASE + "/admin/realms/tasks/users/42/reset-password"))
+        .andExpect(method(HttpMethod.PUT))
+        .andExpect(header("Authorization", "Bearer tok-123"))
+        .andRespond(withSuccess());
+    server
+        .expect(requestTo(BASE + "/admin/realms/tasks/users/42"))
+        .andExpect(method(HttpMethod.PUT))
+        .andExpect(header("Authorization", "Bearer tok-123"))
+        .andRespond(withSuccess());
+
+    adapter.provisionCredential("a@example.com", "raw-password");
+
+    server.verify();
+  }
+
+  @Test
+  void throwsWhenUserNotFound() {
+    server
+        .expect(requestTo(BASE + "/realms/tasks/protocol/openid-connect/token"))
+        .andRespond(withSuccess("{\"access_token\":\"tok-123\"}", MediaType.APPLICATION_JSON));
+    server
+        .expect(requestTo(Matchers.startsWith(BASE + "/admin/realms/tasks/users?")))
+        .andRespond(withSuccess("[]", MediaType.APPLICATION_JSON));
+
+    assertThatThrownBy(() -> adapter.provisionCredential("missing@example.com", "pw"))
+        .isInstanceOf(CredentialProvisioningException.class);
+  }
+
+  @Test
+  void throwsWhenTokenEndpointReturnsNoAccessToken() {
+    server
+        .expect(requestTo(BASE + "/realms/tasks/protocol/openid-connect/token"))
+        .andRespond(withSuccess("{}", MediaType.APPLICATION_JSON));
+
+    assertThatThrownBy(() -> adapter.provisionCredential("a@example.com", "pw"))
+        .isInstanceOf(CredentialProvisioningException.class);
+  }
+}

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/user/adapter/external/KeycloakAdminRuntimeHintsTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/user/adapter/external/KeycloakAdminRuntimeHintsTest.java
@@ -1,0 +1,31 @@
+package xyz.dgz48.tasks.webapi.user.adapter.external;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.aot.hint.predicate.RuntimeHintsPredicates.reflection;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.aot.hint.RuntimeHints;
+
+/**
+ * Keycloak Admin DTO の native reflection hints が登録されていることを固定する(ADR-0008)。RestClient + Jackson の
+ * record シリアライズは JVM CI では reflection 不要だが native image では必要。[[native-hibernate-validator-hints]]
+ * と同種の native-only 退行を防ぐ。
+ */
+class KeycloakAdminRuntimeHintsTest {
+
+  @Test
+  void registersReflectionHintsForKeycloakAdminDtos() {
+    RuntimeHints hints = new RuntimeHints();
+
+    new KeycloakAdminCredentialAdapter.Hints().registerHints(hints, getClass().getClassLoader());
+
+    assertThat(reflection().onType(KeycloakAdminCredentialAdapter.TokenResponse.class))
+        .accepts(hints);
+    assertThat(reflection().onType(KeycloakAdminCredentialAdapter.KeycloakUserRef.class))
+        .accepts(hints);
+    assertThat(reflection().onType(KeycloakAdminCredentialAdapter.PasswordCredential.class))
+        .accepts(hints);
+    assertThat(reflection().onType(KeycloakAdminCredentialAdapter.EmailVerifiedUpdate.class))
+        .accepts(hints);
+  }
+}

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/user/infra/CredentialProvisioningConfigTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/user/infra/CredentialProvisioningConfigTest.java
@@ -1,0 +1,28 @@
+package xyz.dgz48.tasks.webapi.user.infra;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import xyz.dgz48.tasks.webapi.user.adapter.external.KeycloakAdminCredentialAdapter;
+import xyz.dgz48.tasks.webapi.user.adapter.external.LoggingCredentialProvisioningAdapter;
+import xyz.dgz48.tasks.webapi.user.usecase.CredentialProvisioningPort;
+
+class CredentialProvisioningConfigTest {
+
+  private final CredentialProvisioningConfig config = new CredentialProvisioningConfig();
+
+  @Test
+  void buildsKeycloakAdapterWhenEnabled() {
+    var props = new KeycloakAdminProperties(true, "http://kc.local", "tasks", "cid", "secret");
+
+    CredentialProvisioningPort port = config.keycloakAdminCredentialProvisioningAdapter(props);
+
+    assertThat(port).isInstanceOf(KeycloakAdminCredentialAdapter.class);
+  }
+
+  @Test
+  void fallsBackToLoggingAdapter() {
+    assertThat(config.loggingCredentialProvisioningAdapter())
+        .isInstanceOf(LoggingCredentialProvisioningAdapter.class);
+  }
+}

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/user/infra/KeycloakAdminPropertiesTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/user/infra/KeycloakAdminPropertiesTest.java
@@ -1,0 +1,21 @@
+package xyz.dgz48.tasks.webapi.user.infra;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class KeycloakAdminPropertiesTest {
+
+  @Test
+  void exposesAllConfiguredValues() {
+    var props =
+        new KeycloakAdminProperties(
+            true, "https://auth.example", "tasks", "tasks-webapi-admin", "s3cr3t");
+
+    assertThat(props.enabled()).isTrue();
+    assertThat(props.serverUrl()).isEqualTo("https://auth.example");
+    assertThat(props.realm()).isEqualTo("tasks");
+    assertThat(props.clientId()).isEqualTo("tasks-webapi-admin");
+    assertThat(props.clientSecret()).isEqualTo("s3cr3t");
+  }
+}


### PR DESCRIPTION
ADR-0040 §3.1 の **本番 credential 転送**。PR2b の `CredentialProvisioningPort` に Keycloak Admin REST API 実装を追加し、`keycloak.admin.enabled=true` で有効化します(未設定は dev/test の log フォールバック)。これで ADR §6 の PR2(RegisterMember + credential 転送)が完結します。

## 変更
- **`KeycloakAdminCredentialAdapter`**(`user/adapter/external`): service-account の `client_credentials` grant で admin トークン取得 → email でユーザー検索 → `reset-password` → `emailVerified=true`。`RestClientException` は `CredentialProvisioningException`(cause 保持)にラップ。**PII / パスワードは非ログ**
  - **native 安全な Spring `RestClient`** を使用し、GraalVM native(ADR-0008)で重い JAX-RS/RESTEasy 依存(`keycloak-admin-client`)を回避
- **`KeycloakAdminProperties`**(`@ConfigurationProperties("keycloak.admin")`)+ `application.yml` ブロック
- **`CredentialProvisioningConfig`**: `enabled=true` → Keycloak 実装、未設定 → log フォールバック(`@ConditionalOnProperty` / `@ConditionalOnMissingBean`、SES と同方式)
- **native hints**: Admin API DTO record を reflection 登録(RestClient + Jackson は AOT 自動登録されない)
- **realm-export**: `tasks-webapi-admin` service-account client(`manage-users` / `view-users` 限定)+ service-account user のロール割当(**PR1 から移設**)

## テスト
- `KeycloakAdminCredentialAdapterTest`(MockRestServiceServer): トークン取得 → 検索 → reset-password → emailVerified の **4 呼び出し列**を順序・ヘッダ・クエリで contract 固定 + 失敗系(ユーザー不在 / トークン不正)
- `KeycloakAdminRuntimeHintsTest` / `CredentialProvisioningConfigTest` / `KeycloakAdminPropertiesTest`

`./gradlew :webapi:check` green。realm JSON 構文検証済み。

## 検証メモ(重要)
- 実 Keycloak を用いる full-IT は webapi 内で不可のため **contract テストで固定**(ADR §6)。
- **realm の service-account ロール割当の実効性 + Admin API 疎通は dev native 実機で要確認**(#810 と同様、JVM CI では非検出 = silent-fail リスク)。これが PR1 から realm client を本 PR へ移した理由(consuming コードと co-locate して一緒に検証)。
- **prod の ECS への client-secret 注入**(PR1 の SSM `/<env>/app/keycloak-admin-client-secret` → `KEYCLOAK_ADMIN_CLIENT_SECRET`)は別 infra タスク。dev 検証は realm の `dev-admin-secret` を使用。

## 残タスク(#817)
PR2 完結後は **PR3(Flow A 招待受諾)** / **PR4(Flow B サインアップ double opt-in)** で `RegisterMemberUseCase` を結線。

Refs #817