### PR TITLE
feat: dev の会員登録 Keycloak 資格プロビジョニングを有効化 (Refs #843)

### DIFF
--- a/infra/environments/dev/ecs_service.tf
+++ b/infra/environments/dev/ecs_service.tf
@@ -41,6 +41,7 @@ resource "aws_iam_role_policy" "webapi_exec_ssm" {
         Resource = [
           "arn:aws:ssm:${var.region}:${data.aws_caller_identity.current.account_id}:parameter/tasks/${var.env}/app/jwt-issuer",
           "arn:aws:ssm:${var.region}:${data.aws_caller_identity.current.account_id}:parameter/tasks/${var.env}/app/tenant-default-id",
+          "arn:aws:ssm:${var.region}:${data.aws_caller_identity.current.account_id}:parameter/tasks/${var.env}/app/keycloak-admin-client-secret",
           "arn:aws:ssm:${var.region}:${data.aws_caller_identity.current.account_id}:parameter/tasks/${var.env}/keycloak/oauth-client-secret",
         ]
       },
@@ -154,6 +155,10 @@ resource "aws_ecs_task_definition" "webapi" {
         { name = "NOTIFICATION_EMAIL_FROM", value = "no-reply@mail.dgz48.xyz" },
         { name = "TENANT_SIGNUP_CONFIRM_URL_BASE", value = "https://tasks-dev.dgz48.xyz/signup-complete.html" },
         { name = "TENANT_INVITE_ACCEPT_URL_BASE", value = "https://tasks-dev.dgz48.xyz/invitation.html" },
+        # 会員登録の Keycloak 資格プロビジョニングを有効化(既定 false = LoggingCredentialProvisioning
+        # フォールバック)。ADR-0040 §3.1。client-id/realm は既定(tasks-webapi-admin / tasks)を使用。
+        { name = "KEYCLOAK_ADMIN_ENABLED", value = "true" },
+        { name = "KEYCLOAK_ADMIN_SERVER_URL", value = "https://auth-dev.dgz48.xyz" },
       ]
 
       secrets = [
@@ -168,6 +173,10 @@ resource "aws_ecs_task_definition" "webapi" {
         {
           name      = "KEYCLOAK_CLIENT_SECRET"
           valueFrom = "arn:aws:ssm:${var.region}:${data.aws_caller_identity.current.account_id}:parameter/tasks/${var.env}/keycloak/oauth-client-secret"
+        },
+        {
+          name      = "KEYCLOAK_ADMIN_CLIENT_SECRET"
+          valueFrom = "arn:aws:ssm:${var.region}:${data.aws_caller_identity.current.account_id}:parameter/tasks/${var.env}/app/keycloak-admin-client-secret"
         },
       ]
 

--- a/webapi/build.gradle.kts
+++ b/webapi/build.gradle.kts
@@ -235,6 +235,12 @@ tasks.named<JavaExec>("processAot") {
     // フォールバックのままになる(dev post-deploy E2E / ADR-0041 で検出)。deploy 先(native)は常に SES
     // 実送信のため AOT で ses を強制する。FROM 等は実行時 env(NOTIFICATION_EMAIL_FROM)で供給。
     environment("NOTIFICATION_EMAIL_PROVIDER", "ses")
+    // 同理由で会員登録の Keycloak 資格プロビジョニング(ADR-0040): keycloak.admin.enabled の
+    // @ConditionalOnProperty は AOT で評価される。既定 false のままだと KeycloakAdminCredentialAdapter が
+    // native から除外され LoggingCredentialProvisioningAdapter(実プロビジョニングなし)に固定される
+    // (dev post-deploy E2E / ADR-0041 で検出)。deploy 先は常に実プロビジョニングのため AOT で true を強制。
+    // server-url / client-secret 等は実行時 env(KEYCLOAK_ADMIN_*)で供給。
+    environment("KEYCLOAK_ADMIN_ENABLED", "true")
 }
 
 tasks.named<JavaExec>("processTestAot") {


### PR DESCRIPTION
## 概要

dev post-deploy E2E(ADR-0041 / #843)が検出した **3つ目の dev 設定 gap** の是正。signup `complete` で **Keycloak ユーザーが作られていなかった**(既定 `keycloak.admin.enabled=false` → `LoggingCredentialProvisioningAdapter` フォールバック)。しかも `@ConditionalOnProperty` は **AOT 焼込**のため実行時 env では効かない(メール/SES と同じ native 限定パターン)。

## 変更

- **`webapi/build.gradle.kts`**: `processAot` に `KEYCLOAK_ADMIN_ENABLED=true` を強制 → `KeycloakAdminCredentialAdapter` を native image に焼込
- **`ecs_service.tf`**: env `KEYCLOAK_ADMIN_ENABLED=true` + `KEYCLOAK_ADMIN_SERVER_URL=https://auth-dev.dgz48.xyz`、secrets に `KEYCLOAK_ADMIN_CLIENT_SECRET`(SSM 参照)、exec ロール SSM 読取に同 param 追加
- **運用**: SSM `/tasks/dev/app/keycloak-admin-client-secret` を実値へ設定(`client_credentials` 200 確認済。従来は `CHANGE_ME` で 401)

## 検証

- `terraform validate` 成功 / IAM wildcard gate pass / fmt 済
- SSM 実値で dev Keycloak `client_credentials` = **200**

## 完成

#845(受信)+ #854(送信)+ #855(SES 焼込)+ 本 PR(資格プロビジョニング)で、signup `complete→login` フルフローが dev で成立。マージ後 **v0.2.5 → release-build → deploy → dev-smoke 全スイート再実行**で緑を確認する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)