### PR TITLE
feat(infra): dev webapi のメール実送信を有効化(SES)(Refs #843)

### DIFF
--- a/infra/environments/dev/ecs_service.tf
+++ b/infra/environments/dev/ecs_service.tf
@@ -148,6 +148,12 @@ resource "aws_ecs_task_definition" "webapi" {
         # OTLP エクスポート先は localhost の ADOT Collector サイドカー(ADR-0007)
         { name = "OTEL_EXPORTER_OTLP_ENDPOINT", value = "http://localhost:4317" },
         { name = "OTEL_EXPORTER_OTLP_PROTOCOL", value = "grpc" },
+        # メール送信を SES 実送信に切替(既定は log フォールバック)。FROM は検証済み mail.<domain>。
+        # 会員登録/招待の確認リンクは dev SPA の実 URL を指す(既定 localhost を上書き)。ADR-0040 / ADR-0041。
+        { name = "NOTIFICATION_EMAIL_PROVIDER", value = "ses" },
+        { name = "NOTIFICATION_EMAIL_FROM", value = "no-reply@mail.dgz48.xyz" },
+        { name = "TENANT_SIGNUP_CONFIRM_URL_BASE", value = "https://tasks-dev.dgz48.xyz/signup-complete.html" },
+        { name = "TENANT_INVITE_ACCEPT_URL_BASE", value = "https://tasks-dev.dgz48.xyz/invitation.html" },
       ]
 
       secrets = [

--- a/infra/environments/dev/iam.tf
+++ b/infra/environments/dev/iam.tf
@@ -118,3 +118,22 @@ resource "aws_iam_role_policy" "webapi_ssm" {
     ]
   })
 }
+
+# webapi の SES 実送信(会員登録/招待/通知/リセットのメール、ADR-0040 / ADR-0041)。
+# 規約 R1: 書込み action は完全列挙。R2: 送信元 identity(mail.<base_domain>)の ARN に限定。
+resource "aws_iam_role_policy" "webapi_ses" {
+  name = "tasks-${var.env}-webapi-ses"
+  role = aws_iam_role.webapi_task.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "SesSendFromMailIdentity"
+        Effect   = "Allow"
+        Action   = "ses:SendEmail"
+        Resource = "arn:aws:ses:${var.region}:${data.aws_caller_identity.current.account_id}:identity/mail.dgz48.xyz"
+      }
+    ]
+  })
+}


### PR DESCRIPTION
## 概要

post-deploy E2E(ADR-0041 / #843)が検出した gap の是正: **dev では `NOTIFICATION_EMAIL_*` 未設定で `log` フォールバック(実送信なし)**だったため、会員登録/招待/通知/リセットのメールが一切飛んでいなかった。SES 実送信へ切り替える。

## 変更

- **`ecs_service.tf`** webapi env 追加:
  - `NOTIFICATION_EMAIL_PROVIDER=ses`
  - `NOTIFICATION_EMAIL_FROM=no-reply@mail.dgz48.xyz`(SES 送信検証済 identity)
  - `TENANT_SIGNUP_CONFIRM_URL_BASE=https://tasks-dev.dgz48.xyz/signup-complete.html`(既定 localhost を上書き)
  - `TENANT_INVITE_ACCEPT_URL_BASE=https://tasks-dev.dgz48.xyz/invitation.html`
- **`iam.tf`**: webapi タスクロールに `ses:SendEmail`(規約 R2: `mail.dgz48.xyz` identity ARN に限定)

## 検証

- `terraform validate` 成功 / IAM wildcard gate pass / `terraform fmt` 済
- `mail.dgz48.xyz`: SES `Verified: true` / `DKIM: SUCCESS`(送信可)
- 受信基盤 #845(`e2e.dgz48.xyz` 検証済 + receipt rule active)と合わせ、signup-email E2E を通せるようになる

## 適用後

env 変更で webapi TD 差替 = 同一イメージの再デプロイ。apply 後、dev-smoke の signup-email を再実行して緑を確認する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)