### PR TITLE
test(e2e): dev-smoke ブラウザ E2E(login/SPI・タスク journey・login テーマ) (Refs #843)

### DIFF
--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -8,13 +8,342 @@
       "name": "tasks-e2e",
       "version": "1.0.0",
       "devDependencies": {
+        "@aws-sdk/client-s3": "^3.700.0",
         "@biomejs/biome": "^2.4.16",
         "@playwright/test": "^1.61.0",
+        "@types/mailparser": "^3.4.5",
         "@types/node": "^24.13.2",
+        "mailparser": "^3.7.1",
         "typescript": "^5.8.0"
       },
       "engines": {
         "node": ">=24"
+      }
+    },
+    "node_modules/@aws-sdk/checksums": {
+      "version": "3.1000.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.12.tgz",
+      "integrity": "sha512-RgNDWfhNRIlNEzePIRrYTNi/6q+wwRMMapojn8YVzw4ZcJRa/gxVMtUbeZARR1gmopuv6oIhMbY7J66qIQ0ynw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.27",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.1079.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1079.0.tgz",
+      "integrity": "sha512-di9U/7Po7qlVYb2dq58ULsbBAE1pBIk53rux+50LQCvH1X+/l1Ys+BIk/QLBtdaK1nADk0xRNEBbA1QWVnMccw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/checksums": "^3.1000.12",
+        "@aws-sdk/core": "^3.974.27",
+        "@aws-sdk/credential-provider-node": "^3.972.62",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.58",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.38",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/fetch-http-handler": "^5.6.2",
+        "@smithy/node-http-handler": "^4.9.2",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.974.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.27.tgz",
+      "integrity": "sha512-WRWEgIq6vx+NU6ot3VrRu4Jovj9MIObitSi6of/GV5THDDPccBhivCRNkWJutMM+m3GvdeI3l/UbGNcoOobxOA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.15",
+        "@aws-sdk/xml-builder": "^3.972.33",
+        "@aws/lambda-invoke-store": "^0.3.0",
+        "@smithy/core": "^3.29.0",
+        "@smithy/signature-v4": "^5.6.1",
+        "@smithy/types": "^4.15.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.53",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.53.tgz",
+      "integrity": "sha512-+KDA3uc/HZ1vIneGu5QMQb0gAXDYrm2vOE60+BJ7lS0YinMQ5i2oV4PR1A16XkF6K1IbSwjEHd1hQIIgMsK48w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.27",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.55",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.55.tgz",
+      "integrity": "sha512-1gBfkWY3RWeBlCoB9lIJjXMx45/54wxcgfzv6BY9otTmMrZPcNPi1v+MwZxxaCUg441NV3jsr1efnFNCXiW70g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.27",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/fetch-http-handler": "^5.6.2",
+        "@smithy/node-http-handler": "^4.9.2",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.60",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.60.tgz",
+      "integrity": "sha512-CV2md+PXvABwRjApWGhQ0wACy9WSFIhnUGrovLcjnjBCd/46TbuivLADtkF8IWNjtCQmQ+2IagSaxqBYqXBNAQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.27",
+        "@aws-sdk/credential-provider-env": "^3.972.53",
+        "@aws-sdk/credential-provider-http": "^3.972.55",
+        "@aws-sdk/credential-provider-login": "^3.972.59",
+        "@aws-sdk/credential-provider-process": "^3.972.53",
+        "@aws-sdk/credential-provider-sso": "^3.972.59",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.59",
+        "@aws-sdk/nested-clients": "^3.997.27",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/credential-provider-imds": "^4.4.5",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.59",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.59.tgz",
+      "integrity": "sha512-JG4S9yyA1GFzJdJXqLKrUzZbyK+VDp2QIsJD7YOicJHAhqymfHpDJIok2dLnhOdVB0I37RjdC53uOwCMVS00gw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.27",
+        "@aws-sdk/nested-clients": "^3.997.27",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.62",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.62.tgz",
+      "integrity": "sha512-S6Slq3Tx7bvFk5yc34XNADyZYTX2HUXvaFAnowGRQnhjBO8J/mP62Fn7lxvJwjaDyYm/7gh9h6HEHaltRyMFXw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.53",
+        "@aws-sdk/credential-provider-http": "^3.972.55",
+        "@aws-sdk/credential-provider-ini": "^3.972.60",
+        "@aws-sdk/credential-provider-process": "^3.972.53",
+        "@aws-sdk/credential-provider-sso": "^3.972.59",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.59",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/credential-provider-imds": "^4.4.5",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.53",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.53.tgz",
+      "integrity": "sha512-EhfH+MQlqOMCkXIVa8MMObPzAQqwTTtxA7KhEJiyPeuNVA8PLOOUpgK7nBrgaDaGiIDLN/9LpGdaHuDjomeRTw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.27",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.59",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.59.tgz",
+      "integrity": "sha512-h8793pOjcImx0SB+VcLONcaQQ57VAvKVuqyewQMRKqqH+CSXsG2dwOeLMUJPMxLdNvL7dXOM0ueTukyNUnu5mA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.27",
+        "@aws-sdk/nested-clients": "^3.997.27",
+        "@aws-sdk/token-providers": "3.1079.0",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.59",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.59.tgz",
+      "integrity": "sha512-VoyO9+vl3XVmpZwn4obskrWIkrA/Jf3lSe1E3ZERlaN9u0D4YZ6+HywC3+L98QOXqZesEfedk67gRER8tK8+8w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.27",
+        "@aws-sdk/nested-clients": "^3.997.27",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.972.58",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.58.tgz",
+      "integrity": "sha512-6uaWRRYJGhOqc9EoTSbLDf9nI/doSAb5vAwGshs5/Hlv5Ce25b246lBkbRd/77fLAi+uMI1a70mJzVyLyCEufQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.27",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.38",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.27.tgz",
+      "integrity": "sha512-A8PIePF9NIIOJ/4Lg1rl9xm/+QaKkHGetq+Z9wb5B+3Da31YYXRo8n7IDMh5C+HQI5eyEmjrwkGWVdYtnLtbXQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.27",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.38",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/fetch-http-handler": "^5.6.2",
+        "@smithy/node-http-handler": "^4.9.2",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.38.tgz",
+      "integrity": "sha512-C379Sk+MiFZCfWZphKlMyLHKxV22OjoGM5KJjj5IJNJcOCWL4IGIpnEGzv1FQiRwhYXfq55SJMfxlqPE08JJ9g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/signature-v4": "^5.6.1",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1079.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1079.0.tgz",
+      "integrity": "sha512-cbietrLlHPhhmbnMPTuDS4Zj/KNGhY+3vVhn6dwjO6Dqzrwothzg2srtcY34T9mlICsTXn34avDoWLHSntP54A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.27",
+        "@aws-sdk/nested-clients": "^3.997.27",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.973.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.15.tgz",
+      "integrity": "sha512-IULn8uBV/SMtmOIANsm4WHXIOtVPBWfOWs3WGL0j/sI+KhaYehvOw0ET+9urnn8MBpiijuU/0JOpuwKOE451PQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.33",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.33.tgz",
+      "integrity": "sha512-ezbwz9WpuLctm6o7P2t2naDhVVPI5jFGrVefVybhcKGjU57VIyT46pQVO0RI2RYkUdhdj2Z9uSIlAzGZE9NW9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+      "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@biomejs/biome": {
@@ -208,6 +537,121 @@
         "node": ">=18"
       }
     },
+    "node_modules/@selderee/plugin-htmlparser2": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@selderee/plugin-htmlparser2/-/plugin-htmlparser2-0.12.0.tgz",
+      "integrity": "sha512-oELmoyA6ML9jDRMV3kgcMQFKxUfBU0yFVn6yTctVaLT5ygXnxH52I3TZEgV9EhXJC68/uFvE5Daj1/25c0Xa/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "~2.3.0",
+        "domhandler": "~5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/KillyMXI"
+      },
+      "peerDependencies": {
+        "selderee": "~0.12.0"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.29.1",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.1.tgz",
+      "integrity": "sha512-qoiY4nrk5OCu1+eIR1VB8l5DmON/oKiqrd5zZFAhXJXjJlLWQusKEW/SkBDAtGDcPaz86m9kfcE1lngU0GlM6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.4.6",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.6.tgz",
+      "integrity": "sha512-B2WQ/PV/H6Jeg3lrIq6bKUfa6Hy01mtK7CGs6lhjzHA6k4aagldH6T6eEjnzKl4HI0cJnAsxfJ19pgb5PV+CVQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.1",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.3.tgz",
+      "integrity": "sha512-CwCc/7SMTj45y97MUnDTbTaxvtAsiNNRm81z3abROIuMbMsC2Iy5EKfkkVdsKrz8WExQAAMx1EJapq+9j4fFTQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.1",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.9.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.3.tgz",
+      "integrity": "sha512-qZTa4gQFUo8RM02rk6q5UVTDLNrQ1oS20LsepBzqq1QBVc/EHJ03OOUADcqMZiXHArW+Y7+OGY0BpdTwZRq/Yg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.1",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.2.tgz",
+      "integrity": "sha512-QgHflghMoPxCJ9axiCVh8KZfbC9fuP6vkXXyK//E3cq7nLaSSyyLj0GAoqVWezYeDQmXIZhmlRvLE16jsqDK6g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.1",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.15.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.1.tgz",
+      "integrity": "sha512-x3L0XSACF6UYzKpa9biqiRMgvH5+wnFFew9Tm/grFYqgaupPwx/+ojDPpPJM8dZON3S9tjz5U+PQYsCBd1Mw5Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@types/mailparser": {
+      "version": "3.4.6",
+      "resolved": "https://registry.npmjs.org/@types/mailparser/-/mailparser-3.4.6.tgz",
+      "integrity": "sha512-wVV3cnIKzxTffaPH8iRnddX1zahbYB1ZEoAxyhoBo3TBCBuK6nZ8M8JYO/RhsCuuBVOw/DEN/t/ENbruwlxn6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "iconv-lite": "^0.6.3"
+      }
+    },
     "node_modules/@types/node": {
       "version": "24.13.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
@@ -216,6 +660,117 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@zone-eu/mailsplit": {
+      "version": "5.4.13",
+      "resolved": "https://registry.npmjs.org/@zone-eu/mailsplit/-/mailsplit-5.4.13.tgz",
+      "integrity": "sha512-j40NeNlSAivqnKEjzZYsGP/bKWr2zwuyb8XOYsC3i0ZlfM5UnTYTa7aCRkE8rYQvVzE1dRjVYdvZ1Epi6x+h6w==",
+      "dev": true,
+      "license": "(MIT OR EUPL-1.1+)",
+      "dependencies": {
+        "libbase64": "1.3.0",
+        "libmime": "5.4.0",
+        "libqp": "2.1.1"
+      }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/deepmerge-ts": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
+      "integrity": "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/encoding-japanese": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/encoding-japanese/-/encoding-japanese-2.2.0.tgz",
+      "integrity": "sha512-EuJWwlHPZ1LbADuKTClvHtwbaFn4rOD+dRAbWysqEOXRc2Uui0hJInNJrsdH0c+OhJA4nrCBdSkW4DD5YxAo6A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/fsevents": {
@@ -231,6 +786,226 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
+    "node_modules/html-to-text": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-10.0.0.tgz",
+      "integrity": "sha512-2OH59Gtprdczel+7Rxgpz9hGVJREaf8Lt1H4kZwWHpEn70VQKRuMNGsb2eDbwaTzrYzb0hheiOG1P7Dim0B4dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@selderee/plugin-htmlparser2": "~0.12.0",
+        "deepmerge-ts": "^7.1.5",
+        "dom-serializer": "^2.0.0",
+        "htmlparser2": "^10.1.0",
+        "selderee": "~0.12.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/KillyMXI"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/leac": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/leac/-/leac-0.7.0.tgz",
+      "integrity": "sha512-qMrZeyEekgdRQ9o6a4NAB2EQZrv827GJdn1vnapwSJ90hWRB4TzUSunvacPkxQ2TnNqHNI1/zSt0hlo0crG8Jw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/KillyMXI"
+      }
+    },
+    "node_modules/libbase64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/libbase64/-/libbase64-1.3.0.tgz",
+      "integrity": "sha512-GgOXd0Eo6phYgh0DJtjQ2tO8dc0IVINtZJeARPeiIJqge+HdsWSuaDTe8ztQ7j/cONByDZ3zeB325AHiv5O0dg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/libmime": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/libmime/-/libmime-5.4.0.tgz",
+      "integrity": "sha512-MAWyU2qYtCsrZ6GClgukz2jx73NQrzA6ASo9qzThuTG+A7+H3lWQuBsjoy9lls+v6q/epAeBdEMJ3T0f4b+uRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "encoding-japanese": "2.2.0",
+        "iconv-lite": "0.7.2",
+        "libbase64": "1.3.0",
+        "libqp": "2.1.1"
+      }
+    },
+    "node_modules/libmime/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/libqp": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/libqp/-/libqp-2.1.1.tgz",
+      "integrity": "sha512-0Wd+GPz1O134cP62YU2GTOPNA7Qgl09XwCqM5zpBv87ERCXdfDtyKXvV7c9U22yWJh44QZqBocFnXN11K96qow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/linkify-it": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
+      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
+    "node_modules/mailparser": {
+      "version": "3.9.12",
+      "resolved": "https://registry.npmjs.org/mailparser/-/mailparser-3.9.12.tgz",
+      "integrity": "sha512-kbT4xtkKEddonhDTjjWWVFJlI5axm0S9QuIAHs1ue3IEw+fNd9o4ytPKaG7p1LOE2aKifrWLjx/omOGLHz/9RQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@zone-eu/mailsplit": "5.4.13",
+        "encoding-japanese": "2.2.0",
+        "he": "1.2.0",
+        "html-to-text": "10.0.0",
+        "iconv-lite": "0.7.2",
+        "libmime": "5.4.0",
+        "linkify-it": "5.0.1",
+        "nodemailer": "9.0.1",
+        "punycode.js": "2.3.1",
+        "tlds": "1.261.0"
+      }
+    },
+    "node_modules/mailparser/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.0.1.tgz",
+      "integrity": "sha512-Gwv8SQewT616ZM/URn0H54b8PWo/Wum7md3EW2aWy1lO27+WZCX+Xyak3J+NlmHUjDh5ME+uesJUDRbR3Ye8Bw==",
+      "dev": true,
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/parseley": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/parseley/-/parseley-0.13.1.tgz",
+      "integrity": "sha512-uNBJZzmb60l6p6VWLTmevizNAGnE0xoSf1n0B4q3ntegDNzcS68NRCcBDZTcyXHxt2XhBChsCuqj4M+nChvE/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "leac": "^0.7.0",
+        "peberminta": "^0.10.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/KillyMXI"
+      }
+    },
+    "node_modules/peberminta": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/peberminta/-/peberminta-0.10.0.tgz",
+      "integrity": "sha512-80B2AsU+I4Qdb0ZAPSfe9UwvGzwkM37IKIFEvdS3D/3Ndgv2bsuJ0bfG1+iEYO+l7Gfd4EUJmuRyq7efLgRMzQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/KillyMXI"
       }
     },
     "node_modules/playwright": {
@@ -265,6 +1040,53 @@
         "node": ">=18"
       }
     },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/selderee": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/selderee/-/selderee-0.12.0.tgz",
+      "integrity": "sha512-b1YMh3+DHZp59DLna3qVwQ5iOla/nrI6mLBNW02XxU77M3046Df6VLkoaJyFz20VsGIG5kkp+FK0kg4K4HnUFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parseley": "~0.13.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/KillyMXI"
+      }
+    },
+    "node_modules/tlds": {
+      "version": "1.261.0",
+      "resolved": "https://registry.npmjs.org/tlds/-/tlds-1.261.0.tgz",
+      "integrity": "sha512-QXqwfEl9ddlGBaRFXIvNKK6OhipSiLXuRuLJX5DErz0o0Q0rYxulWLdFryTkV5PkdZct5iMInwYEGe/eR++1AA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tlds": "bin.js"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -278,6 +1100,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "7.18.2",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "playwright test",
     "test:headed": "playwright test --headed",
+    "test:dev-smoke": "playwright test -c playwright.dev-smoke.config.ts",
     "report": "playwright show-report"
   },
   "engines": {

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -13,9 +13,12 @@
     "node": ">=24"
   },
   "devDependencies": {
+    "@aws-sdk/client-s3": "^3.700.0",
     "@biomejs/biome": "^2.4.16",
     "@playwright/test": "^1.61.0",
+    "@types/mailparser": "^3.4.5",
     "@types/node": "^24.13.2",
+    "mailparser": "^3.7.1",
     "typescript": "^5.8.0"
   }
 }

--- a/e2e/playwright.dev-smoke.config.ts
+++ b/e2e/playwright.dev-smoke.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * dev post-deploy smoke(ADR-0041 / #843)専用 Playwright 設定。
+ *
+ * 既存の hermetic スイート(`./tests`、ローカル compose 前提)とは完全分離し、`./tests-dev` を
+ * live dev 環境に対して実行する。SPA は hostname から Keycloak/API オリジンを導出するため、
+ * `BASE_URL` を dev SPA に向けるだけで auth-dev / api-dev も自動で使われる。
+ */
+export default defineConfig({
+  testDir: './tests-dev',
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  // live 環境は伝播やコールドスタートで揺れるため CI では 2 回まで再試行
+  retries: process.env.CI ? 2 : 1,
+  workers: 1,
+  reporter: [['html', { open: 'never' }], ['list']],
+  // 実 Keycloak ログイン往復 + native コールドスタートを考慮し余裕を持たせる
+  timeout: 60_000,
+  expect: { timeout: 15_000 },
+  use: {
+    baseURL: process.env.BASE_URL ?? 'https://tasks-dev.dgz48.xyz',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+});

--- a/e2e/tests-dev/api-invariants.dev-smoke.spec.ts
+++ b/e2e/tests-dev/api-invariants.dev-smoke.spec.ts
@@ -1,0 +1,23 @@
+import { expect, test } from '@playwright/test';
+import { API_BASE, getAccessToken } from './support/api';
+import { DEV_MEMBER } from './support/dev-auth';
+
+/**
+ * dev-smoke: UI から踏めない API 不変条件(NIST)を薄く補完(ADR-0041 / #843)。
+ *
+ * 正しく作られた UI は越境リクエストや無認証リクエストを送らないため、これらは API を直接叩かないと固定できない。
+ */
+test.describe('dev-smoke: API invariants (NIST)', { tag: '@dev-smoke' }, () => {
+  test('未認証リクエストは 401', async ({ request }) => {
+    const res = await request.get(`${API_BASE}/api/tasks`, { headers: { 'X-Tenant-Id': '1' } });
+    expect(res.status()).toBe(401);
+  });
+
+  test('非メンバーのテナント指定は拒否される(403/404、存在を漏らさない)', async ({ request }) => {
+    const token = await getAccessToken(request, DEV_MEMBER.username, DEV_MEMBER.password);
+    const res = await request.get(`${API_BASE}/api/tasks`, {
+      headers: { Authorization: `Bearer ${token}`, 'X-Tenant-Id': '999999' },
+    });
+    expect([403, 404]).toContain(res.status());
+  });
+});

--- a/e2e/tests-dev/api-invariants.dev-smoke.spec.ts
+++ b/e2e/tests-dev/api-invariants.dev-smoke.spec.ts
@@ -13,11 +13,15 @@ test.describe('dev-smoke: API invariants (NIST)', { tag: '@dev-smoke' }, () => {
     expect(res.status()).toBe(401);
   });
 
-  test('非メンバーのテナント指定は拒否される(403/404、存在を漏らさない)', async ({ request }) => {
+  test('非メンバーのテナント指定は 403(TenantContextFilter 境界、認可マトリクス §4.1)', async ({
+    request,
+  }) => {
     const token = await getAccessToken(request, DEV_MEMBER.username, DEV_MEMBER.password);
     const res = await request.get(`${API_BASE}/api/tasks`, {
       headers: { Authorization: `Bearer ${token}`, 'X-Tenant-Id': '999999' },
     });
-    expect([403, 404]).toContain(res.status());
+    // 非所属テナント指定は TenantContextFilter が 403 で弾く(SSOT: 認可マトリクス §4.1/§5.1)。
+    // 404 は task 単位 Hibernate Filter 到達後の別シナリオであり、ここで許容すると境界層の regression を見逃す。
+    expect(res.status()).toBe(403);
   });
 });

--- a/e2e/tests-dev/login-dashboard.dev-smoke.spec.ts
+++ b/e2e/tests-dev/login-dashboard.dev-smoke.spec.ts
@@ -1,0 +1,24 @@
+import { expect, test } from '@playwright/test';
+import { DEV_MEMBER, devLogin, devLogout } from './support/dev-auth';
+
+/**
+ * dev-smoke: ログイン(OIDC 認可コード + PKCE = カスタム User Storage SPI を dev 実機で通す)→
+ * ダッシュボード表示 → ログアウト。native コールドスタート + SPI federation の到達性を担保する。
+ */
+test.describe('dev-smoke: login & dashboard', { tag: '@dev-smoke' }, () => {
+  test('member がログインしてダッシュボードが表示される', async ({ page }) => {
+    await devLogin(page, DEV_MEMBER.username, DEV_MEMBER.password);
+
+    // ダッシュボードのコンテンツと 4 枚の数値カードが描画される(裏で GET /api/dashboard/* が成功)
+    await expect(page.locator('#content')).toBeVisible();
+    await expect(page.locator('#card-today-due')).toBeVisible();
+    await expect(page.locator('#card-overdue')).toBeVisible();
+    await expect(page.locator('#card-completed-today')).toBeVisible();
+    await expect(page.locator('#card-my-open')).toBeVisible();
+
+    // ナビにユーザー名が出る(GET /api/auth/me = SPI 経由のユーザー解決が成功)
+    await expect(page.locator('#nav-username')).not.toBeEmpty();
+
+    await devLogout(page);
+  });
+});

--- a/e2e/tests-dev/login-theme.dev-smoke.spec.ts
+++ b/e2e/tests-dev/login-theme.dev-smoke.spec.ts
@@ -1,0 +1,23 @@
+import { expect, test } from '@playwright/test';
+
+/**
+ * dev-smoke: Keycloak ログイン画面(auth-dev)に tasks-login テーマの「新規登録」リンクが描画される。
+ *
+ * signup-link.js はホストが `auth(-env).dgz48.xyz` のときだけリンクを注入するため、これは **dev 実機でしか
+ * 検証できない**(localhost では描画されない)。テーマ配備 + サインアップ導線の到達性を担保する。
+ */
+test.describe('dev-smoke: login theme signup link', { tag: '@dev-smoke' }, () => {
+  test('ログイン画面に新規登録リンクが表示され signup.html を指す', async ({ page }) => {
+    // SPA を開くと Keycloak(auth-dev)ログイン画面へリダイレクトされる
+    await page.goto('/');
+    await page.waitForURL(/\/realms\/tasks\//, { timeout: 30_000 });
+
+    const signupLink = page.locator('#tasks-signup-link a');
+    await expect(signupLink).toBeVisible();
+    await expect(signupLink).toHaveText('新規登録');
+    await expect(signupLink).toHaveAttribute(
+      'href',
+      /https:\/\/tasks(-\w+)?\.dgz48\.xyz\/signup\.html$/,
+    );
+  });
+});

--- a/e2e/tests-dev/signup-email.dev-smoke.spec.ts
+++ b/e2e/tests-dev/signup-email.dev-smoke.spec.ts
@@ -1,20 +1,36 @@
 import { expect, test } from '@playwright/test';
+import { devLogin } from './support/dev-auth';
+import { deleteKeycloakUserByEmail } from './support/keycloak-admin';
 import { uniqueRecipient, waitForEmailTo } from './support/mail';
 
 /**
- * dev-smoke: セルフサインアップ double opt-in の **実配信メール**検証(ADR-0041 / #843)。
+ * dev-smoke: セルフサインアップ double opt-in の **フルフロー**検証(ADR-0041 §6 / #843)。
  *
- * signup.html で一意アドレス(`signup-<uuid>@e2e.dgz48.xyz`)を送信 → アプリが実 SES で確認メールを送出 →
- * SES email receiving が S3 に格納 → テストが S3 から取得しリンク/トークンを抽出 → 確認リンクを開いて
- * トークンが有効(signup-complete が表示)であることを確認する。SES 受信基盤(#845)の疎通を通しで担保。
+ * signup.html で一意アドレス(`signup-<uuid>@e2e.dgz48.xyz`)を送信 → アプリが実 SES で確認メール送出 →
+ * SES email receiving が S3 へ格納 → テストが S3 から取得しリンク/トークンを抽出 → 確認リンクを開いて
+ * complete(ユーザー作成 + Keycloak 資格プロビジョニング)→ 作成ユーザーでログイン到達まで確認する。
+ * #845(受信)+ #854(送信 env/IAM)+ native への SES 焼込 を通しで担保する。
  *
- * データ汚染を避けるため complete(ユーザー作成)は行わず、トークン有効性の確認までに留める。
+ * データ汚染対策(ADR-0041 決定5): afterEach で作成した Keycloak ユーザーを Admin API で削除する。
+ * 注: アプリ `users` 行は物理削除 API 未提供(MVP・#167)かつ dev RDS 非公開のため E2E から削除できず、
+ * ログイン不能な inert 孤児として残る(一意メールゆえ衝突なし)。#167 実装時に恒久クリーンアップへ移行。
  */
 test.describe('dev-smoke: signup email (double opt-in)', { tag: '@dev-smoke' }, () => {
-  test('確認メールが実配信され、確認リンクのトークンが有効', async ({ page }) => {
-    // メール実配信 + S3 受信ポーリングのため、既定 60s ではなくテスト単位で延長する。
+  const PASSWORD = 'DevSmoke!Pw12345';
+  let createdEmail: string | undefined;
+
+  test.afterEach(async ({ request }) => {
+    if (createdEmail) {
+      await deleteKeycloakUserByEmail(request, createdEmail);
+      createdEmail = undefined;
+    }
+  });
+
+  test('確認メール実配信 → complete → 作成ユーザーでログインできる', async ({ page }) => {
+    // メール実配信 + S3 受信ポーリング + ログイン往復のため、既定 60s ではなくテスト単位で延長する。
     test.setTimeout(180_000);
     const recipient = uniqueRecipient('signup');
+    createdEmail = recipient; // complete 前でも afterEach が掃除できるよう先に記録
 
     // --- サインアップ要求(signup.html UI → POST /api/signup/request)---
     await page.goto('/signup.html');
@@ -22,20 +38,27 @@ test.describe('dev-smoke: signup email (double opt-in)', { tag: '@dev-smoke' }, 
     await page.click('#btn-request');
     await expect(page.locator('#sent-notice')).toBeVisible();
 
-    // --- 実配信メールを S3(SES 受信)から取得 ---
+    // --- 実配信メールを S3(SES 受信)から取得し確認リンクを抽出 ---
     const mail = await waitForEmailTo(recipient, { timeoutMs: 120_000 });
-    expect(mail.subject.length).toBeGreaterThan(0);
-
-    // --- 確認リンク(signup-complete.html?token=...)を抽出 ---
     const confirmUrl = mail.links.find(
       (u) => u.includes('signup-complete.html') && u.includes('token='),
     );
     expect(confirmUrl, `確認リンクがメールに見つからない: ${mail.links.join(', ')}`).toBeDefined();
 
-    // --- 確認リンクを開く → GET /api/signup/{token} が pending を返しトークン有効(complete フォーム表示)---
+    // --- 確認リンクを開く → complete フォーム(トークン有効・email エコー)---
     await page.goto(confirmUrl as string);
     await expect(page.locator('#complete-form')).toBeVisible();
-    // 宛先メールがフォームにエコーされる(トークンに紐づく email が解決できている)
     await expect(page.locator('#email-label')).toContainText(recipient);
+
+    // --- complete(POST /api/signup/{token}/complete = ユーザー作成 + 資格プロビジョニング)---
+    await page.fill('#full-name', 'devスモーク太郎');
+    await page.fill('#full-name-kana', 'デブスモークタロウ');
+    await page.fill('#password', PASSWORD);
+    await page.click('#btn-complete');
+    await expect(page.locator('#notice')).toBeVisible();
+
+    // --- 作成ユーザーでログイン到達(プロビジョニングされた資格が Keycloak/SPI で認証できる)---
+    await devLogin(page, recipient, PASSWORD);
+    await expect(page.locator('#content')).toBeVisible();
   });
 });

--- a/e2e/tests-dev/signup-email.dev-smoke.spec.ts
+++ b/e2e/tests-dev/signup-email.dev-smoke.spec.ts
@@ -11,8 +11,9 @@ import { uniqueRecipient, waitForEmailTo } from './support/mail';
  * データ汚染を避けるため complete(ユーザー作成)は行わず、トークン有効性の確認までに留める。
  */
 test.describe('dev-smoke: signup email (double opt-in)', { tag: '@dev-smoke' }, () => {
-  // メール実配信 + S3 受信ポーリングのため、既定 60s ではなくテスト単位で延長する。
-  test('確認メールが実配信され、確認リンクのトークンが有効', { timeout: 180_000 }, async ({ page }) => {
+  test('確認メールが実配信され、確認リンクのトークンが有効', async ({ page }) => {
+    // メール実配信 + S3 受信ポーリングのため、既定 60s ではなくテスト単位で延長する。
+    test.setTimeout(180_000);
     const recipient = uniqueRecipient('signup');
 
     // --- サインアップ要求(signup.html UI → POST /api/signup/request)---

--- a/e2e/tests-dev/signup-email.dev-smoke.spec.ts
+++ b/e2e/tests-dev/signup-email.dev-smoke.spec.ts
@@ -1,0 +1,40 @@
+import { expect, test } from '@playwright/test';
+import { uniqueRecipient, waitForEmailTo } from './support/mail';
+
+/**
+ * dev-smoke: セルフサインアップ double opt-in の **実配信メール**検証(ADR-0041 / #843)。
+ *
+ * signup.html で一意アドレス(`signup-<uuid>@e2e.dgz48.xyz`)を送信 → アプリが実 SES で確認メールを送出 →
+ * SES email receiving が S3 に格納 → テストが S3 から取得しリンク/トークンを抽出 → 確認リンクを開いて
+ * トークンが有効(signup-complete が表示)であることを確認する。SES 受信基盤(#845)の疎通を通しで担保。
+ *
+ * データ汚染を避けるため complete(ユーザー作成)は行わず、トークン有効性の確認までに留める。
+ */
+test.describe('dev-smoke: signup email (double opt-in)', { tag: '@dev-smoke' }, () => {
+  // メール実配信 + S3 受信ポーリングのため、既定 60s ではなくテスト単位で延長する。
+  test('確認メールが実配信され、確認リンクのトークンが有効', { timeout: 180_000 }, async ({ page }) => {
+    const recipient = uniqueRecipient('signup');
+
+    // --- サインアップ要求(signup.html UI → POST /api/signup/request)---
+    await page.goto('/signup.html');
+    await page.fill('#email', recipient);
+    await page.click('#btn-request');
+    await expect(page.locator('#sent-notice')).toBeVisible();
+
+    // --- 実配信メールを S3(SES 受信)から取得 ---
+    const mail = await waitForEmailTo(recipient, { timeoutMs: 120_000 });
+    expect(mail.subject.length).toBeGreaterThan(0);
+
+    // --- 確認リンク(signup-complete.html?token=...)を抽出 ---
+    const confirmUrl = mail.links.find(
+      (u) => u.includes('signup-complete.html') && u.includes('token='),
+    );
+    expect(confirmUrl, `確認リンクがメールに見つからない: ${mail.links.join(', ')}`).toBeDefined();
+
+    // --- 確認リンクを開く → GET /api/signup/{token} が pending を返しトークン有効(complete フォーム表示)---
+    await page.goto(confirmUrl as string);
+    await expect(page.locator('#complete-form')).toBeVisible();
+    // 宛先メールがフォームにエコーされる(トークンに紐づく email が解決できている)
+    await expect(page.locator('#email-label')).toContainText(recipient);
+  });
+});

--- a/e2e/tests-dev/signup-email.dev-smoke.spec.ts
+++ b/e2e/tests-dev/signup-email.dev-smoke.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { devLogin } from './support/dev-auth';
+import { devLoginNewMember } from './support/dev-auth';
 import { deleteKeycloakUserByEmail } from './support/keycloak-admin';
 import { uniqueRecipient, waitForEmailTo } from './support/mail';
 
@@ -58,7 +58,10 @@ test.describe('dev-smoke: signup email (double opt-in)', { tag: '@dev-smoke' }, 
     await expect(page.locator('#notice')).toBeVisible();
 
     // --- 作成ユーザーでログイン到達(プロビジョニングされた資格が Keycloak/SPI で認証できる)---
-    await devLogin(page, recipient, PASSWORD);
-    await expect(page.locator('#content')).toBeVisible();
+    // 登録直後はテナント未所属(ADR-0040 §3.5)。dashboard ではなく認証済み SPA(`/`)の
+    // 「テナント作成」導線に着地することを確認する(= ログイン成功 + oidc_sub correlation 成立)。
+    await devLoginNewMember(page, recipient, PASSWORD);
+    await expect(page.locator('#content-logged-in')).toBeVisible();
+    await expect(page.locator('#link-create-tenant')).toBeVisible();
   });
 });

--- a/e2e/tests-dev/support/api.ts
+++ b/e2e/tests-dev/support/api.ts
@@ -1,0 +1,30 @@
+import type { APIRequestContext } from '@playwright/test';
+
+/**
+ * dev-smoke の API 直叩き補完用ヘルパ(ADR-0041 / #843)。UI からは発生しない不変条件(NIST AC-4 の越境拒否・
+ * 認証境界)を検証するため、Keycloak の password grant でトークンを取り、api-dev を直接叩く。
+ */
+const AUTH_BASE = process.env.DEV_SMOKE_AUTH_URL ?? 'https://auth-dev.dgz48.xyz';
+export const API_BASE = process.env.DEV_SMOKE_API_URL ?? 'https://api-dev.tasks.dgz48.xyz';
+
+/** tasks-webapi public client の password grant でアクセストークンを取得する。 */
+export async function getAccessToken(
+  request: APIRequestContext,
+  username: string,
+  password: string,
+): Promise<string> {
+  const res = await request.post(`${AUTH_BASE}/realms/tasks/protocol/openid-connect/token`, {
+    form: {
+      grant_type: 'password',
+      client_id: 'tasks-webapi',
+      username,
+      password,
+      scope: 'openid',
+    },
+  });
+  if (!res.ok()) {
+    throw new Error(`token 取得失敗: ${res.status()} ${await res.text()}`);
+  }
+  const body = (await res.json()) as { access_token: string };
+  return body.access_token;
+}

--- a/e2e/tests-dev/support/api.ts
+++ b/e2e/tests-dev/support/api.ts
@@ -28,3 +28,50 @@ export async function getAccessToken(
   const body = (await res.json()) as { access_token: string };
   return body.access_token;
 }
+
+/**
+ * 指定タイトルのタスクを API 経由で強制削除する best-effort クリーンアップ(dev 実データ汚染防止、ADR-0041 決定5)。
+ * afterEach から呼び、テストが作成〜削除の途中で失敗しても共有テナントにゴミを残さないようにする。失敗しても投げない。
+ */
+export async function forceDeleteTasksByTitle(
+  request: APIRequestContext,
+  username: string,
+  password: string,
+  title: string,
+): Promise<void> {
+  try {
+    const token = await getAccessToken(request, username, password);
+    const auth = { Authorization: `Bearer ${token}` };
+    // テナント未指定で許可される /api/auth/me からテナント id を得る
+    const meRes = await request.get(`${API_BASE}/api/auth/me`, { headers: auth });
+    if (!meRes.ok()) {
+      return;
+    }
+    const me = (await meRes.json()) as { tenants?: Array<{ id: number }> };
+    const tenantId = me.tenants?.[0]?.id;
+    if (tenantId == null) {
+      return;
+    }
+    const headers = { ...auth, 'X-Tenant-Id': String(tenantId) };
+    const listRes = await request.get(
+      `${API_BASE}/api/tasks?keyword=${encodeURIComponent(title)}&size=100`,
+      { headers },
+    );
+    if (!listRes.ok()) {
+      return;
+    }
+    const body = (await listRes.json()) as {
+      content?: Array<{ id: number; version: number; title: string }>;
+    };
+    for (const t of body.content ?? []) {
+      if (t.title !== title) {
+        continue;
+      }
+      await request.delete(`${API_BASE}/api/tasks/${t.id}`, {
+        headers: { ...headers, 'If-Match': `"${t.version}"` },
+      });
+    }
+  } catch {
+    // best-effort: クリーンアップ失敗でテストは落とさない
+  }
+}

--- a/e2e/tests-dev/support/dev-auth.ts
+++ b/e2e/tests-dev/support/dev-auth.ts
@@ -1,0 +1,31 @@
+import type { Page } from '@playwright/test';
+
+/**
+ * dev-smoke 用の認証ヘルパ(ADR-0041 / #843)。
+ *
+ * 資格情報は環境変数で上書き可能(CI からは GitHub secret / SSM 注入)。未指定時は dev realm-export の
+ * 既定シードユーザー(`tenant1-member1@example.com` 等)にフォールバックする。ログインは実 Keycloak の
+ * ログインフォームを操作 = カスタム User Storage SPI(Keycloak → tasks DB federation)を dev 実機で通す。
+ */
+export const DEV_MEMBER = {
+  username: process.env.DEV_SMOKE_USERNAME ?? 'tenant1-member1@example.com',
+  password: process.env.DEV_SMOKE_PASSWORD ?? 'password',
+} as const;
+
+const KEYCLOAK_REALM_URL = /\/realms\/tasks\//;
+
+/** SPA(`/`)→ Keycloak ログイン → dashboard までを通す。 */
+export async function devLogin(page: Page, username: string, password: string): Promise<void> {
+  await page.goto('/');
+  await page.waitForURL(KEYCLOAK_REALM_URL, { timeout: 30_000 });
+  await page.fill('#username', username);
+  await page.fill('#password', password);
+  await page.click('#kc-login');
+  await page.waitForURL(/\/dashboard\.html/, { timeout: 30_000 });
+}
+
+/** SPA からログアウトする。 */
+export async function devLogout(page: Page): Promise<void> {
+  await page.click('#btn-logout');
+  await page.waitForURL(KEYCLOAK_REALM_URL, { timeout: 30_000 });
+}

--- a/e2e/tests-dev/support/dev-auth.ts
+++ b/e2e/tests-dev/support/dev-auth.ts
@@ -14,14 +14,32 @@ export const DEV_MEMBER = {
 
 const KEYCLOAK_REALM_URL = /\/realms\/tasks\//;
 
-/** SPA(`/`)→ Keycloak ログイン → dashboard までを通す。 */
-export async function devLogin(page: Page, username: string, password: string): Promise<void> {
+/** SPA(`/`)→ Keycloak ログインフォーム送信までを行う(遷移先の判定は呼び出し側)。 */
+async function submitKeycloakLogin(page: Page, username: string, password: string): Promise<void> {
   await page.goto('/');
   await page.waitForURL(KEYCLOAK_REALM_URL, { timeout: 30_000 });
   await page.fill('#username', username);
   await page.fill('#password', password);
   await page.click('#kc-login');
+}
+
+/** SPA(`/`)→ Keycloak ログイン → dashboard までを通す(テナント所属済みユーザー向け)。 */
+export async function devLogin(page: Page, username: string, password: string): Promise<void> {
+  await submitKeycloakLogin(page, username, password);
   await page.waitForURL(/\/dashboard\.html/, { timeout: 30_000 });
+}
+
+/**
+ * テナント未所属の新規会員のログイン到達を通す。dashboard へは遷移せず、認証済み SPA(`/`)へ戻るまでを待つ
+ * (ADR-0040 §3.5: 登録直後はテナント未所属で、`/` の「テナント作成」導線に着地する)。着地状態の検証は呼び出し側。
+ */
+export async function devLoginNewMember(
+  page: Page,
+  username: string,
+  password: string,
+): Promise<void> {
+  await submitKeycloakLogin(page, username, password);
+  await page.waitForURL((url) => !KEYCLOAK_REALM_URL.test(url.href), { timeout: 30_000 });
 }
 
 /** SPA からログアウトする。 */

--- a/e2e/tests-dev/support/keycloak-admin.ts
+++ b/e2e/tests-dev/support/keycloak-admin.ts
@@ -1,0 +1,59 @@
+import type { APIRequestContext } from '@playwright/test';
+
+/**
+ * dev-smoke の Keycloak Admin クリーンアップ用ヘルパ(ADR-0041 / #843)。
+ *
+ * signup complete で作成された Keycloak ユーザーを afterEach で削除し、共有 dev の realm にログイン可能な
+ * テストユーザーが溜まらないようにする。`tasks-webapi-admin`(service account, realm-management manage-users)の
+ * client_credentials を用いる。secret は env(CI は SSM 注入)。
+ *
+ * 注意: アプリ側 `users` テーブル行は物理削除 API が未提供(MVP、#167 で統合)かつ dev RDS は非公開のため
+ * E2E からは削除できない。本ヘルパは Keycloak ユーザー(= ログイン資格)のみ削除する。残る `users` 行は
+ * ログイン不能な inert な孤児で、一意メール(`signup-<uuid>@e2e.dgz48.xyz`)ゆえ衝突もしない。#167 の
+ * 物理削除 API 実装時に恒久クリーンアップへ移行する。
+ */
+const AUTH_BASE = process.env.DEV_SMOKE_AUTH_URL ?? 'https://auth-dev.dgz48.xyz';
+const ADMIN_CLIENT_ID = process.env.DEV_SMOKE_KC_ADMIN_CLIENT_ID ?? 'tasks-webapi-admin';
+const ADMIN_CLIENT_SECRET = process.env.DEV_SMOKE_KC_ADMIN_CLIENT_SECRET ?? '';
+const REALM = 'tasks';
+
+/** signup complete で作成された Keycloak ユーザーをメールで検索して削除する(best-effort、失敗しても投げない)。 */
+export async function deleteKeycloakUserByEmail(
+  request: APIRequestContext,
+  email: string,
+): Promise<void> {
+  if (!ADMIN_CLIENT_SECRET) {
+    return; // secret 未提供時はスキップ(ローカルで cleanup 不要な場合など)
+  }
+  try {
+    const tokenRes = await request.post(
+      `${AUTH_BASE}/realms/${REALM}/protocol/openid-connect/token`,
+      {
+        form: {
+          grant_type: 'client_credentials',
+          client_id: ADMIN_CLIENT_ID,
+          client_secret: ADMIN_CLIENT_SECRET,
+        },
+      },
+    );
+    if (!tokenRes.ok()) {
+      return;
+    }
+    const token = ((await tokenRes.json()) as { access_token: string }).access_token;
+    const auth = { Authorization: `Bearer ${token}` };
+
+    const usersRes = await request.get(
+      `${AUTH_BASE}/admin/realms/${REALM}/users?email=${encodeURIComponent(email)}&exact=true`,
+      { headers: auth },
+    );
+    if (!usersRes.ok()) {
+      return;
+    }
+    const users = (await usersRes.json()) as Array<{ id: string }>;
+    for (const u of users) {
+      await request.delete(`${AUTH_BASE}/admin/realms/${REALM}/users/${u.id}`, { headers: auth });
+    }
+  } catch {
+    // best-effort: cleanup 失敗でテストは落とさない
+  }
+}

--- a/e2e/tests-dev/support/mail.ts
+++ b/e2e/tests-dev/support/mail.ts
@@ -1,0 +1,103 @@
+import { randomUUID } from 'node:crypto';
+import { GetObjectCommand, ListObjectsV2Command, S3Client } from '@aws-sdk/client-s3';
+import { simpleParser } from 'mailparser';
+
+/**
+ * dev E2E のメール受信ヘルパ(ADR-0041 / #843)。
+ *
+ * `e2e.dgz48.xyz` 宛メールは SES email receiving で S3(`platform-dev-e2e-mail` の `inbound/`)へ
+ * 生 MIME として格納される。テストは一意アドレスでフローを起動し、本ヘルパで S3 をポーリングして
+ * 該当メールを取得・パースし、リンク/トークンを抽出する。サインアップ確認 / 招待 / パスワードリセット /
+ * 通知など全メールフローで共用する。認証情報は既定の AWS 資格情報チェーン(ローカル SSO / CI は OIDC ロール)。
+ */
+const REGION = process.env.AWS_REGION ?? 'ap-northeast-1';
+const BUCKET = process.env.DEV_SMOKE_MAIL_BUCKET ?? 'platform-dev-e2e-mail';
+const PREFIX = process.env.DEV_SMOKE_MAIL_PREFIX ?? 'inbound/';
+const MAIL_DOMAIN = process.env.DEV_SMOKE_MAIL_DOMAIN ?? 'e2e.dgz48.xyz';
+
+const s3 = new S3Client({ region: REGION });
+
+export interface ReceivedMail {
+  key: string;
+  subject: string;
+  to: string;
+  text: string;
+  html: string;
+  /** 本文(text + html)から抽出した http(s) URL 一覧。 */
+  links: string[];
+}
+
+/** テストごとに一意な受信アドレスを作る(例: `signup-<uuid>@e2e.dgz48.xyz`)。 */
+export function uniqueRecipient(localPrefix: string): string {
+  return `${localPrefix}-${randomUUID()}@${MAIL_DOMAIN}`;
+}
+
+async function streamToString(body: unknown): Promise<string> {
+  // @aws-sdk の Body は Node の Readable。transformToString があれば使う。
+  const b = body as { transformToString?: () => Promise<string> };
+  if (b?.transformToString) {
+    return b.transformToString();
+  }
+  const chunks: Buffer[] = [];
+  for await (const chunk of body as AsyncIterable<Buffer>) {
+    chunks.push(Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString('utf-8');
+}
+
+function extractLinks(text: string, html: string): string[] {
+  const found = new Set<string>();
+  const urlRe = /https?:\/\/[^\s"'<>)\]]+/g;
+  for (const src of [text, html]) {
+    for (const m of src.matchAll(urlRe)) {
+      found.add(m[0]);
+    }
+  }
+  return [...found];
+}
+
+/**
+ * 指定した受信アドレス宛のメールが S3 に届くまでポーリングして取得する。届いたメールの To を照合するため、
+ * 一意アドレス(`uniqueRecipient`)の利用を前提とする。
+ */
+export async function waitForEmailTo(
+  recipient: string,
+  opts: { timeoutMs?: number; pollMs?: number } = {},
+): Promise<ReceivedMail> {
+  const timeoutMs = opts.timeoutMs ?? 90_000;
+  const pollMs = opts.pollMs ?? 5_000;
+  const target = recipient.toLowerCase();
+  const deadline = Date.now() + timeoutMs;
+  const seen = new Set<string>();
+
+  while (Date.now() < deadline) {
+    const listed = await s3.send(new ListObjectsV2Command({ Bucket: BUCKET, Prefix: PREFIX }));
+    const objects = (listed.Contents ?? [])
+      .filter((o) => o.Key && !seen.has(o.Key))
+      .sort((a, b) => (b.LastModified?.getTime() ?? 0) - (a.LastModified?.getTime() ?? 0));
+
+    for (const obj of objects) {
+      const key = obj.Key as string;
+      seen.add(key);
+      const got = await s3.send(new GetObjectCommand({ Bucket: BUCKET, Key: key }));
+      const raw = await streamToString(got.Body);
+      const parsed = await simpleParser(raw);
+      const toText = (parsed.to && !Array.isArray(parsed.to) ? parsed.to.text : '') ?? '';
+      if (!toText.toLowerCase().includes(target)) {
+        continue;
+      }
+      const text = parsed.text ?? '';
+      const html = typeof parsed.html === 'string' ? parsed.html : '';
+      return {
+        key,
+        subject: parsed.subject ?? '',
+        to: toText,
+        text,
+        html,
+        links: extractLinks(text, html),
+      };
+    }
+    await new Promise((r) => setTimeout(r, pollMs));
+  }
+  throw new Error(`メールが ${timeoutMs}ms 以内に届きませんでした: to=${recipient}`);
+}

--- a/e2e/tests-dev/task-journey.dev-smoke.spec.ts
+++ b/e2e/tests-dev/task-journey.dev-smoke.spec.ts
@@ -1,0 +1,51 @@
+import { expect, test } from '@playwright/test';
+import { DEV_MEMBER, devLogin } from './support/dev-auth';
+
+/**
+ * dev-smoke: タスクの作成 → ステータス変更 → 削除(後始末)を実 UI で通す。
+ *
+ * native 実機でしか出ない事象(@Valid の validator hints 欠落による write 500、@AuthenticationPrincipal
+ * の SpEL による read 500、If-Match/ETag)を、ユーザー操作の経路で踏む。dev データを汚さないよう作成した
+ * タスクは最後に削除する(冪等 create + cleanup)。
+ */
+test.describe('dev-smoke: task journey', { tag: '@dev-smoke' }, () => {
+  /** Asia/Tokyo の当日(YYYY-MM-DD)。一覧は当日タスクのみ表示するため due を当日にする。 */
+  function todayInJst(): string {
+    return new Intl.DateTimeFormat('en-CA', { timeZone: 'Asia/Tokyo' }).format(new Date());
+  }
+
+  test('タスクを作成・ステータス変更・削除できる', async ({ page }) => {
+    await devLogin(page, DEV_MEMBER.username, DEV_MEMBER.password);
+
+    await page.goto('/tasks.html');
+    await expect(page.locator('#task-panel')).toBeVisible();
+
+    const title = `dev-smoke ${Date.now()}`;
+
+    // --- 作成(POST /api/tasks, @Valid 経路)---
+    await page.click('#btn-new-task');
+    const drawer = page.locator('app-task-drawer .offcanvas');
+    await expect(drawer).toBeVisible();
+    await drawer.locator('#newTitle').fill(title);
+    await drawer.locator('#newDue').fill(todayInJst());
+    // priority=MEDIUM / visibility=TENANT は既定のまま(所有者=自分で一覧に出る)
+    await drawer.locator('button[type="submit"]').click();
+    await expect(drawer).toBeHidden();
+
+    const row = page.locator('app-task-row').filter({ hasText: title });
+    await expect(row).toBeVisible();
+
+    // --- 詳細を開く(編集不可セルをクリック)→ ステータス変更(PATCH /status, ETag)---
+    await row.locator('.cell-owner').click();
+    await expect(drawer).toBeVisible();
+    await drawer.locator('select.inline-sel').first().selectOption('IN_PROGRESS');
+    // 反映確認: 詳細ドロワーのステータス select が更新される
+    await expect(drawer.locator('select.inline-sel').first()).toHaveValue('IN_PROGRESS');
+
+    // --- 削除(後始末、DELETE /api/tasks/{id}, If-Match)---
+    await drawer.locator('.btn-outline-danger').click();
+    await drawer.locator('button.btn-danger').click();
+    await expect(drawer).toBeHidden();
+    await expect(page.locator('app-task-row').filter({ hasText: title })).toHaveCount(0);
+  });
+});

--- a/e2e/tests-dev/task-journey.dev-smoke.spec.ts
+++ b/e2e/tests-dev/task-journey.dev-smoke.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { forceDeleteTasksByTitle } from './support/api';
 import { DEV_MEMBER, devLogin } from './support/dev-auth';
 
 /**
@@ -14,6 +15,22 @@ test.describe('dev-smoke: task journey', { tag: '@dev-smoke' }, () => {
     return new Intl.DateTimeFormat('en-CA', { timeZone: 'Asia/Tokyo' }).format(new Date());
   }
 
+  // 作成〜削除の途中で失敗しても共有テナントにゴミを残さないよう、作成したタスクを afterEach で
+  // 強制削除する(ADR-0041 決定5)。正常に UI 削除できた場合は createdTitle を消して二重削除を避ける。
+  let createdTitle: string | undefined;
+
+  test.afterEach(async ({ request }) => {
+    if (createdTitle) {
+      await forceDeleteTasksByTitle(
+        request,
+        DEV_MEMBER.username,
+        DEV_MEMBER.password,
+        createdTitle,
+      );
+      createdTitle = undefined;
+    }
+  });
+
   test('タスクを作成・ステータス変更・削除できる', async ({ page }) => {
     await devLogin(page, DEV_MEMBER.username, DEV_MEMBER.password);
 
@@ -21,6 +38,7 @@ test.describe('dev-smoke: task journey', { tag: '@dev-smoke' }, () => {
     await expect(page.locator('#task-panel')).toBeVisible();
 
     const title = `dev-smoke ${Date.now()}`;
+    createdTitle = title; // 失敗時 afterEach が掃除できるよう先に記録
 
     // --- 作成(POST /api/tasks, @Valid 経路)---
     await page.click('#btn-new-task');
@@ -47,5 +65,6 @@ test.describe('dev-smoke: task journey', { tag: '@dev-smoke' }, () => {
     await drawer.locator('button.btn-danger').click();
     await expect(drawer).toBeHidden();
     await expect(page.locator('app-task-row').filter({ hasText: title })).toHaveCount(0);
+    createdTitle = undefined; // 正常に UI 削除できたので afterEach の掃除は不要
   });
 });


### PR DESCRIPTION
## 概要

[ADR-0041](../blob/main/docs/adr/0041-post-deploy-dev-e2e-and-email-verification.md) 実装 **フェーズ②**(#843)。live dev に対するブラウザ主軸 E2E `@dev-smoke` を新設。

既存 hermetic スイート(`./tests`、ローカル compose 前提)とは **完全分離**(別 config + `tests-dev/`)。SPA が hostname から auth-dev/api-dev を自動導出するため、`BASE_URL=https://tasks-dev.dgz48.xyz` を指すだけで dev の Keycloak/API を叩く。

## 変更

- `e2e/playwright.dev-smoke.config.ts`(testDir=`./tests-dev`、baseURL=dev、live 向け retry/timeout)
- `e2e/tests-dev/support/dev-auth.ts`(資格情報 env 上書き可、既定は dev seed ユーザー)
- **login-dashboard**: ログイン(OIDC+**User Storage SPI を dev 実機で通す**)→ ダッシュボード 4 カード + username
- **task-journey**: タスク作成 → ステータス変更 → 削除(**native の @Valid/SpEL/ETag 経路** + 冪等 cleanup)
- **login-theme**: auth-dev ログイン画面の「新規登録」リンク描画(**dev 実機限定**)
- `package.json`: `test:dev-smoke` スクリプト

## CI への影響なし

`tests-dev/` は既定 config(testDir=`./tests`)の対象外なので **hermetic `e2e-test` は本スイートを実行しない**(localhost へ誤爆しない)。biome / tsc は green。

## ⚠️ 検証状態

本スイートは**検証済みセレクタ**(実 SPA + 既存 passing テストから採取)で書いたが、**まだ live dev では実行していない**。初回の実 dev 実行は **フェーズ④の `dev-smoke.yml`(または手動 `npm run test:dev-smoke`)**で行い、そこで確定検証する。フェーズ③(メール E2E)は #845 の infra を **dev へ apply** 後に有効。

🤖 Generated with [Claude Code](https://claude.com/claude-code)