### PR TITLE
fix(native): SES メール送信を AOT で native image に焼き込む (Refs #843)

### DIFF
--- a/webapi/build.gradle.kts
+++ b/webapi/build.gradle.kts
@@ -229,6 +229,12 @@ tasks.named<JavaExec>("processAot") {
     // at AOT time. GraalVM bakes the condition result in; local JVM tests are unaffected because
     // they never run the native image.
     environment("RDS_IAM_AUTH_ENABLED", "true")
+    // Same reason for the SES email sender: NotificationConfig の @ConditionalOnProperty
+    // (notification.email.provider=ses) は AOT 時に評価され native image に焼き込まれる。既定 log の
+    // ままだと SesEmailSender が native から除外され、実行時 env で ses を指定しても LoggingEmailSender
+    // フォールバックのままになる(dev post-deploy E2E / ADR-0041 で検出)。deploy 先(native)は常に SES
+    // 実送信のため AOT で ses を強制する。FROM 等は実行時 env(NOTIFICATION_EMAIL_FROM)で供給。
+    environment("NOTIFICATION_EMAIL_PROVIDER", "ses")
 }
 
 tasks.named<JavaExec>("processTestAot") {


### PR DESCRIPTION
## 概要

**dev post-deploy E2E(ADR-0041 / #843)が native 限定バグを検出した**ものの是正。まさに ADR-0041 の狙いどおり、pre-deploy(JVM)テストでは見えないバグ。

## 根本原因

`NotificationConfig` の `@ConditionalOnProperty(name="notification.email.provider", havingValue="ses")` は **GraalVM AOT のビルド時**に評価され、結果が native image に焼き込まれる。native image は既定 `log` でビルドされていたため **`SesEmailSender` が native から除外**され、実行時に `NOTIFICATION_EMAIL_PROVIDER=ses` を設定しても効かず `LoggingEmailSender`(フォールバック)のまま。

dev ログの実証:
```
x.d.t.w.n.a.external.LoggingEmailSender : メール送出(ログフォールバック、実送出なし) to=s***@e2e.dgz48.xyz
```

JVM テストは条件を実行時評価するため、この事象は **native 実機でしか出ない**。

## 修正

`RDS_IAM_AUTH_ENABLED=true` の確立パターンと同一: `processAot` 環境に `NOTIFICATION_EMAIL_PROVIDER=ses` を強制し、native image に SES sender を焼き込む。deploy 先(dev/stg/prd = native)は常に実送信のため妥当。FROM/URL は実行時 env(#854)で供給。JVM(ローカル/テスト)は実行時評価のため影響なし。

`webapi-native-build`(CI)が native image への焼込を検証する。

## 完成条件

#845(SES 受信)+ #854(送信 env/IAM)+ 本修正(native 焼込)で実メール送信が成立。マージ後、**release-build で native image 再ビルド → dev 再デプロイ → signup-email E2E 再実行**で通しを緑にする。

🤖 Generated with [Claude Code](https://claude.com/claude-code)