### PR TITLE
fix(user): 会員登録の credential provisioning を find-or-create にする

### DIFF
--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/adapter/external/KeycloakAdminCredentialAdapter.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/adapter/external/KeycloakAdminCredentialAdapter.java
@@ -1,6 +1,7 @@
 package xyz.dgz48.tasks.webapi.user.adapter.external;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.net.URI;
 import org.jspecify.annotations.Nullable;
 import org.springframework.aot.hint.MemberCategory;
 import org.springframework.aot.hint.RuntimeHints;
@@ -23,6 +24,12 @@ import xyz.dgz48.tasks.webapi.user.usecase.CredentialProvisioningPort;
  * パスワード設定(reset-password) → ② {@code emailVerified=true} を設定する(ADR-0040 §3.4)。credential 自体は
  * Keycloak が SoT(ADR-0006 §3.3)。Spring {@link RestClient} を用い、native image(ADR-0008)で重い
  * JAX-RS/RESTEasy 依存(keycloak-admin-client)を避ける。
+ *
+ * <p>email 検索がヒットしない場合はローカル Keycloak ユーザーを新規作成する(ADR-0040 §3.1「必要なら addUser correlation」)。User
+ * Storage SPI federation(ADR-0006)が有効な環境では検索が app {@code users} を federated user
+ * として返すため作成は行われない。federation 未活性の環境では作成したローカルユーザーが、初回ログイン時に app {@code users} の {@code pending} 行と
+ * correlation される(ADR-0040 §3.2 / {@code OidcSubCorrelationService})。いずれの構成でも provisioning が成立するよう
+ * find-or-create とする。
  */
 public class KeycloakAdminCredentialAdapter implements CredentialProvisioningPort {
 
@@ -38,13 +45,22 @@ public class KeycloakAdminCredentialAdapter implements CredentialProvisioningPor
   public void provisionCredential(String email, String rawPassword) {
     try {
       String token = fetchAdminToken();
-      String userId = findUserIdByEmail(email, token);
+      String userId = resolveOrCreateUserId(email, token);
       resetPassword(userId, rawPassword, token);
       markEmailVerified(userId, token);
     } catch (RestClientException e) {
       // PII / パスワードは含めない(規約 §7)
       throw new CredentialProvisioningException("Keycloak Admin API 呼び出しに失敗しました", e);
     }
+  }
+
+  /**
+   * email でユーザーを解決する。既存(federated 含む)ならその id を返し、無ければローカルユーザーを新規作成して id を返す。SPI federation
+   * 有効時は検索がヒットするため作成は行わない。
+   */
+  private String resolveOrCreateUserId(String email, String token) {
+    String existing = findUserIdByEmail(email, token);
+    return existing != null ? existing : createUser(email, token);
   }
 
   private String fetchAdminToken() {
@@ -66,7 +82,7 @@ public class KeycloakAdminCredentialAdapter implements CredentialProvisioningPor
     return resp.accessToken();
   }
 
-  private String findUserIdByEmail(String email, String token) {
+  private @Nullable String findUserIdByEmail(String email, String token) {
     KeycloakUserRef[] users =
         restClient
             .get()
@@ -81,9 +97,48 @@ public class KeycloakAdminCredentialAdapter implements CredentialProvisioningPor
             .retrieve()
             .body(KeycloakUserRef[].class);
     if (users == null || users.length == 0 || users[0].id() == null) {
-      throw new CredentialProvisioningException("Keycloak に対象ユーザーが見つかりません");
+      return null;
     }
     return users[0].id();
+  }
+
+  /**
+   * ローカル Keycloak ユーザーを作成し id を返す({@code username=email}、{@code enabled=true}、{@code emailVerified}
+   * は後続の {@link #markEmailVerified} で設定)。作成レスポンスの {@code Location} ヘッダから id を取り出す。並行 complete による
+   * {@code 409}(既存)は無視し、email 再検索でフォールバックする。
+   */
+  private String createUser(String email, String token) {
+    URI location =
+        restClient
+            .post()
+            .uri("/admin/realms/{realm}/users", props.realm())
+            .header(HttpHeaders.AUTHORIZATION, bearer(token))
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(new UserCreateRequest(email, email, true))
+            .retrieve()
+            // 競合(既に存在)は例外にせず、下の再検索でフォールバックする
+            .onStatus(status -> status.value() == 409, (req, res) -> {})
+            .toBodilessEntity()
+            .getHeaders()
+            .getLocation();
+    if (location != null) {
+      String userId = extractUserId(location);
+      if (userId != null && !userId.isBlank()) {
+        return userId;
+      }
+    }
+    String refetched = findUserIdByEmail(email, token);
+    if (refetched == null) {
+      throw new CredentialProvisioningException("Keycloak ユーザーの作成に失敗しました");
+    }
+    return refetched;
+  }
+
+  /** {@code .../users/{id}} 形式の Location パスから末尾の user id を取り出す。 */
+  private static @Nullable String extractUserId(URI location) {
+    String path = location.getPath();
+    int idx = path.lastIndexOf('/');
+    return idx >= 0 && idx < path.length() - 1 ? path.substring(idx + 1) : null;
   }
 
   private void resetPassword(String userId, String rawPassword, String token) {
@@ -121,6 +176,9 @@ public class KeycloakAdminCredentialAdapter implements CredentialProvisioningPor
   /** reset-password の credential 表現。 */
   public record PasswordCredential(String type, String value, boolean temporary) {}
 
+  /** ユーザー新規作成リクエスト(username=email, enabled=true)。emailVerified は後続で設定。 */
+  public record UserCreateRequest(String username, String email, boolean enabled) {}
+
   /** ユーザー更新(emailVerified のみ)。 */
   public record EmailVerifiedUpdate(boolean emailVerified) {}
 
@@ -137,6 +195,7 @@ public class KeycloakAdminCredentialAdapter implements CredentialProvisioningPor
             TokenResponse.class,
             KeycloakUserRef.class,
             PasswordCredential.class,
+            UserCreateRequest.class,
             EmailVerifiedUpdate.class
           }) {
         hints.reflection().registerType(dto, MemberCategory.values());

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/user/adapter/external/KeycloakAdminCredentialAdapterTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/user/adapter/external/KeycloakAdminCredentialAdapterTest.java
@@ -2,11 +2,14 @@ package xyz.dgz48.tasks.webapi.user.adapter.external;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.jsonPath;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.queryParam;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withCreatedEntity;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
+import java.net.URI;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -67,12 +70,56 @@ class KeycloakAdminCredentialAdapterTest {
   }
 
   @Test
-  void throwsWhenUserNotFound() {
+  void createsUserWhenNotFoundThenProvisions() {
+    server
+        .expect(requestTo(BASE + "/realms/tasks/protocol/openid-connect/token"))
+        .andRespond(withSuccess("{\"access_token\":\"tok-123\"}", MediaType.APPLICATION_JSON));
+    // ① email 検索: ヒットなし → 新規作成へ
+    server
+        .expect(requestTo(Matchers.startsWith(BASE + "/admin/realms/tasks/users?")))
+        .andExpect(method(HttpMethod.GET))
+        .andRespond(withSuccess("[]", MediaType.APPLICATION_JSON));
+    // ② 作成: username=email, enabled=true。201 + Location ヘッダで id を返す
+    server
+        .expect(requestTo(BASE + "/admin/realms/tasks/users"))
+        .andExpect(method(HttpMethod.POST))
+        .andExpect(header("Authorization", "Bearer tok-123"))
+        .andExpect(jsonPath("$.username").value("new@example.com"))
+        .andExpect(jsonPath("$.email").value("new@example.com"))
+        .andExpect(jsonPath("$.enabled").value(true))
+        .andRespond(withCreatedEntity(URI.create(BASE + "/admin/realms/tasks/users/99")));
+    // ③ reset-password → ④ emailVerified を新規 id に対して実施
+    server
+        .expect(requestTo(BASE + "/admin/realms/tasks/users/99/reset-password"))
+        .andExpect(method(HttpMethod.PUT))
+        .andRespond(withSuccess());
+    server
+        .expect(requestTo(BASE + "/admin/realms/tasks/users/99"))
+        .andExpect(method(HttpMethod.PUT))
+        .andRespond(withSuccess());
+
+    adapter.provisionCredential("new@example.com", "raw-password");
+
+    server.verify();
+  }
+
+  @Test
+  void throwsWhenUserCreationYieldsNoId() {
     server
         .expect(requestTo(BASE + "/realms/tasks/protocol/openid-connect/token"))
         .andRespond(withSuccess("{\"access_token\":\"tok-123\"}", MediaType.APPLICATION_JSON));
     server
         .expect(requestTo(Matchers.startsWith(BASE + "/admin/realms/tasks/users?")))
+        .andExpect(method(HttpMethod.GET))
+        .andRespond(withSuccess("[]", MediaType.APPLICATION_JSON));
+    // 作成が Location を返さず(異常)、再検索も空 → プロビジョニング失敗
+    server
+        .expect(requestTo(BASE + "/admin/realms/tasks/users"))
+        .andExpect(method(HttpMethod.POST))
+        .andRespond(withSuccess());
+    server
+        .expect(requestTo(Matchers.startsWith(BASE + "/admin/realms/tasks/users?")))
+        .andExpect(method(HttpMethod.GET))
         .andRespond(withSuccess("[]", MediaType.APPLICATION_JSON));
 
     assertThatThrownBy(() -> adapter.provisionCredential("missing@example.com", "pw"))

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/user/adapter/external/KeycloakAdminCredentialAdapterTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/user/adapter/external/KeycloakAdminCredentialAdapterTest.java
@@ -7,6 +7,7 @@ import static org.springframework.test.web.client.match.MockRestRequestMatchers.
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.queryParam;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withCreatedEntity;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
 import java.net.URI;
@@ -14,6 +15,7 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.RestClient;
@@ -99,6 +101,40 @@ class KeycloakAdminCredentialAdapterTest {
         .andRespond(withSuccess());
 
     adapter.provisionCredential("new@example.com", "raw-password");
+
+    server.verify();
+  }
+
+  @Test
+  void recoversWhenCreateConflicts409() {
+    server
+        .expect(requestTo(BASE + "/realms/tasks/protocol/openid-connect/token"))
+        .andRespond(withSuccess("{\"access_token\":\"tok-123\"}", MediaType.APPLICATION_JSON));
+    // ① 初回検索: ヒットなし(競合相手がまだ作成していない)→ 作成へ
+    server
+        .expect(requestTo(Matchers.startsWith(BASE + "/admin/realms/tasks/users?")))
+        .andExpect(method(HttpMethod.GET))
+        .andRespond(withSuccess("[]", MediaType.APPLICATION_JSON));
+    // ② 作成: 並行 complete が先に作成済 → 409(Location 無し)。例外化せず再検索へ
+    server
+        .expect(requestTo(BASE + "/admin/realms/tasks/users"))
+        .andExpect(method(HttpMethod.POST))
+        .andRespond(withStatus(HttpStatus.CONFLICT));
+    // ③ 再検索: 相手が作成したユーザーがヒット → その id で provisioning 継続
+    server
+        .expect(requestTo(Matchers.startsWith(BASE + "/admin/realms/tasks/users?")))
+        .andExpect(method(HttpMethod.GET))
+        .andRespond(withSuccess("[{\"id\":\"77\"}]", MediaType.APPLICATION_JSON));
+    server
+        .expect(requestTo(BASE + "/admin/realms/tasks/users/77/reset-password"))
+        .andExpect(method(HttpMethod.PUT))
+        .andRespond(withSuccess());
+    server
+        .expect(requestTo(BASE + "/admin/realms/tasks/users/77"))
+        .andExpect(method(HttpMethod.PUT))
+        .andRespond(withSuccess());
+
+    adapter.provisionCredential("race@example.com", "raw-password");
 
     server.verify();
   }

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/user/adapter/external/KeycloakAdminRuntimeHintsTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/user/adapter/external/KeycloakAdminRuntimeHintsTest.java
@@ -25,6 +25,8 @@ class KeycloakAdminRuntimeHintsTest {
         .accepts(hints);
     assertThat(reflection().onType(KeycloakAdminCredentialAdapter.PasswordCredential.class))
         .accepts(hints);
+    assertThat(reflection().onType(KeycloakAdminCredentialAdapter.UserCreateRequest.class))
+        .accepts(hints);
     assertThat(reflection().onType(KeycloakAdminCredentialAdapter.EmailVerifiedUpdate.class))
         .accepts(hints);
   }


### PR DESCRIPTION
## 背景

ADR-0041 の dev post-deploy E2E(#843)で、SES メール実配信の修正後に会員登録フローを通したところ、**complete(`POST /api/signup/{token}/complete`)が失敗**した:

```
CredentialProvisioningException: Keycloak に対象ユーザーが見つかりません
  at KeycloakAdminCredentialAdapter.findUserIdByEmail
```

### 根本原因

`KeycloakAdminCredentialAdapter.provisionCredential` は **email 検索(find)のみ**で、新規 Keycloak ユーザーを作成する経路を持たない(コード全体に `POST /admin/realms/{realm}/users` が存在しない)。

ADR-0040 §3.1 の設計は、ADR-0006 の **User Storage SPI federation** がアプリ `users` 行を Keycloak に federated user として見せる前提だった。しかし調査の結果:

- SPI JAR は Keycloak イメージに焼き込まれ検索も実装済みだが、**どの環境の realm-export にも `UserStorageProvider` component が未配線**(federation 未活性)
- dev の Keycloak ユーザーは realm-export でシードした**ローカル4ユーザーのみ**(`federationLink=None`)
- したがって新規 signup の email は Admin API 検索に永遠に現れず、`findUserIdByEmail` が空を返して失敗

これは dev の実際の認証モデル(ローカル KC ユーザー + `OidcSubCorrelationService` による初回ログイン correlation、ADR-0040 §3.2)と整合していなかった。

## 変更

`provisionCredential` を **find-or-create** に変更:

1. email 検索 → ヒットすればその id を使用(**SPI federation 有効時はここで解決 → 作成しない**)
2. 無ければローカル Keycloak ユーザーを作成(`username=email` / `enabled=true`)
3. reset-password → `emailVerified=true`

作成したユーザーは初回ログインで app `users` の pending 行と correlation される(既存4ユーザーと同一モデル)。**SPI federation が将来有効化(ADR-0040 PR3/PR4)された環境では検索がヒットするため作成は行われず、どちらの構成でも provisioning が成立する**(create-if-not-found は両モデルに対して安全な superset)。ADR-0040 §3.1「必要なら addUser correlation」に沿う。

- `UserCreateRequest` DTO 追加 + native reflection hints 登録(ADR-0008、`KeycloakAdminRuntimeHintsTest` で固定)
- contract テスト: `not-found → create → provision` の呼び出し列 / 作成が id を返さない異常系
- 並行 complete による `409`(既存)は無視し email 再検索でフォールバック
- service account `tasks-webapi-admin` は `manage-users` 保持済(作成可能)を dev 実機で確認

## 検証

- `:webapi:test`(該当 contract + hints)green
- merge → 通常デプロイ(native build → ECS)後、dev-smoke `signup-email`(signup → SES 実配信 → complete → **新規ユーザーでログイン**)まで green を確認する

Refs #843

🤖 Generated with [Claude Code](https://claude.com/claude-code)