### PR TITLE
docs(perf): index EXPLAIN 所見 + 性能所見メモ (Closes #769)

### DIFF
--- a/docs/reviews/2026-07-03-adr0039-performance-findings.md
+++ b/docs/reviews/2026-07-03-adr0039-performance-findings.md
@@ -1,0 +1,99 @@
+# 性能所見メモ — N+1 / クエリ / index(ADR-0039 / Issue #769)
+
+- 日付: 2026-07-03
+- 対象: [Issue #769](https://github.com/win2cot/tasks-webapi/issues/769)(Phase 1 Sprint 5 性能チューニング)
+- 方式: [ADR-0039](../adr/0039-performance-tuning-measurement-and-regression.md)(測定 → 是正 → 所見記録。定量 SLO なし)
+- 前提: 実行基盤は GraalVM Native([ADR-0008](../adr/0008-graalvm-native-image.md))/ テストは Testcontainers MySQL 8.4(H2 不可)/ テナント分離は Hibernate Filter([ADR-0010](../adr/0010-tenant-isolation-hibernate-filter.md))
+
+## 1. 結論(サマリ)
+
+- **N+1**: 主要4経路(タスク一覧 / 関係者一覧 / ダッシュボード tasks / ダッシュボード summary)は既に一括解決済みで N+1 は無い。**クエリ本数を回帰固定するガードを追加**(PR #837)し、将来の退行を CI で検知できるようにした。
+- **index**: 主要 endpoint の代表クエリを実 MySQL 8.4 上で `EXPLAIN` した結果、**マルチテナント実配分では `tasks` へのフルスキャン(`type=ALL`)は発生せず**、いずれも `tenant_id` 先頭の複合 index(`idx_tasks_tenant_*`)または index_merge を使用する。**新規 index の追加は不要**と判断した。
+- **record-only**: keyword 部分一致(`LIKE '%kw%'`、前方ワイルドカード)は index 不可。ADR-0039 §5 に従い所見記録のみとし、改善(前方一致化 / FULLTEXT 等)は別 Issue 候補とする。
+
+## 2. レイヤー②: N+1 回帰固定(PR #837、`Refs #769`)
+
+ADR-0039 §3 選択肢 B(datasource-proxy, test scope)。実 DataSource を proxy 化してクエリ本数を計数し、別ユーザー所有のタスク / 関係者を多めに seed して「本数がフィクスチャ件数 N に依存せず定数」であることを固定した。N+1 退行時は本数が N に比例して増え、テストが落ちる。
+
+| endpoint | 固定本数 | 対策機構 |
+|---|---|---|
+| `GET /api/tasks` | 5 | `loadUserMap` の一括 `findAllById` |
+| `GET /api/tasks/{id}/stakeholders` | 4 | `users` を JOIN した単一 native query |
+| `GET /api/dashboard/tasks` | 5 | 4 セクション query + 一括 `loadUserMap` |
+| `GET /api/dashboard/summary` | 2 | STAKEHOLDERS 認可の `EXISTS` 単一 query |
+
+テスト: `TaskQueryCountIT` / `DashboardQueryCountIT`、ヘルパ `QueryCountProbe` / `QueryCountTestConfiguration`。
+
+## 3. レイヤー①: index EXPLAIN 所見
+
+計測スクリプト: `webapi/src/test/java/xyz/dgz48/tasks/webapi/perf/IndexExplainMeasurementIT.java`(`@Disabled`、手動実行)。Hibernate Filter が注入する `tenant_id = ?` を明示的に含めた「MySQL が実際に実行する形」の native SQL を `EXPLAIN` する。
+
+### 3.1 重要な注意 — 計測ボリューム由来の見かけの full scan
+
+**全タスクを 1 テナントに偏らせて seed すると `tenant_id = ?` が非選択的になり、`tasks` が `type=ALL`(full scan)になる**。これは「full scan が最適」というオプティマイザの正しい判断であって index 不足ではない。他テナントにも実データを積んで **マルチテナント実配分**(対象テナント ≒ 全体の 2〜3%)にすると、`tenant_id` 先頭の複合 index が選択され `type=ref` に変わる。
+
+例: `GET /api/tasks`(認可述語 + `ORDER BY due_date` + LIMIT)
+
+| seed | type | key | rows |
+|---|---|---|---|
+| 単一テナント偏在(≒全行が対象テナント) | `ALL` | NULL | 300 |
+| **マルチテナント実配分(対象 ≒ 2.6%)** | **`ref`** | **`idx_tasks_tenant_due`** | 120 |
+
+以下 3.2 の所見は **マルチテナント実配分**(対象テナント 120 タスク / 全体 ≒ 4,620 タスク × 16 テナント)で採取した。
+
+### 3.2 代表クエリの EXPLAIN(マルチテナント実配分)
+
+| # | endpoint / query | type | 使用 key | rows | 所見 |
+|---|---|---|---|---|---|
+| A-1 | `GET /api/tasks` 一覧(認可述語, ORDER BY due_date, LIMIT) | ref | `idx_tasks_tenant_due` | 120 | tenant で絞り込み後に OR 認可述語を filter。関係者 EXISTS は `task_stakeholders` PK を eq_ref |
+| A-2 | `GET /api/tasks` COUNT | ref | `idx_tasks_tenant_due` | 120 | 同上 |
+| A-3 | `GET /api/tasks` keyword `LIKE '%kw%'` | ref | `idx_tasks_tenant_due` | 120 | tenant で絞り込み後、LIKE は index 不可のため filter(**record-only**、§4) |
+| A-4 | `GET /api/tasks` overdueCount | range | `idx_tasks_tenant_due` | 60 | `due_date < ?` を range スキャン |
+| B-1 | `GET /api/tasks/{id}/stakeholders`(native JOIN) | ref / eq_ref | `PRIMARY`(×3) | 3 | `ts` は PK `(task_id,user_id)` 前方一致、`users` は PK eq_ref。`ORDER BY added_at` で filesort(数件、無視可) |
+| C-1 | dashboard findOverdue | index_merge | union(`fk_tasks_owner`,`fk_tasks_assignee`) | 5 | `(owner OR assignee)` を index_merge。所有/担当タスクは少数のため良好 |
+| C-2 | dashboard findToday | ref | `idx_tasks_tenant_due` | 2 | `due_date = ?` |
+| C-3 | dashboard findUpcoming | index_merge | union(owner,assignee) | 5 | C-1 と同型 |
+| C-4 | dashboard findCompletedToday | index_merge | union(owner,assignee) | 5 | 同型。filesort(数件) |
+| D-1 | `GET /api/dashboard/summary`(EXISTS) | ref | `idx_tasks_tenant_due` | 120 | tenant 絞り込み後に OR + 関係者 EXISTS(PK eq_ref) |
+| D-2 | `GET /api/tenant/dashboard/summary` | ref | `idx_tasks_tenant_due` | 120 | `visibility IN (...)` を filter |
+| D-3 | `〃` countActiveMembers(`user_tenants`) | ALL | NULL | 33 | 小テーブル(テナント内メンバー数)。full scan が最適。at scale は `idx_ut_tenant (tenant_id,user_id)` が絞り込む(§3.3) |
+| E-1 | `GET /api/tenant/users`(`user_tenants`, ORDER BY joined_at) | ALL | NULL | 33 | 同上。`joined_at` は無 index のため filesort。メンバー数は有界のため許容 |
+| F-1 | `GET /api/tenants`(admin, status + name LIKE) | index | `PRIMARY`(backward) | 17 | 小テーブル。`name LIKE '%kw%'` は index 不可(**record-only**) |
+| F-2 | `〃` countTasksByTenantIds(native, IN batch) | ref | `idx_tasks_tenant_deleted` | 120 | covering(`Using index`) |
+
+### 3.3 `user_tenants`(D-3 / E-1)の `type=ALL` について
+
+本計測では他テナントの **メンバーシップ行を積んでいない**ため `user_tenants` が単一テナント偏在となり `type=ALL`(33 行)になる。§3.1 の `tasks` と同じ機構で、マルチテナント実配分では `idx_ut_tenant (tenant_id, user_id)` により `tenant_id = ?` が絞り込まれる。`GET /api/tenant/users` の `ORDER BY joined_at` は `joined_at` が index に無いため filesort が残るが、**テナント内メンバー数は有界(数十〜数百)** のため実害は小さい。重大事象ではないため index 追加は見送る(不要な書込コストを避ける)。
+
+## 4. record-only(#769 では是正しない、別 Issue 候補)
+
+- **keyword 部分一致**: `tasks.title/description` の `LIKE '%kw%'`(A-3)と `tenants.name` の `LIKE '%kw%'`(F-1)は前方ワイルドカードのため B-Tree index を使えない。tenant 絞り込み後の filter で現状は許容範囲だが、タスク数が多いテナントで悪化しうる。前方一致化(`kw%`)/ MySQL FULLTEXT / 生成列 + index 等の改善は **別 Issue 候補**(ADR-0039 §5)。
+
+## 5. 是正スコープの判断(ADR-0039 §4)
+
+- **新規 index 追加**: なし。既存の `tasks` 7 本(`tenant_id` 先頭複合)+ `task_stakeholders` PK/idx + `user_tenants` idx で主要 endpoint は充足。`type=ALL` は小テーブル(`user_tenants`)または計測ボリューム由来の見かけ上のもので、大テーブル `tasks` に実害のあるフルスキャンは無い。
+- **Flyway migration**: 不要(スキーマ変更なし)。
+
+## 6. リリース前チェックリスト([#770](https://github.com/win2cot/tasks-webapi/issues/770))への引き継ぎ
+
+- [x] 主要 endpoint のクエリ本数を回帰テストで固定(N+1 退行の CI 検知)
+- [x] 主要 endpoint 代表クエリの `EXPLAIN` 所見を記録、重大事象(大テーブルの `type=ALL`)は無し
+- [ ] keyword `LIKE '%kw%'` 改善 — 別 Issue 化を検討(タスク数の多いテナントが現れた段階で優先度再評価)
+- [ ] 本番トラフィックでの N+1 継続観測は ADR-0029 の datasource-micrometer 計装(OTLP span)に委譲
+
+## 7. 再現手順
+
+```bash
+# N+1 回帰ガード(CI で常時実行)
+./gradlew :webapi:test --tests "*QueryCountIT"
+
+# index EXPLAIN 計測(@Disabled を外して手動実行)
+#   IndexExplainMeasurementIT の @Disabled を一時的に外し:
+./gradlew :webapi:test --tests "*IndexExplainMeasurementIT"
+```
+
+## 参考
+
+- [ADR-0039](../adr/0039-performance-tuning-measurement-and-regression.md) — 本メモの方式
+- [ADR-0029](../adr/0029-performance-measurement-and-diagnostics.md) §6.1 — ランタイム JDBC 計装(datasource-micrometer)
+- [2026-06-05 Hibernate Filter 性能所見](2026-06-05-hibernate-filter-perf.md)(#316)— filter ON/OFF の先行計測(本メモは認可述語・ダッシュボード・関係者・テナント系へ範囲拡大)

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/perf/IndexExplainMeasurementIT.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/perf/IndexExplainMeasurementIT.java
@@ -1,0 +1,395 @@
+package xyz.dgz48.tasks.webapi.perf;
+
+import jakarta.persistence.EntityManager;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.transaction.annotation.Transactional;
+import xyz.dgz48.tasks.webapi.MockJwtDecoderConfiguration;
+import xyz.dgz48.tasks.webapi.TestcontainersConfiguration;
+import xyz.dgz48.tasks.webapi.security.adapter.web.TasksAuthenticationToken;
+import xyz.dgz48.tasks.webapi.security.domain.TasksPrincipal;
+import xyz.dgz48.tasks.webapi.task.adapter.persistence.TaskJpaEntity;
+import xyz.dgz48.tasks.webapi.task.domain.Priority;
+import xyz.dgz48.tasks.webapi.task.domain.TaskStatus;
+import xyz.dgz48.tasks.webapi.tenant.adapter.persistence.TenantJpaEntity;
+import xyz.dgz48.tasks.webapi.user.adapter.persistence.UserJpaEntity;
+
+/**
+ * ADR-0039 / #769 PR② — 主要 endpoint 代表クエリの index EXPLAIN 計測スクリプト。
+ *
+ * <p>Hibernate Filter がクエリに注入する {@code tenant_id = ?} を明示的に含めた「MySQL が実際に実行する形」の native SQL を
+ * マルチテナント実配分(対象テナント ≒ 120 タスク / 全体 ≒ 16 テナント × 数千タスク)に対して {@code EXPLAIN} し、{@code type} / 使用 index
+ * / {@code rows} / {@code Extra} を出力する。他テナントにも実データを積むのは、対象テナントの {@code tenant_id} を
+ * 選択的にして計測ボリューム由来の見かけの full scan を避けるため(所見メモ §3.1 参照)。結果は {@code
+ * docs/reviews/2026-07-03-adr0039-performance-findings.md} に記録する。CI ではスキップ({@code @Disabled})。ローカルで
+ * 手動実行する際は {@code @Disabled} を外すこと。
+ */
+@Disabled("手動計測用スクリプト — CI では実行しない(ADR-0039 / #769)。所見は docs/reviews に記録済み。")
+@SpringBootTest
+@Import({TestcontainersConfiguration.class, MockJwtDecoderConfiguration.class})
+@Transactional
+class IndexExplainMeasurementIT {
+
+  private static final int USERS = 30;
+  private static final int TASKS = 120;
+  private static final int OTHER_TENANTS = 15;
+
+  /**
+   * 他テナントにも実データを積み、対象テナントの {@code tenant_id = ?} が選択的になる「マルチテナント実配分」を再現する。これを積まないと 全行が 1
+   * テナントに偏り、{@code tenant_id} index が効かず full scan が最適(=計測ボリューム由来の見かけの {@code type=ALL})に なってしまう。
+   */
+  private static final int FILLER_TASKS_PER_TENANT = 300;
+
+  private Long auditorId;
+  private static final LocalDate BASE = LocalDate.of(2026, 6, 15);
+  private static final LocalDateTime DAY_START = LocalDate.of(2026, 6, 15).atStartOfDay();
+
+  @Autowired EntityManager em;
+
+  private Long tenantId;
+  private Long userId;
+  private Long stakeholderTaskId;
+
+  @BeforeEach
+  void seed() {
+    var auditor =
+        new UserJpaEntity("sub-ix-auditor", "ix-auditor@example.com", "計測監査", "ケイソクカンサ", null);
+    em.persist(auditor);
+    em.flush();
+    auditorId = auditor.getId();
+    SecurityContextHolder.getContext()
+        .setAuthentication(
+            new TasksAuthenticationToken(
+                new TasksPrincipal(
+                    auditor.getId(),
+                    "sub-ix-auditor",
+                    "ix-auditor@example.com",
+                    "計測監査",
+                    "ケイソクカンサ",
+                    null),
+                List.of()));
+
+    var tenant = new TenantJpaEntity("IX-1", "計測テナント");
+    em.persist(tenant);
+    em.flush();
+    tenantId = tenant.getId();
+
+    var userIds = new Long[USERS];
+    for (int i = 0; i < USERS; i++) {
+      var u =
+          new UserJpaEntity(
+              "sub-ix-u" + i, "ix-u" + i + "@example.com", "利用者" + i, "りようしゃ" + i, null);
+      em.persist(u);
+      em.flush();
+      userIds[i] = u.getId();
+      insertMembership(userIds[i], tenantId);
+    }
+    userId = userIds[0];
+
+    var visibilities = new String[] {"TENANT", "STAKEHOLDERS", "PRIVATE"};
+    var statuses =
+        new TaskStatus[] {
+          TaskStatus.NOT_STARTED, TaskStatus.IN_PROGRESS, TaskStatus.DONE, TaskStatus.NOT_STARTED
+        };
+    Long firstStakeholderTask = null;
+    for (int i = 0; i < TASKS; i++) {
+      var status = statuses[i % statuses.length];
+      var task =
+          new TaskJpaEntity(
+              tenantId,
+              userIds[i % USERS],
+              "計測タスク" + i,
+              i % 5 == 0 ? "四半期レビュー資料" : null,
+              status,
+              Priority.values()[i % Priority.values().length],
+              BASE.plusDays((i % 60) - 30));
+      em.persist(task);
+      em.flush();
+      var vis = visibilities[i % visibilities.length];
+      em.createNativeQuery("UPDATE tasks SET visibility = ? WHERE id = ?")
+          .setParameter(1, vis)
+          .setParameter(2, task.getId())
+          .executeUpdate();
+      if (i % 3 == 0) {
+        em.createNativeQuery("UPDATE tasks SET assignee_id = ? WHERE id = ?")
+            .setParameter(1, userIds[(i + 1) % USERS])
+            .setParameter(2, task.getId())
+            .executeUpdate();
+      }
+      if (status == TaskStatus.DONE) {
+        em.createNativeQuery("UPDATE tasks SET completed_at = ? WHERE id = ?")
+            .setParameter(1, DAY_START.plusHours(i % 12))
+            .setParameter(2, task.getId())
+            .executeUpdate();
+      }
+      if ("STAKEHOLDERS".equals(vis)) {
+        if (firstStakeholderTask == null) {
+          firstStakeholderTask = task.getId();
+        }
+        for (int s = 0; s < 3; s++) {
+          insertStakeholder(task.getId(), userIds[(i + s) % USERS], tenantId, userIds[i % USERS]);
+        }
+      }
+    }
+    stakeholderTaskId = firstStakeholderTask;
+
+    // 他テナントにも実データを積み、対象テナントの tenant_id を選択的にする(マルチテナント実配分の再現)。
+    int flushCounter = 0;
+    for (int t = 0; t < OTHER_TENANTS; t++) {
+      var other = new TenantJpaEntity("IX-OTHER-" + t, "他テナント" + t);
+      em.persist(other);
+      em.flush();
+      var otherTenantId = other.getId();
+      for (int i = 0; i < FILLER_TASKS_PER_TENANT; i++) {
+        em.persist(
+            new TaskJpaEntity(
+                otherTenantId,
+                auditorId,
+                "他テナントタスク" + t + "-" + i,
+                null,
+                TaskStatus.NOT_STARTED,
+                Priority.MEDIUM,
+                BASE.plusDays((i % 60) - 30)));
+        if (++flushCounter % 200 == 0) {
+          em.flush();
+          em.clear();
+          // em.clear() で detached になるため以降の参照はしない(挿入専用ループ)
+        }
+      }
+    }
+    em.flush();
+    em.clear();
+  }
+
+  @Test
+  void explainRepresentativeQueries() {
+    var today = java.sql.Date.valueOf(BASE);
+    var upper = java.sql.Date.valueOf(BASE.plusDays(7));
+    var dayStart = java.sql.Timestamp.valueOf(DAY_START);
+    var dayEnd = java.sql.Timestamp.valueOf(DAY_START.plusDays(1));
+
+    // A-1: タスク一覧 データ取得(認可述語 + 既定 due_date ソート + paging)
+    explain(
+        "A-1 GET /api/tasks (data, auth predicate, ORDER BY due_date, LIMIT)",
+        "EXPLAIN SELECT t.id FROM tasks t"
+            + " WHERE t.tenant_id = ? AND t.deleted_at IS NULL"
+            + " AND (t.visibility = 'TENANT' OR t.owner_id = ? OR t.assignee_id = ?"
+            + "   OR (t.visibility = 'STAKEHOLDERS' AND EXISTS ("
+            + "     SELECT 1 FROM task_stakeholders ts"
+            + "     WHERE ts.task_id = t.id AND ts.user_id = ? AND ts.tenant_id = ?)))"
+            + " ORDER BY t.due_date ASC LIMIT 20",
+        tenantId,
+        userId,
+        userId,
+        userId,
+        tenantId);
+
+    // A-2: タスク一覧 COUNT(同一述語)
+    explain(
+        "A-2 GET /api/tasks (count, auth predicate)",
+        "EXPLAIN SELECT COUNT(t.id) FROM tasks t"
+            + " WHERE t.tenant_id = ? AND t.deleted_at IS NULL"
+            + " AND (t.visibility = 'TENANT' OR t.owner_id = ? OR t.assignee_id = ?"
+            + "   OR (t.visibility = 'STAKEHOLDERS' AND EXISTS ("
+            + "     SELECT 1 FROM task_stakeholders ts"
+            + "     WHERE ts.task_id = t.id AND ts.user_id = ? AND ts.tenant_id = ?)))",
+        tenantId,
+        userId,
+        userId,
+        userId,
+        tenantId);
+
+    // A-3: keyword LIKE(前方ワイルドカード=index 不可、ADR-0039 §5 は所見記録のみ)
+    explain(
+        "A-3 GET /api/tasks (keyword LIKE %kw%, leading wildcard — record only)",
+        "EXPLAIN SELECT t.id FROM tasks t"
+            + " WHERE t.tenant_id = ? AND t.deleted_at IS NULL"
+            + " AND (LOWER(t.title) LIKE '%レビュー%' OR LOWER(t.description) LIKE '%レビュー%')"
+            + " ORDER BY t.due_date ASC LIMIT 20",
+        tenantId);
+
+    // A-4: overdue 件数(認可述語 + due_date < today AND status <> DONE)
+    explain(
+        "A-4 GET /api/tasks (overdueCount)",
+        "EXPLAIN SELECT COUNT(t.id) FROM tasks t"
+            + " WHERE t.tenant_id = ? AND t.deleted_at IS NULL"
+            + " AND (t.visibility = 'TENANT' OR t.owner_id = ? OR t.assignee_id = ?)"
+            + " AND t.due_date < ? AND t.status <> 'DONE'",
+        tenantId,
+        userId,
+        userId,
+        today);
+
+    // B-1: 関係者一覧(native JOIN users x2)
+    explain(
+        "B-1 GET /api/tasks/{id}/stakeholders (native JOIN)",
+        "EXPLAIN SELECT ts.user_id, u.full_name, u.email, ts.added_by, ab.full_name, ts.added_at"
+            + " FROM task_stakeholders ts"
+            + " JOIN users u ON ts.user_id = u.id"
+            + " JOIN users ab ON ts.added_by = ab.id"
+            + " WHERE ts.task_id = ? AND ts.tenant_id = ?"
+            + " ORDER BY ts.added_at ASC",
+        stakeholderTaskId,
+        tenantId);
+
+    // C-1: dashboard overdue
+    explain(
+        "C-1 GET /api/dashboard/tasks findOverdue",
+        "EXPLAIN SELECT t.id FROM tasks t"
+            + " WHERE t.tenant_id = ? AND t.deleted_at IS NULL"
+            + " AND (t.owner_id = ? OR t.assignee_id = ?) AND t.due_date < ? AND t.status <> 'DONE'"
+            + " ORDER BY t.due_date ASC",
+        tenantId,
+        userId,
+        userId,
+        today);
+
+    // C-2: dashboard today
+    explain(
+        "C-2 GET /api/dashboard/tasks findToday",
+        "EXPLAIN SELECT t.id FROM tasks t"
+            + " WHERE t.tenant_id = ? AND t.deleted_at IS NULL"
+            + " AND (t.owner_id = ? OR t.assignee_id = ?) AND t.due_date = ?",
+        tenantId,
+        userId,
+        userId,
+        today);
+
+    // C-3: dashboard upcoming
+    explain(
+        "C-3 GET /api/dashboard/tasks findUpcoming",
+        "EXPLAIN SELECT t.id FROM tasks t"
+            + " WHERE t.tenant_id = ? AND t.deleted_at IS NULL"
+            + " AND (t.owner_id = ? OR t.assignee_id = ?)"
+            + " AND t.due_date > ? AND t.due_date <= ? AND t.status <> 'DONE'"
+            + " ORDER BY t.due_date ASC",
+        tenantId,
+        userId,
+        userId,
+        today,
+        upper);
+
+    // C-4: dashboard completedToday
+    explain(
+        "C-4 GET /api/dashboard/tasks findCompletedToday",
+        "EXPLAIN SELECT t.id FROM tasks t"
+            + " WHERE t.tenant_id = ? AND t.deleted_at IS NULL"
+            + " AND (t.owner_id = ? OR t.assignee_id = ?)"
+            + " AND t.status = 'DONE' AND t.completed_at >= ? AND t.completed_at < ?"
+            + " ORDER BY t.completed_at DESC",
+        tenantId,
+        userId,
+        userId,
+        dayStart,
+        dayEnd);
+
+    // D-1: dashboard summary(EXISTS 相関サブクエリ)
+    explain(
+        "D-1 GET /api/dashboard/summary findVisibleSummaryRows",
+        "EXPLAIN SELECT t.status, t.priority, t.due_date, t.completed_at, t.owner_id FROM tasks t"
+            + " WHERE t.tenant_id = ? AND t.deleted_at IS NULL"
+            + " AND (t.visibility = 'TENANT' OR t.owner_id = ? OR t.assignee_id = ?"
+            + "   OR (t.visibility = 'STAKEHOLDERS' AND EXISTS ("
+            + "     SELECT 1 FROM task_stakeholders s"
+            + "     WHERE s.task_id = t.id AND s.user_id = ? AND s.tenant_id = ?)))",
+        tenantId,
+        userId,
+        userId,
+        userId,
+        tenantId);
+
+    // D-2: tenant dashboard summary
+    explain(
+        "D-2 GET /api/tenant/dashboard/summary findTenantVisibleSummaryRows",
+        "EXPLAIN SELECT t.status, t.priority, t.due_date, t.completed_at, t.owner_id FROM tasks t"
+            + " WHERE t.tenant_id = ? AND t.deleted_at IS NULL"
+            + " AND t.visibility IN ('TENANT','STAKEHOLDERS')",
+        tenantId);
+
+    // D-3: countActiveMembers(native)
+    explain(
+        "D-3 GET /api/tenant/dashboard/summary countActiveMembers",
+        "EXPLAIN SELECT COUNT(*) FROM user_tenants WHERE tenant_id = ? AND status = 'ACTIVE'",
+        tenantId);
+
+    // E-1: テナントユーザー一覧(derived, ORDER BY joined_at)
+    explain(
+        "E-1 GET /api/tenant/users findByIdTenantIdOrderByJoinedAtAsc",
+        "EXPLAIN SELECT ut.user_id, ut.tenant_id, ut.role, ut.status, ut.joined_at"
+            + " FROM user_tenants ut WHERE ut.tenant_id = ? ORDER BY ut.joined_at ASC",
+        tenantId);
+
+    // F-1: 管理者テナント一覧(status + name LIKE、小テーブル)
+    explain(
+        "F-1 GET /api/tenants findAllFiltered (status + name LIKE %kw%)",
+        "EXPLAIN SELECT t.id, t.code, t.name, t.status FROM tenants t"
+            + " WHERE (t.status = 'ACTIVE') AND (t.name LIKE '%計測%')"
+            + " ORDER BY t.id DESC LIMIT 20",
+        new Object[0]);
+
+    // F-2: テナント別タスク件数集計(native, IN batch)
+    explain(
+        "F-2 GET /api/tenants countTasksByTenantIds",
+        "EXPLAIN SELECT tenant_id, COUNT(*) FROM tasks"
+            + " WHERE tenant_id IN (?) AND deleted_at IS NULL GROUP BY tenant_id",
+        tenantId);
+  }
+
+  private void insertMembership(Long user, Long tenant) {
+    em.createNativeQuery(
+            "INSERT INTO user_tenants (user_id, tenant_id, role, status, joined_at) VALUES (?,?,?,?,?)")
+        .setParameter(1, user)
+        .setParameter(2, tenant)
+        .setParameter(3, "MEMBER")
+        .setParameter(4, "ACTIVE")
+        .setParameter(5, LocalDateTime.of(2026, 1, 1, 0, 0))
+        .executeUpdate();
+  }
+
+  private void insertStakeholder(Long taskId, Long user, Long tenant, Long addedBy) {
+    em.createNativeQuery(
+            "INSERT IGNORE INTO task_stakeholders (task_id, user_id, tenant_id, added_by, added_at)"
+                + " VALUES (?,?,?,?,?)")
+        .setParameter(1, taskId)
+        .setParameter(2, user)
+        .setParameter(3, tenant)
+        .setParameter(4, addedBy)
+        .setParameter(5, LocalDateTime.of(2026, 1, 1, 0, 0))
+        .executeUpdate();
+  }
+
+  private void explain(String label, String sql, Object... params) {
+    var q = em.createNativeQuery(sql);
+    for (int i = 0; i < params.length; i++) {
+      q.setParameter(i + 1, params[i]);
+    }
+    @SuppressWarnings("unchecked")
+    List<Object[]> rows = q.getResultList();
+    System.out.println("\n[EXPLAIN] " + label);
+    for (Object[] row : rows) {
+      // MySQL EXPLAIN cols: 0 id,1 select_type,2 table,3 partitions,4 type,5 possible_keys,
+      //                     6 key,7 key_len,8 ref,9 rows,10 filtered,11 Extra
+      System.out.printf(
+          "  select_type=%-12s table=%-18s type=%-8s key=%-26s rows=%-6s filtered=%-6s Extra=%s%n",
+          str(row[1]),
+          str(row[2]),
+          str(row[4]),
+          str(row[6]),
+          str(row[9]),
+          str(row[10]),
+          str(row[11]));
+    }
+  }
+
+  private String str(Object o) {
+    return o == null ? "NULL" : String.valueOf(o);
+  }
+}


### PR DESCRIPTION
## 概要

Issue #769(性能チューニング)/ ADR-0039 の **最終 PR**。PR #837(N+1 回帰固定ハーネス、`Refs #769`)に続き、主要 endpoint 代表クエリの index `EXPLAIN` 所見を記録する。

ADR-0039 §6 は PR②(index 所見 + 必要な Flyway 追加)と PR③(所見メモ docs)を分けているが、**EXPLAIN の結果スキーマ変更(index 追加)が不要と判明した**ため、両者を 1 つの文書 PR に集約した(ADR-0039 §4 の「スコープは所見記録 + 重大事象の是正」に沿う)。

## 変更

- `webapi/src/test/java/.../perf/IndexExplainMeasurementIT.java`(`@Disabled` 手動計測): 認可述語つきタスク一覧 / 関係者 native JOIN / ダッシュボード4セクション / 2 summary / テナントユーザー / 管理者テナント一覧を、Hibernate Filter が注入する `tenant_id = ?` を明示した native SQL で `EXPLAIN`。**他テナントにも実データを積み**マルチテナント実配分(対象 ≒ 全体の 2〜3%)を再現する
- `docs/reviews/2026-07-03-adr0039-performance-findings.md`: 所見メモ(N+1 回帰固定 + index EXPLAIN + record-only + リリース前チェックリスト #770 引き継ぎ)

## 主な所見

- **マルチテナント実配分では `tasks` へのフルスキャン(`type=ALL`)は発生せず**、いずれも `tenant_id` 先頭複合 index(`idx_tasks_tenant_*`)または index_merge を使用。
- **落とし穴**: 全行を 1 テナントに偏らせて seed すると `tenant_id` が非選択的になり見かけ上 `type=ALL` になる(計測ボリューム由来、index 不足ではない)。他テナントにも実データを積むと `type=ref` に変わることを実測(所見メモ §3.1)。
- 残る `type=ALL` は小テーブル `user_tenants` のみで実害なし。
- → **新規 index 追加なし・Flyway migration なし**。keyword `LIKE '%kw%'` は index 不可のため所見記録のみ(別 Issue 候補、ADR-0039 §5)。

## 検証

- 計測 IT を手動実行(`@Disabled` を一時的に外して)し、単一テナント偏在 → マルチテナント実配分で全 `tasks` クエリが `ALL → ref/range/index_merge` に変わることを実 MySQL 8.4 で確認。
- `@Disabled` のため CI では実行されない(`:webapi:check` に影響なし)。spotless / compileTestJava green。

## #769 受け入れ条件

- [x] 主要 endpoint の測定結果を記録(所見メモ §3)
- [x] N+1 を回帰テストで固定(PR #837)
- [x] index レビュー実施、必要な Flyway 追加(→ 不要と判断)
- [x] 所見メモを docs に残す、CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)