### PR TITLE
fix(deps): update static analysis (error prone + nullaway) + JPA init 注釈補完

### DIFF
--- a/keycloak/build.gradle.kts
+++ b/keycloak/build.gradle.kts
@@ -71,8 +71,8 @@ dependencies {
     testImplementation("org.mockito:mockito-core:5.14.2")
     testRuntimeOnly("org.slf4j:slf4j-simple:2.0.18")
 
-    errorprone("com.google.errorprone:error_prone_core:2.49.0")
-    errorprone("com.uber.nullaway:nullaway:0.13.6")
+    errorprone("com.google.errorprone:error_prone_core:2.50.0")
+    errorprone("com.uber.nullaway:nullaway:0.13.7")
 }
 
 tasks.named<JavaCompile>("compileJava") {

--- a/webapi/build.gradle
+++ b/webapi/build.gradle
@@ -85,8 +85,8 @@ dependencies {
     implementation 'net.javacrumbs.shedlock:shedlock-provider-jdbc-template:6.10.0'
 
     // Other dependencies
-    errorprone 'com.google.errorprone:error_prone_core:2.49.0'
-    errorprone 'com.uber.nullaway:nullaway:0.13.6'
+    errorprone 'com.google.errorprone:error_prone_core:2.50.0'
+    errorprone 'com.uber.nullaway:nullaway:0.13.7'
 }
 
 tasks.withType(JavaCompile).configureEach {

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/adapter/persistence/InvitationJpaEntity.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/adapter/persistence/InvitationJpaEntity.java
@@ -22,6 +22,7 @@ import xyz.dgz48.tasks.webapi.tenant.domain.TenantRole;
 @Table(name = "invitations")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SuppressWarnings("NullAway.Init") // JPA requires no-args constructor; fields initialized via JPA
 class InvitationJpaEntity extends TenantFilteredEntity {
 
   @Id

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/adapter/persistence/SignupRequestJpaEntity.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/tenant/adapter/persistence/SignupRequestJpaEntity.java
@@ -23,6 +23,7 @@ import xyz.dgz48.tasks.webapi.tenant.domain.SignupRequestStatus;
 @Table(name = "signup_requests")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SuppressWarnings("NullAway.Init") // JPA requires no-args constructor; fields initialized via JPA
 class SignupRequestJpaEntity {
 
   @Id


### PR DESCRIPTION
## 概要

Renovate PR #694(Error Prone 2.49.0→2.50.0 / NullAway 0.13.6→0.13.7)に、CI を green にするためのコード修正を同梱した置き換え PR。**#694 は本 PR マージ後に close 予定。**

## #694 が落ちていた原因

NullAway **0.13.7** が新規導入した「引数付き JPA コンストラクタの初期化警告」(uber/NullAway#1604)により、`@GeneratedValue(IDENTITY)` で `id` を DB 採番に委ねている下記2エンティティがコンパイル失敗していた:

```
SignupRequestJpaEntity.java: error: [NullAway] @NonNull field id is not initialized along all control-flow paths
InvitationJpaEntity.java:    error: [NullAway] @NonNull field id is not initialized along all control-flow paths
```

`e2e-test` / `webapi-ci` / `webapi-native-build` の3チェック失敗はすべてこのコンパイル失敗の連鎖。Error Prone 2.50.0 側の新チェックによるエラーは0件。

## 真因と対策

本リポジトリの JPA エンティティは全18個中16個が `@SuppressWarnings("NullAway.Init")` を付与している(`id` が JPA 採番で null 始まりなのは設計どおり、の宣言)。ADR-0040 で追加した `SignupRequestJpaEntity` / `InvitationJpaEntity` の2つだけがこれを欠いており、0.13.6 が JPA コンストラクタを免除していたため CI をすり抜けていた**潜在的な規約違反**だった。0.13.7 の厳格化がそれを顕在化させた。

→ 依存更新は正当(新チェックは妥当)なのでロールバックせず、2エンティティに他16個と同一の注釈を補完する。

## 変更

- `webapi/build.gradle` / `keycloak/build.gradle.kts`: Error Prone 2.50.0 / NullAway 0.13.7(#694 相当)
- `SignupRequestJpaEntity` / `InvitationJpaEntity`: `@SuppressWarnings("NullAway.Init")` を追加

## ローカル確認

- `./gradlew :webapi:compileJava` ✅(0.13.7 で BUILD SUCCESSFUL)
- `./gradlew :webapi:spotlessCheck` ✅

Supersedes #694.

🤖 Generated with [Claude Code](https://claude.com/claude-code)