### PR TITLE
feat(keycloak): ログイン画面に新規登録導線 (tasks-login テーマ) (Closes #832, Closes #817)

### DIFF
--- a/keycloak/realm-export/tasks-realm.json
+++ b/keycloak/realm-export/tasks-realm.json
@@ -193,6 +193,7 @@
   ],
   "defaultLocale": "en",
   "adminTheme": "tasks-admin",
+  "loginTheme": "tasks-login",
   "components": {
     "org.keycloak.userprofile.UserProfileProvider": [
       {

--- a/keycloak/src/test/java/xyz/dgz48/tasks/keycloak/AbstractSpiContainerTest.java
+++ b/keycloak/src/test/java/xyz/dgz48/tasks/keycloak/AbstractSpiContainerTest.java
@@ -34,8 +34,7 @@ abstract class AbstractSpiContainerTest extends AbstractMySqlContainerTest {
             // tasks-test-realm の loginTheme=tasks-login(#832)を解決できるよう、テーマを焼き込み済イメージと
             // 同じ /opt/keycloak/themes/ へ投入する(本イメージは vanilla なため明示コピーが要る)。
             .withCopyFileToContainer(
-                MountableFile.forHostPath("themes/tasks-login"),
-                "/opt/keycloak/themes/tasks-login")
+                MountableFile.forHostPath("themes/tasks-login"), "/opt/keycloak/themes/tasks-login")
             .withFeaturesEnabled("update-email");
     keycloak.start();
     return keycloak;

--- a/keycloak/src/test/java/xyz/dgz48/tasks/keycloak/AbstractSpiContainerTest.java
+++ b/keycloak/src/test/java/xyz/dgz48/tasks/keycloak/AbstractSpiContainerTest.java
@@ -5,6 +5,7 @@ import java.io.File;
 import java.util.List;
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.admin.client.KeycloakBuilder;
+import org.testcontainers.utility.MountableFile;
 
 /**
  * {@link AbstractMySqlContainerTest} の MySQL に加え、SPI を配備した Keycloak 26.6.3 を共有 singleton
@@ -30,6 +31,11 @@ abstract class AbstractSpiContainerTest extends AbstractMySqlContainerTest {
             .withNetwork(NETWORK)
             .withProviderLibsFrom(List.of(spiJar(), mysqlDriverJar()))
             .withRealmImportFile("/tasks-test-realm.json")
+            // tasks-test-realm の loginTheme=tasks-login(#832)を解決できるよう、テーマを焼き込み済イメージと
+            // 同じ /opt/keycloak/themes/ へ投入する(本イメージは vanilla なため明示コピーが要る)。
+            .withCopyFileToContainer(
+                MountableFile.forHostPath("themes/tasks-login"),
+                "/opt/keycloak/themes/tasks-login")
             .withFeaturesEnabled("update-email");
     keycloak.start();
     return keycloak;

--- a/keycloak/src/test/java/xyz/dgz48/tasks/keycloak/LoginThemeIT.java
+++ b/keycloak/src/test/java/xyz/dgz48/tasks/keycloak/LoginThemeIT.java
@@ -1,0 +1,47 @@
+package xyz.dgz48.tasks.keycloak;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+
+/**
+ * ログイン画面テーマ {@code tasks-login}(ADR-0040 / #832)が realm の {@code loginTheme} 経由で適用され、セルフサインアップ導線用の
+ * スクリプト({@code signup-link.js})がログインページに注入されることを実 Keycloak(Testcontainers)で検証する。
+ *
+ * <p>テーマ未適用 / theme.properties の {@code scripts} 設定ミス / {@code loginTheme} 名の不一致は、いずれもログインページのレンダリングが
+ * 静かに壊れる(JVM 単体テストでは非検出)ため、ここで CI 固定する。スクリプトの DOM 注入挙動はブラウザ実行を要するため本テストの対象外で、テーマ配線(=スクリプト
+ * タグが出力されること)のみを裏取りする。
+ */
+class LoginThemeIT extends AbstractSpiContainerTest {
+
+  @Test
+  void loginPageIncludesSignupLinkScript() throws Exception {
+    String redirectUri = URLEncoder.encode("http://localhost/cb", StandardCharsets.UTF_8);
+    String authUrl =
+        KEYCLOAK.getAuthServerUrl()
+            + "/realms/"
+            + REALM
+            + "/protocol/openid-connect/auth"
+            + "?client_id="
+            + CLI_CLIENT
+            + "&redirect_uri="
+            + redirectUri
+            + "&response_type=code&scope=openid&state=test";
+
+    HttpClient client = HttpClient.newHttpClient();
+    HttpResponse<String> response =
+        client.send(
+            HttpRequest.newBuilder(URI.create(authUrl)).GET().build(),
+            HttpResponse.BodyHandlers.ofString());
+
+    assertThat(response.statusCode()).isEqualTo(200);
+    // theme.properties の scripts=js/signup-link.js が template に出力される = loginTheme が適用された証跡。
+    assertThat(response.body()).contains("signup-link.js");
+  }
+}

--- a/keycloak/src/test/java/xyz/dgz48/tasks/keycloak/LoginThemeIT.java
+++ b/keycloak/src/test/java/xyz/dgz48/tasks/keycloak/LoginThemeIT.java
@@ -14,9 +14,9 @@ import org.junit.jupiter.api.Test;
  * ログイン画面テーマ {@code tasks-login}(ADR-0040 / #832)が realm の {@code loginTheme} 経由で適用され、セルフサインアップ導線用の
  * スクリプト({@code signup-link.js})がログインページに注入されることを実 Keycloak(Testcontainers)で検証する。
  *
- * <p>テーマ未適用 / theme.properties の {@code scripts} 設定ミス / {@code loginTheme} 名の不一致は、いずれもログインページのレンダリングが
- * 静かに壊れる(JVM 単体テストでは非検出)ため、ここで CI 固定する。スクリプトの DOM 注入挙動はブラウザ実行を要するため本テストの対象外で、テーマ配線(=スクリプト
- * タグが出力されること)のみを裏取りする。
+ * <p>テーマ未適用 / theme.properties の {@code scripts} 設定ミス / {@code loginTheme}
+ * 名の不一致は、いずれもログインページのレンダリングが 静かに壊れる(JVM 単体テストでは非検出)ため、ここで CI 固定する。スクリプトの DOM
+ * 注入挙動はブラウザ実行を要するため本テストの対象外で、テーマ配線(=スクリプト タグが出力されること)のみを裏取りする。
  */
 class LoginThemeIT extends AbstractSpiContainerTest {
 

--- a/keycloak/src/test/resources/tasks-test-realm.json
+++ b/keycloak/src/test/resources/tasks-test-realm.json
@@ -10,6 +10,7 @@
   "internationalizationEnabled": true,
   "supportedLocales": ["en", "ja"],
   "defaultLocale": "en",
+  "loginTheme": "tasks-login",
   "smtpServer": {
     "host": "mailpit",
     "port": "1025",

--- a/keycloak/themes/tasks-login/login/resources/js/signup-link.js
+++ b/keycloak/themes/tasks-login/login/resources/js/signup-link.js
@@ -1,0 +1,45 @@
+// tasks-login テーマ(ADR-0040 / #832): ログイン画面に「新規登録」リンクを注入する。
+// login.ftl を上書きせず scripts で読み込む軽量実装(Keycloak バージョン追従の脆さを避ける)。
+//
+// セルフサインアップ画面(signup.html)は SPA 側ドメイン(tasks[-env].dgz48.xyz)にあり、ログイン画面は
+// 認証ドメイン(auth[-env].dgz48.xyz)にあるため、ホスト名から SPA の絶対 URL を導出する。既知パターンに
+// 一致しないホスト(ローカル等)ではリンクを注入しない(誤誘導を避ける)。
+(() => {
+  const host = window.location.hostname;
+  const match = host.match(/^auth(?:-(\w+))?\.dgz48\.xyz$/);
+  if (!match) {
+    return;
+  }
+  const env = match[1] ? `-${match[1]}` : "";
+  const signupUrl = `https://tasks${env}.dgz48.xyz/signup.html`;
+
+  const render = () => {
+    if (document.getElementById("tasks-signup-link")) {
+      return;
+    }
+    // ログインフォーム(#kc-form)直後に控えめに配置。無ければ body 末尾。
+    const anchor =
+      document.getElementById("kc-form") || document.querySelector(".login-pf-page") || document.body;
+    const wrapper = document.createElement("div");
+    wrapper.id = "tasks-signup-link";
+    wrapper.style.marginTop = "1rem";
+    wrapper.style.textAlign = "center";
+
+    const intro = document.createElement("span");
+    intro.textContent = "アカウントをお持ちでない方は ";
+
+    const link = document.createElement("a");
+    link.href = signupUrl;
+    link.textContent = "新規登録";
+
+    wrapper.appendChild(intro);
+    wrapper.appendChild(link);
+    anchor.appendChild(wrapper);
+  };
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", render);
+  } else {
+    render();
+  }
+})();

--- a/keycloak/themes/tasks-login/login/theme.properties
+++ b/keycloak/themes/tasks-login/login/theme.properties
@@ -1,0 +1,5 @@
+# tasks-login: ログイン画面テーマ(ADR-0040 / #832)。
+# 標準 keycloak login テーマを継承し、login.ftl は上書きせず(バージョン追従の脆さ回避)、
+# scripts で軽量 JS を注入してセルフサインアップ(/signup.html)への「新規登録」リンクを表示する。
+parent=keycloak
+scripts=js/signup-link.js


### PR DESCRIPTION
## 概要

ADR-0040 Flow B の最後の導線。Keycloak ログイン画面からセルフサインアップ(`/signup.html`)への「新規登録」リンクを追加する。`index.html` は未認証で即 Keycloak ログインへ遷移するためアプリ側に未認証画面が無く、リンクは **Keycloak の login テーマ**に置く必要がある。

Closes #832 / Closes #817(オンボーディングの全成果物が揃う)

## 実装

- **`themes/tasks-login`**: 標準 keycloak login テーマを `parent` 継承。`login.ftl` は**上書きしない**(Keycloak バージョン追従の脆さを回避)。`theme.properties` の `scripts` で軽量 JS(`signup-link.js`)を注入。
- **`signup-link.js`**: `auth[-env].dgz48.xyz` から `tasks[-env].dgz48.xyz/signup.html` を導出してリンクを表示。既知パターンに一致しないホスト(ローカル等)では注入しない(誤誘導回避)。
- `realm-export` / テスト realm に `loginTheme=tasks-login`。Dockerfile が `themes/` を焼き込むためイメージに同梱される。

## 検証

- **`LoginThemeIT`**(Testcontainers Keycloak): `loginTheme` 経由でテーマが適用され、ログインページに `signup-link.js` が出力されることを実 Keycloak で固定。テーマ未適用 / `scripts` 設定ミス / `loginTheme` 名不一致の silent-fail を CI 検出(#830 の fullScopeAllowed 同様の native/実 Keycloak 限定退行を JVM 非依存で防ぐ)。
- `:keycloak:test` green(全 SPI IT + 新 IT)。

## なぜ FTL 上書きでなく JS 注入か

`login.ftl` 上書きは Keycloak 26.6.x の base テンプレ写経が必要でバージョン追従が脆い。`theme.properties` の `scripts=` は安定したテーマ拡張機構で、リンク 1 本の追加には十分。

## dev 反映(別途)

dev は realm `IGNORE_EXISTING` のため、反映には Keycloak イメージ再デプロイ(`themes/` 同梱)+ Admin API で既存 `tasks` realm の `loginTheme` 設定が必要(client 反映と同型)。本 PR マージ後に対応可能。

注: keycloak モジュールの spotless はローカル JDK 25 で実行不可のため CI(temurin 21)で検証。

🤖 Generated with [Claude Code](https://claude.com/claude-code)