### PR TITLE
fix(infra): dev webapi の ses:SendEmail を SES サンドボックス宛先 identity まで許可

### DIFF
--- a/infra/environments/dev/iam.tf
+++ b/infra/environments/dev/iam.tf
@@ -121,12 +121,12 @@ resource "aws_iam_role_policy" "webapi_ssm" {
 
 # webapi の SES 実送信(会員登録/招待/通知/リセットのメール、ADR-0040 / ADR-0041)。
 # 規約 R1: 書込み action は完全列挙(ses:SendEmail のみ)。
-# R2: リソースは当アカウント・当リージョンの SES identity に限定(identity/*)。
+# R2: リソースは必要な SES identity を ARN で列挙(wildcard 不使用)。
+#   - 送信元: mail.dgz48.xyz(検証済み送信ドメイン)
+#   - 宛先:   e2e.dgz48.xyz(ADR-0041 の E2E 受信ドメイン)
 # NOTE: SES サンドボックスでは ses:SendEmail が「送信元」identity だけでなく
-#       「宛先」verified identity(dev では E2E 受信ドメイン e2e.dgz48.xyz)に対しても
-#       認可評価される。送信元 mail.dgz48.xyz 単体スコープでは宛先評価で 403 になるため、
-#       アカウント内 SES identity 全体(送信元 + サンドボックス検証済み宛先)に広げる。
-#       本番(サンドボックス解除後)は送信元 identity のみ評価されるため過剰権限は生じない。
+#       「宛先」verified identity に対しても認可評価される。送信元単体スコープでは
+#       宛先評価で 403 となり会員登録メールが送出できないため、宛先 identity も列挙する。
 resource "aws_iam_role_policy" "webapi_ses" {
   name = "tasks-${var.env}-webapi-ses"
   role = aws_iam_role.webapi_task.id
@@ -135,10 +135,13 @@ resource "aws_iam_role_policy" "webapi_ses" {
     Version = "2012-10-17"
     Statement = [
       {
-        Sid      = "SesSendFromMailIdentity"
-        Effect   = "Allow"
-        Action   = "ses:SendEmail"
-        Resource = "arn:aws:ses:${var.region}:${data.aws_caller_identity.current.account_id}:identity/*"
+        Sid    = "SesSendFromMailIdentity"
+        Effect = "Allow"
+        Action = "ses:SendEmail"
+        Resource = [
+          "arn:aws:ses:${var.region}:${data.aws_caller_identity.current.account_id}:identity/mail.dgz48.xyz",
+          "arn:aws:ses:${var.region}:${data.aws_caller_identity.current.account_id}:identity/e2e.dgz48.xyz",
+        ]
       }
     ]
   })

--- a/infra/environments/dev/iam.tf
+++ b/infra/environments/dev/iam.tf
@@ -120,7 +120,13 @@ resource "aws_iam_role_policy" "webapi_ssm" {
 }
 
 # webapi の SES 実送信(会員登録/招待/通知/リセットのメール、ADR-0040 / ADR-0041)。
-# 規約 R1: 書込み action は完全列挙。R2: 送信元 identity(mail.<base_domain>)の ARN に限定。
+# 規約 R1: 書込み action は完全列挙(ses:SendEmail のみ)。
+# R2: リソースは当アカウント・当リージョンの SES identity に限定(identity/*)。
+# NOTE: SES サンドボックスでは ses:SendEmail が「送信元」identity だけでなく
+#       「宛先」verified identity(dev では E2E 受信ドメイン e2e.dgz48.xyz)に対しても
+#       認可評価される。送信元 mail.dgz48.xyz 単体スコープでは宛先評価で 403 になるため、
+#       アカウント内 SES identity 全体(送信元 + サンドボックス検証済み宛先)に広げる。
+#       本番(サンドボックス解除後)は送信元 identity のみ評価されるため過剰権限は生じない。
 resource "aws_iam_role_policy" "webapi_ses" {
   name = "tasks-${var.env}-webapi-ses"
   role = aws_iam_role.webapi_task.id
@@ -132,7 +138,7 @@ resource "aws_iam_role_policy" "webapi_ses" {
         Sid      = "SesSendFromMailIdentity"
         Effect   = "Allow"
         Action   = "ses:SendEmail"
-        Resource = "arn:aws:ses:${var.region}:${data.aws_caller_identity.current.account_id}:identity/mail.dgz48.xyz"
+        Resource = "arn:aws:ses:${var.region}:${data.aws_caller_identity.current.account_id}:identity/*"
       }
     ]
   })


### PR DESCRIPTION
## 背景

ADR-0041 の dev post-deploy E2E(#843)で会員登録メールの実配信を検証したところ、`signup-email` シナリオでメールが届かず失敗。dev ログで根本原因を特定:

\`\`\`
tasks-dev-webapi-task-role is not authorized to perform ses:SendEmail
on resource arn:aws:ses:ap-northeast-1:...:identity/e2e.dgz48.xyz (403)
\`\`\`

**SES サンドボックス**では `ses:SendEmail` が「送信元」identity だけでなく「宛先」の verified identity(E2E 受信ドメイン `e2e.dgz48.xyz`)に対しても IAM 認可評価される。従来ポリシーは送信元 `mail.dgz48.xyz` 単体にスコープしていたため、宛先評価で 403 となり送出失敗していた(例外は enumeration-resistant な会員登録経路で握り潰され、メール未達としてのみ表面化)。

## 変更

`webapi_ses` の `ses:SendEmail` リソースを、アカウント内・当リージョンの SES identity 全体(`identity/*`)へ拡張。

- R1(action 完全列挙)維持 — action は `ses:SendEmail` のみ。
- R2 — リソースは account+region の SES identity に限定(full wildcard `*` ではない)。
- 本番のサンドボックス解除後は送信元 identity のみ評価されるため過剰権限は生じない。

## 検証

- `terraform validate` / `fmt` 済。
- apply 後、dev の `signup-email` dev-smoke を再実行し実配信 → complete → ログインまで green を確認する(本 PR merge → terraform-apply 後)。
- IAM は per-request 評価のため、apply 後は稼働中タスクの再デプロイ不要で即反映。

Refs #843

🤖 Generated with [Claude Code](https://claude.com/claude-code)