### PR TITLE
test(perf): N+1 回帰固定ハーネス + 既対策4経路のクエリ本数ガード (Refs #769)

### DIFF
--- a/webapi/build.gradle.kts
+++ b/webapi/build.gradle.kts
@@ -69,6 +69,11 @@ dependencies {
     testImplementation("org.testcontainers:testcontainers-mysql")
     testImplementation("org.testcontainers:testcontainers-junit-jupiter")
 
+    // datasource-proxy — N+1 回帰固定用のクエリ本数計数(test scope、ADR-0039 §3 選択肢 B)。
+    // 実 DataSource を proxy 化して実行クエリを QueryCountHolder に記録する。テストは JVM 実行のため
+    // Native Image 互換の検証対象外(ADR-0039)。
+    testImplementation("net.ttddyy:datasource-proxy:1.10.1")
+
     // JsonNullable for PATCH partial-update DTOs (ADR-0014)
     // jackson-databind-nullable は Jackson 2/3 両対応だが当プロジェクトは Jackson 3 (tools.jackson) のみ使用する。
     // Jackson 2 の transitive 依存は Flyway / Logback から別途持ち込まれるため機能上問題なく除外可能。

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/QueryCountProbe.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/QueryCountProbe.java
@@ -1,0 +1,29 @@
+package xyz.dgz48.tasks.webapi;
+
+import net.ttddyy.dsproxy.QueryCountHolder;
+
+/**
+ * datasource-proxy の {@code QueryCountHolder}(ThreadLocal)を薄くラップする N+1 回帰テスト用ヘルパ(ADR-0039)。
+ *
+ * <p>計測区間の直前に {@link #reset()} し、区間後に {@link #totalQueries()} / {@link #selectQueries()} で本数を
+ * assert する。本数がフィクスチャ件数 N に依存せず定数であることを固定することで、将来の実装変更による N+1 退行を CI で検知する。
+ */
+public final class QueryCountProbe {
+
+  private QueryCountProbe() {}
+
+  /** 計測区間開始前にスレッドローカルのクエリ計数をリセットする。 */
+  public static void reset() {
+    QueryCountHolder.clear();
+  }
+
+  /** リセット以降に実行された総クエリ本数(SELECT / INSERT / UPDATE / DELETE / OTHER の合算)。 */
+  public static long totalQueries() {
+    return QueryCountHolder.getGrandTotal().getTotal();
+  }
+
+  /** リセット以降に実行された SELECT 本数。 */
+  public static long selectQueries() {
+    return QueryCountHolder.getGrandTotal().getSelect();
+  }
+}

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/QueryCountTestConfiguration.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/QueryCountTestConfiguration.java
@@ -1,0 +1,39 @@
+package xyz.dgz48.tasks.webapi;
+
+import javax.sql.DataSource;
+import net.ttddyy.dsproxy.support.ProxyDataSourceBuilder;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * N+1 回帰固定用に、オートコンフィグされた {@link DataSource} を datasource-proxy でラップしてクエリ本数を計数する テスト設定(ADR-0039 §3
+ * 選択肢 B)。{@code countQuery()} が {@code QueryCountHolder}(ThreadLocal)へ実行クエリを
+ * 記録するため、{@code @SpringBootTest}(MOCK, 同一スレッド同期実行)の MockMvc 呼び出し後にテストスレッドから本数を 参照できる。
+ *
+ * <p>本設定は {@code @Import} した IT のみに適用する(全 IT には効かせない)。既存の datasource-micrometer による DataSource
+ * ラップ(ADR-0029)とは BeanPostProcessor チェーン上で共存し、どちらが外側でも全クエリが本 proxy を通過 するため計数に影響しない。
+ */
+@TestConfiguration(proxyBeanMethods = false)
+public class QueryCountTestConfiguration {
+
+  /**
+   * オートコンフィグ済み {@link DataSource} を datasource-proxy でラップする。{@code static} にして BPP を早期生成し、
+   * 設定クラス本体の初期化に依存させない。
+   */
+  @Bean
+  static BeanPostProcessor queryCountingDataSourcePostProcessor() {
+    return new BeanPostProcessor() {
+      @Override
+      public Object postProcessAfterInitialization(Object bean, String beanName) {
+        if (bean instanceof DataSource dataSource) {
+          return ProxyDataSourceBuilder.create(dataSource)
+              .name("query-count-test")
+              .countQuery()
+              .build();
+        }
+        return bean;
+      }
+    };
+  }
+}

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/dashboard/adapter/web/DashboardQueryCountIT.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/dashboard/adapter/web/DashboardQueryCountIT.java
@@ -1,0 +1,214 @@
+package xyz.dgz48.tasks.webapi.dashboard.adapter.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import jakarta.persistence.EntityManager;
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.support.TransactionTemplate;
+import xyz.dgz48.tasks.webapi.FixedClockConfiguration;
+import xyz.dgz48.tasks.webapi.MockJwtDecoderConfiguration;
+import xyz.dgz48.tasks.webapi.QueryCountProbe;
+import xyz.dgz48.tasks.webapi.QueryCountTestConfiguration;
+import xyz.dgz48.tasks.webapi.TestcontainersConfiguration;
+import xyz.dgz48.tasks.webapi.security.adapter.web.TasksAuthenticationToken;
+import xyz.dgz48.tasks.webapi.security.domain.TasksPrincipal;
+import xyz.dgz48.tasks.webapi.shared.infra.AppZones;
+import xyz.dgz48.tasks.webapi.task.adapter.persistence.TaskJpaEntity;
+import xyz.dgz48.tasks.webapi.task.domain.Priority;
+import xyz.dgz48.tasks.webapi.task.domain.TaskStatus;
+import xyz.dgz48.tasks.webapi.tenant.adapter.persistence.TenantJpaEntity;
+import xyz.dgz48.tasks.webapi.user.adapter.persistence.UserJpaEntity;
+
+/**
+ * N+1 回帰固定テスト(ADR-0039 / #769)— ダッシュボード系エンドポイント。
+ *
+ * <p>異なる所有者の TENANT タスクを各セクションに多めに seed し、クエリ本数がタスク件数 N に依存せず定数であることを固定する。
+ *
+ * <ul>
+ *   <li>{@code GET /api/dashboard/tasks} — 4 セクション query + {@code loadUserMap} の 1 回一括 {@code
+ *       findAllById}。
+ *   <li>{@code GET /api/dashboard/summary} — STAKEHOLDERS 認可を {@code EXISTS} 相関サブクエリで畳んだ単一 query。
+ * </ul>
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@Import({
+  TestcontainersConfiguration.class,
+  MockJwtDecoderConfiguration.class,
+  FixedClockConfiguration.class,
+  QueryCountTestConfiguration.class
+})
+class DashboardQueryCountIT {
+
+  @Autowired MockMvc mockMvc;
+  @Autowired EntityManager em;
+  @Autowired TransactionTemplate txTemplate;
+
+  @MockitoBean Clock clock;
+
+  private static final LocalDate TODAY = LocalDate.of(2026, 1, 15);
+
+  private Long tenantId;
+  private Long viewerId;
+  private TasksAuthenticationToken viewerToken;
+
+  @BeforeEach
+  void setUp() {
+    when(clock.getZone()).thenReturn(AppZones.JST);
+    when(clock.instant())
+        .thenReturn(FixedClockConfiguration.FIXED_NOW.atZone(AppZones.JST).toInstant());
+
+    txTemplate.execute(
+        ignored -> {
+          var viewer =
+              new UserJpaEntity(
+                  "sub-dqc-viewer", "dqc-viewer@example.com", "計数閲覧者", "けいすうえつらんしゃ", null);
+          em.persist(viewer);
+          em.flush();
+          viewerId = viewer.getId();
+
+          SecurityContextHolder.getContext()
+              .setAuthentication(
+                  new TasksAuthenticationToken(
+                      new TasksPrincipal(
+                          viewerId,
+                          "sub-dqc-viewer",
+                          "dqc-viewer@example.com",
+                          "計数閲覧者",
+                          "けいすうえつらんしゃ",
+                          null),
+                      List.of()));
+
+          var tenant = new TenantJpaEntity("DQC-1", "計数テストテナント");
+          em.persist(tenant);
+          em.flush();
+          tenantId = tenant.getId();
+
+          insertMembership(viewerId, tenantId);
+
+          // 各セクション(overdue / today / upcoming)に別ユーザー所有の TENANT タスクを配置。
+          // loadUserMap が複数の別所有者を 1 回で解決することを検証できるよう所有者は全て別ユーザーにする。
+          persistOwnedTask("超過1", TaskStatus.IN_PROGRESS, TODAY.minusDays(5));
+          persistOwnedTask("超過2", TaskStatus.NOT_STARTED, TODAY.minusDays(3));
+          persistOwnedTask("当日1", TaskStatus.NOT_STARTED, TODAY);
+          persistOwnedTask("当日2", TaskStatus.IN_PROGRESS, TODAY);
+          persistOwnedTask("未来1", TaskStatus.NOT_STARTED, TODAY.plusDays(7));
+          persistOwnedTask("未来2", TaskStatus.NOT_STARTED, TODAY.plusDays(14));
+
+          return null;
+        });
+
+    SecurityContextHolder.clearContext();
+
+    viewerToken =
+        new TasksAuthenticationToken(
+            new TasksPrincipal(
+                viewerId, "sub-dqc-viewer", "dqc-viewer@example.com", "計数閲覧者", "けいすうえつらんしゃ", null),
+            List.of());
+  }
+
+  @AfterEach
+  void tearDown() {
+    SecurityContextHolder.clearContext();
+    if (tenantId == null) {
+      return;
+    }
+    txTemplate.execute(
+        ignored -> {
+          em.createNativeQuery("DELETE FROM tasks WHERE tenant_id = ?")
+              .setParameter(1, tenantId)
+              .executeUpdate();
+          em.createNativeQuery("DELETE FROM user_tenants WHERE tenant_id = ?")
+              .setParameter(1, tenantId)
+              .executeUpdate();
+          em.createNativeQuery("DELETE FROM tenants WHERE id = ?")
+              .setParameter(1, tenantId)
+              .executeUpdate();
+          em.createNativeQuery("DELETE FROM users WHERE email LIKE 'dqc-%@example.com'")
+              .executeUpdate();
+          return null;
+        });
+  }
+
+  private void persistOwnedTask(String title, TaskStatus status, LocalDate dueDate) {
+    var owner =
+        new UserJpaEntity(
+            "sub-dqc-" + title,
+            "dqc-" + title + "@example.com",
+            "所有者" + title,
+            "しょゆうしゃ" + title,
+            null);
+    em.persist(owner);
+    em.flush();
+    var task =
+        new TaskJpaEntity(tenantId, owner.getId(), title, null, status, Priority.MEDIUM, dueDate);
+    em.persist(task);
+    em.flush();
+  }
+
+  private void insertMembership(Long userId, Long tenant) {
+    em.createNativeQuery(
+            "INSERT INTO user_tenants (user_id, tenant_id, role, status, joined_at) VALUES (?,?,?,?,?)")
+        .setParameter(1, userId)
+        .setParameter(2, tenant)
+        .setParameter(3, "MEMBER")
+        .setParameter(4, "ACTIVE")
+        .setParameter(5, LocalDateTime.of(2026, 1, 1, 0, 0))
+        .executeUpdate();
+  }
+
+  /**
+   * {@code GET /api/dashboard/tasks} のクエリ本数がタスク件数 N に依存せず定数であることを固定する。内訳: membership 解決 + 4 セクション
+   * query + {@code loadUserMap} の一括 {@code findAllById}。N+1 退行時は所有者数だけ本数が増える。
+   */
+  @Test
+  void dashboardTasks_queryCountIsConstantRegardlessOfTaskCount() throws Exception {
+    QueryCountProbe.reset();
+    mockMvc
+        .perform(
+            get("/api/dashboard/tasks")
+                .header("X-Tenant-Id", String.valueOf(tenantId))
+                .with(authentication(viewerToken)))
+        .andExpect(status().isOk());
+
+    assertThat(QueryCountProbe.totalQueries()).isEqualTo(EXPECTED_DASHBOARD_TASKS_QUERIES);
+  }
+
+  /**
+   * {@code GET /api/dashboard/summary} のクエリ本数がタスク件数 N に依存せず定数であることを固定する。STAKEHOLDERS 認可は {@code
+   * EXISTS} 相関サブクエリでループ外の単一 query に畳まれている。N+1 退行時は本数が N に比例して増える。
+   */
+  @Test
+  void dashboardSummary_queryCountIsConstantRegardlessOfTaskCount() throws Exception {
+    QueryCountProbe.reset();
+    mockMvc
+        .perform(
+            get("/api/dashboard/summary")
+                .header("X-Tenant-Id", String.valueOf(tenantId))
+                .with(authentication(viewerToken)))
+        .andExpect(status().isOk());
+
+    assertThat(QueryCountProbe.totalQueries()).isEqualTo(EXPECTED_DASHBOARD_SUMMARY_QUERIES);
+  }
+
+  // 期待本数はローカル Testcontainers 実行で採取して pin(ADR-0039 §6)。内訳はテスト Javadoc 参照。
+  private static final long EXPECTED_DASHBOARD_TASKS_QUERIES = 5L;
+  private static final long EXPECTED_DASHBOARD_SUMMARY_QUERIES = 2L;
+}

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/adapter/web/TaskQueryCountIT.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/task/adapter/web/TaskQueryCountIT.java
@@ -1,0 +1,273 @@
+package xyz.dgz48.tasks.webapi.task.adapter.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import jakarta.persistence.EntityManager;
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.support.TransactionTemplate;
+import xyz.dgz48.tasks.webapi.FixedClockConfiguration;
+import xyz.dgz48.tasks.webapi.MockJwtDecoderConfiguration;
+import xyz.dgz48.tasks.webapi.QueryCountProbe;
+import xyz.dgz48.tasks.webapi.QueryCountTestConfiguration;
+import xyz.dgz48.tasks.webapi.TestcontainersConfiguration;
+import xyz.dgz48.tasks.webapi.security.adapter.web.TasksAuthenticationToken;
+import xyz.dgz48.tasks.webapi.security.domain.TasksPrincipal;
+import xyz.dgz48.tasks.webapi.shared.infra.AppZones;
+import xyz.dgz48.tasks.webapi.task.adapter.persistence.TaskJpaEntity;
+import xyz.dgz48.tasks.webapi.task.domain.Priority;
+import xyz.dgz48.tasks.webapi.task.domain.TaskStatus;
+import xyz.dgz48.tasks.webapi.tenant.adapter.persistence.TenantJpaEntity;
+import xyz.dgz48.tasks.webapi.user.adapter.persistence.UserJpaEntity;
+
+/**
+ * N+1 回帰固定テスト(ADR-0039 / #769)— タスク系エンドポイント。
+ *
+ * <p>複数の異なる所有者を持つタスク / 複数の関係者を「多めに」seed し、endpoint のクエリ本数がフィクスチャ件数 N に依存せず 定数であることを固定する。将来 {@code
+ * loadUserMap} の一括解決や関係者 JOIN が誤って per-row ループ化(N+1)した場合、 本数が N に比例して増えるため本テストが落ちる。
+ *
+ * <ul>
+ *   <li>{@code GET /api/tasks}(一覧)— {@code loadUserMap} が {@code findAllById} で 1 回一括解決。
+ *   <li>{@code GET /api/tasks/{id}/stakeholders} — {@code users} を JOIN した単一 native query。
+ * </ul>
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@Import({
+  TestcontainersConfiguration.class,
+  MockJwtDecoderConfiguration.class,
+  FixedClockConfiguration.class,
+  QueryCountTestConfiguration.class
+})
+class TaskQueryCountIT {
+
+  @Autowired MockMvc mockMvc;
+  @Autowired EntityManager em;
+  @Autowired TransactionTemplate txTemplate;
+
+  @MockitoBean Clock clock;
+
+  private static final LocalDate TODAY = LocalDate.of(2026, 1, 15);
+
+  /** N+1 なら本数が N に比例するよう、所有者を全て別ユーザーにしたタスクを多めに seed する。 */
+  private static final int OWNED_TASK_COUNT = 6;
+
+  /** 関係者一覧 N+1 検出用に、単一タスクへ複数の別ユーザー関係者を登録する。 */
+  private static final int STAKEHOLDER_COUNT = 4;
+
+  private Long tenantId;
+  private Long viewerId;
+  private TasksAuthenticationToken viewerToken;
+  private Long stakeholderTaskId;
+
+  @BeforeEach
+  void setUp() {
+    when(clock.getZone()).thenReturn(AppZones.JST);
+    when(clock.instant())
+        .thenReturn(FixedClockConfiguration.FIXED_NOW.atZone(AppZones.JST).toInstant());
+
+    txTemplate.execute(
+        ignored -> {
+          var viewer =
+              new UserJpaEntity(
+                  "sub-qc-viewer", "qc-viewer@example.com", "計数閲覧者", "けいすうえつらんしゃ", null);
+          em.persist(viewer);
+          em.flush();
+          viewerId = viewer.getId();
+
+          // JpaAuditorAware が created_by / updated_by を解決できるよう認証コンテキストを設定
+          SecurityContextHolder.getContext()
+              .setAuthentication(
+                  new TasksAuthenticationToken(
+                      new TasksPrincipal(
+                          viewerId,
+                          "sub-qc-viewer",
+                          "qc-viewer@example.com",
+                          "計数閲覧者",
+                          "けいすうえつらんしゃ",
+                          null),
+                      List.of()));
+
+          var tenant = new TenantJpaEntity("QC-1", "計数テストテナント");
+          em.persist(tenant);
+          em.flush();
+          tenantId = tenant.getId();
+
+          insertMembership(viewerId, tenantId);
+
+          // 所有者が全て別ユーザーの TENANT タスクを複数 seed(viewer は tenant member なので全件参照可)
+          for (int i = 0; i < OWNED_TASK_COUNT; i++) {
+            var owner =
+                new UserJpaEntity(
+                    "sub-qc-owner-" + i,
+                    "qc-owner-" + i + "@example.com",
+                    "所有者" + i,
+                    "しょゆうしゃ" + i,
+                    null);
+            em.persist(owner);
+            em.flush();
+            var task =
+                new TaskJpaEntity(
+                    tenantId,
+                    owner.getId(),
+                    "計数タスク" + i,
+                    null,
+                    TaskStatus.NOT_STARTED,
+                    Priority.MEDIUM,
+                    TODAY);
+            em.persist(task);
+            em.flush();
+          }
+
+          // 関係者一覧用: TENANT 可視のタスク 1 件 + 別ユーザー関係者を複数登録(viewer は member なので参照可)
+          var stkOwner =
+              new UserJpaEntity(
+                  "sub-qc-stk-owner",
+                  "qc-stk-owner@example.com",
+                  "関係者タスク所有者",
+                  "かんけいしゃたすくしょゆうしゃ",
+                  null);
+          em.persist(stkOwner);
+          em.flush();
+          var stkTask =
+              new TaskJpaEntity(
+                  tenantId,
+                  stkOwner.getId(),
+                  "関係者計数タスク",
+                  null,
+                  TaskStatus.NOT_STARTED,
+                  Priority.MEDIUM,
+                  TODAY);
+          em.persist(stkTask);
+          em.flush();
+          stakeholderTaskId = stkTask.getId();
+
+          for (int i = 0; i < STAKEHOLDER_COUNT; i++) {
+            var s =
+                new UserJpaEntity(
+                    "sub-qc-stk-" + i,
+                    "qc-stk-" + i + "@example.com",
+                    "関係者" + i,
+                    "かんけいしゃ" + i,
+                    null);
+            em.persist(s);
+            em.flush();
+            insertStakeholder(stakeholderTaskId, s.getId(), tenantId, stkOwner.getId());
+          }
+
+          return null;
+        });
+
+    SecurityContextHolder.clearContext();
+
+    viewerToken =
+        new TasksAuthenticationToken(
+            new TasksPrincipal(
+                viewerId, "sub-qc-viewer", "qc-viewer@example.com", "計数閲覧者", "けいすうえつらんしゃ", null),
+            List.of());
+  }
+
+  @AfterEach
+  void tearDown() {
+    SecurityContextHolder.clearContext();
+    if (tenantId == null) {
+      return;
+    }
+    txTemplate.execute(
+        ignored -> {
+          em.createNativeQuery("DELETE FROM task_stakeholders WHERE tenant_id = ?")
+              .setParameter(1, tenantId)
+              .executeUpdate();
+          em.createNativeQuery("DELETE FROM tasks WHERE tenant_id = ?")
+              .setParameter(1, tenantId)
+              .executeUpdate();
+          em.createNativeQuery("DELETE FROM user_tenants WHERE tenant_id = ?")
+              .setParameter(1, tenantId)
+              .executeUpdate();
+          em.createNativeQuery("DELETE FROM tenants WHERE id = ?")
+              .setParameter(1, tenantId)
+              .executeUpdate();
+          em.createNativeQuery("DELETE FROM users WHERE email LIKE 'qc-%@example.com'")
+              .executeUpdate();
+          return null;
+        });
+  }
+
+  private void insertMembership(Long userId, Long tenant) {
+    em.createNativeQuery(
+            "INSERT INTO user_tenants (user_id, tenant_id, role, status, joined_at) VALUES (?,?,?,?,?)")
+        .setParameter(1, userId)
+        .setParameter(2, tenant)
+        .setParameter(3, "MEMBER")
+        .setParameter(4, "ACTIVE")
+        .setParameter(5, LocalDateTime.of(2026, 1, 1, 0, 0))
+        .executeUpdate();
+  }
+
+  private void insertStakeholder(Long taskId, Long userId, Long tenant, Long addedBy) {
+    em.createNativeQuery(
+            "INSERT INTO task_stakeholders (task_id, user_id, tenant_id, added_by, added_at)"
+                + " VALUES (?,?,?,?,?)")
+        .setParameter(1, taskId)
+        .setParameter(2, userId)
+        .setParameter(3, tenant)
+        .setParameter(4, addedBy)
+        .setParameter(5, LocalDateTime.of(2026, 1, 1, 0, 0))
+        .executeUpdate();
+  }
+
+  /**
+   * {@code GET /api/tasks} のクエリ本数が所有者数(N)に依存せず定数であることを固定する。内訳: TenantContextFilter の membership 解決
+   * + 一覧の count / page / overdue 集計 + {@code loadUserMap} の一括 {@code findAllById}。N+1 退行時は
+   * 所有者数だけ本数が増える。
+   */
+  @Test
+  void listTasks_queryCountIsConstantRegardlessOfOwnerCount() throws Exception {
+    QueryCountProbe.reset();
+    mockMvc
+        .perform(
+            get("/api/tasks")
+                .header("X-Tenant-Id", String.valueOf(tenantId))
+                .with(authentication(viewerToken)))
+        .andExpect(status().isOk());
+
+    assertThat(QueryCountProbe.totalQueries()).isEqualTo(EXPECTED_LIST_TASKS_QUERIES);
+  }
+
+  /**
+   * {@code GET /api/tasks/{id}/stakeholders} のクエリ本数が関係者数(N)に依存せず定数であることを固定する。関係者情報は {@code users} を
+   * JOIN した単一 native query で解決される。N+1 退行時は関係者数だけ本数が増える。
+   */
+  @Test
+  void listStakeholders_queryCountIsConstantRegardlessOfStakeholderCount() throws Exception {
+    QueryCountProbe.reset();
+    mockMvc
+        .perform(
+            get("/api/tasks/{id}/stakeholders", stakeholderTaskId)
+                .header("X-Tenant-Id", String.valueOf(tenantId))
+                .with(authentication(viewerToken)))
+        .andExpect(status().isOk());
+
+    assertThat(QueryCountProbe.totalQueries()).isEqualTo(EXPECTED_LIST_STAKEHOLDERS_QUERIES);
+  }
+
+  // 期待本数はローカル Testcontainers 実行で採取して pin(ADR-0039 §6)。内訳はテスト Javadoc 参照。
+  private static final long EXPECTED_LIST_TASKS_QUERIES = 5L;
+  private static final long EXPECTED_LIST_STAKEHOLDERS_QUERIES = 4L;
+}


### PR DESCRIPTION
## 概要

Issue #769(性能チューニング)/ ADR-0039 の **PR①**。ADR-0039 §3 で確定した **選択肢 B(datasource-proxy, test scope)** に従い、クエリ本数を計数する N+1 回帰テスト基盤を追加し、既に N+1 対策済みの主要4経路に回帰ガードを張る。

ADR-0039 の実態認識どおり「新規 N+1 の発掘」よりも **現状に N+1 が無いことの固定(壊さないためのガード)** が本 Issue の主目的。

## 変更

- `webapi/build.gradle.kts`: `net.ttddyy:datasource-proxy:1.10.1` を `testImplementation` 追加(test 限定・JVM 実行のため Native 互換は無関係)
- `QueryCountTestConfiguration`(test): `BeanPostProcessor` で オートコンフィグ済み `DataSource` を proxy 化し `countQuery()` で `QueryCountHolder` に記録。**`@Import` した IT のみ**に適用し、既存 datasource-micrometer(ADR-0029)とは BPP チェーン上で共存(どちらが外側でも全クエリが通過するため計数に影響なし)
- `QueryCountProbe`(test): `reset` / `totalQueries` / `selectQueries` の薄いヘルパ
- `TaskQueryCountIT` / `DashboardQueryCountIT`: 下表4経路の回帰ガード

## 固定したクエリ本数(ローカル Testcontainers で採取・pin)

| endpoint | 本数 | 対策機構 |
|---|---|---|
| `GET /api/tasks` | 5 | `loadUserMap` の一括 `findAllById` |
| `GET /api/tasks/{id}/stakeholders` | 4 | `users` を JOIN した単一 native query |
| `GET /api/dashboard/tasks` | 5 | 4 セクション query + 一括 `loadUserMap` |
| `GET /api/dashboard/summary` | 2 | STAKEHOLDERS 認可の `EXISTS` 単一 query |

別ユーザー所有のタスク / 関係者を「多め」に seed(所有者6・関係者4)し、本数が件数 N に依存せず定数であることを固定。N+1 退行時は本数が N に比例して増え、テストが落ちて検知する。

## 検証

- `./gradlew :webapi:check`(全 Testcontainers IT + spotless + jacoco 80%)**green**(ローカル、6m40s)
- 4 IT はいずれも実 MySQL 8.4(Testcontainers)で本数を実測して pin

## ADR-0039 の残 PR(本 PR は①)

- ② index の EXPLAIN 所見 + 必要な Flyway 追加(`Refs #769`)
- ③ 性能所見メモ docs(`Closes #769`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)