### PR TITLE
fix(user): 新規 Keycloak ユーザーに表示名を設定し初回ログイン遮断を解消

### DIFF
--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/adapter/external/KeycloakAdminCredentialAdapter.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/adapter/external/KeycloakAdminCredentialAdapter.java
@@ -42,10 +42,10 @@ public class KeycloakAdminCredentialAdapter implements CredentialProvisioningPor
   }
 
   @Override
-  public void provisionCredential(String email, String rawPassword) {
+  public void provisionCredential(String email, String displayName, String rawPassword) {
     try {
       String token = fetchAdminToken();
-      String userId = resolveOrCreateUserId(email, token);
+      String userId = resolveOrCreateUserId(email, displayName, token);
       resetPassword(userId, rawPassword, token);
       markEmailVerified(userId, token);
     } catch (RestClientException e) {
@@ -58,9 +58,9 @@ public class KeycloakAdminCredentialAdapter implements CredentialProvisioningPor
    * email でユーザーを解決する。既存(federated 含む)ならその id を返し、無ければローカルユーザーを新規作成して id を返す。SPI federation
    * 有効時は検索がヒットするため作成は行わない。
    */
-  private String resolveOrCreateUserId(String email, String token) {
+  private String resolveOrCreateUserId(String email, String displayName, String token) {
     String existing = findUserIdByEmail(email, token);
-    return existing != null ? existing : createUser(email, token);
+    return existing != null ? existing : createUser(email, displayName, token);
   }
 
   private String fetchAdminToken() {
@@ -106,15 +106,20 @@ public class KeycloakAdminCredentialAdapter implements CredentialProvisioningPor
    * ローカル Keycloak ユーザーを作成し id を返す({@code username=email}、{@code enabled=true}、{@code emailVerified}
    * は後続の {@link #markEmailVerified} で設定)。作成レスポンスの {@code Location} ヘッダから id を取り出す。並行 complete による
    * {@code 409}(既存)は無視し、email 再検索でフォールバックする。
+   *
+   * <p>{@code firstName} / {@code lastName} は realm の user profile 必須項目であり、未設定だと初回ログインで 「Update
+   * Account Information」に遮られ dashboard へ到達できない。app は表示名を単一の {@code full_name} で保持するため、両フィールドに
+   * {@code displayName} を設定して必須制約を満たす(profile SoT は tasks-webapi の {@code users.full_name}。SPI
+   * federation 経路では UserAdapter が {@code firstName=full_name} を返す)。
    */
-  private String createUser(String email, String token) {
+  private String createUser(String email, String displayName, String token) {
     URI location =
         restClient
             .post()
             .uri("/admin/realms/{realm}/users", props.realm())
             .header(HttpHeaders.AUTHORIZATION, bearer(token))
             .contentType(MediaType.APPLICATION_JSON)
-            .body(new UserCreateRequest(email, email, true))
+            .body(new UserCreateRequest(email, email, displayName, displayName, true))
             .retrieve()
             // 競合(既に存在)は例外にせず、下の再検索でフォールバックする
             .onStatus(status -> status.value() == 409, (req, res) -> {})
@@ -176,8 +181,12 @@ public class KeycloakAdminCredentialAdapter implements CredentialProvisioningPor
   /** reset-password の credential 表現。 */
   public record PasswordCredential(String type, String value, boolean temporary) {}
 
-  /** ユーザー新規作成リクエスト(username=email, enabled=true)。emailVerified は後続で設定。 */
-  public record UserCreateRequest(String username, String email, boolean enabled) {}
+  /**
+   * ユーザー新規作成リクエスト(username=email, enabled=true)。firstName / lastName は realm profile 必須項目を 満たすため
+   * displayName を設定。emailVerified は後続で設定。
+   */
+  public record UserCreateRequest(
+      String username, String email, String firstName, String lastName, boolean enabled) {}
 
   /** ユーザー更新(emailVerified のみ)。 */
   public record EmailVerifiedUpdate(boolean emailVerified) {}

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/adapter/external/LoggingCredentialProvisioningAdapter.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/adapter/external/LoggingCredentialProvisioningAdapter.java
@@ -14,7 +14,7 @@ import xyz.dgz48.tasks.webapi.user.usecase.CredentialProvisioningPort;
 public class LoggingCredentialProvisioningAdapter implements CredentialProvisioningPort {
 
   @Override
-  public void provisionCredential(String email, String rawPassword) {
+  public void provisionCredential(String email, String displayName, String rawPassword) {
     log.info("[dev] credential provisioning skipped (logging adapter): email={}", email);
   }
 }

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/usecase/CredentialProvisioningPort.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/usecase/CredentialProvisioningPort.java
@@ -10,11 +10,14 @@ package xyz.dgz48.tasks.webapi.user.usecase;
 public interface CredentialProvisioningPort {
 
   /**
-   * 指定 email の Keycloak ユーザーにパスワードを設定し、email を検証済みにする。
+   * 指定 email の Keycloak ユーザーにパスワードを設定し、email を検証済みにする。ユーザーが存在しない場合は作成する(SPI federation
+   * 未活性の環境向け。詳細は実装 Javadoc 参照)。
    *
    * @param email 対象ユーザーの email(Keycloak username)
+   * @param displayName 表示名(app の {@code full_name})。ユーザー新規作成時に Keycloak profile の必須項目 (firstName /
+   *     lastName)を満たすために用いる。既存ユーザーへの反映は行わない(profile SoT は tasks-webapi)。
    * @param rawPassword 設定するパスワード(平文。ログ出力禁止)
    * @throws CredentialProvisioningException Keycloak への設定に失敗した場合
    */
-  void provisionCredential(String email, String rawPassword);
+  void provisionCredential(String email, String displayName, String rawPassword);
 }

--- a/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/usecase/RegisterMemberUseCase.java
+++ b/webapi/src/main/java/xyz/dgz48/tasks/webapi/user/usecase/RegisterMemberUseCase.java
@@ -32,7 +32,7 @@ public class RegisterMemberUseCase {
     Long userId =
         userRegistrationPort.upsertPendingMember(
             cmd.email(), cmd.fullName(), cmd.fullNameKana(), cmd.departmentName());
-    credentialProvisioningPort.provisionCredential(cmd.email(), cmd.rawPassword());
+    credentialProvisioningPort.provisionCredential(cmd.email(), cmd.fullName(), cmd.rawPassword());
     return userId;
   }
 }

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/user/adapter/external/KeycloakAdminCredentialAdapterTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/user/adapter/external/KeycloakAdminCredentialAdapterTest.java
@@ -66,7 +66,7 @@ class KeycloakAdminCredentialAdapterTest {
         .andExpect(header("Authorization", "Bearer tok-123"))
         .andRespond(withSuccess());
 
-    adapter.provisionCredential("a@example.com", "raw-password");
+    adapter.provisionCredential("a@example.com", "既存 太郎", "raw-password");
 
     server.verify();
   }
@@ -81,13 +81,16 @@ class KeycloakAdminCredentialAdapterTest {
         .expect(requestTo(Matchers.startsWith(BASE + "/admin/realms/tasks/users?")))
         .andExpect(method(HttpMethod.GET))
         .andRespond(withSuccess("[]", MediaType.APPLICATION_JSON));
-    // ② 作成: username=email, enabled=true。201 + Location ヘッダで id を返す
+    // ② 作成: username=email, enabled=true, firstName/lastName=displayName(realm profile 必須項目)。
+    //   201 + Location ヘッダで id を返す
     server
         .expect(requestTo(BASE + "/admin/realms/tasks/users"))
         .andExpect(method(HttpMethod.POST))
         .andExpect(header("Authorization", "Bearer tok-123"))
         .andExpect(jsonPath("$.username").value("new@example.com"))
         .andExpect(jsonPath("$.email").value("new@example.com"))
+        .andExpect(jsonPath("$.firstName").value("新規 太郎"))
+        .andExpect(jsonPath("$.lastName").value("新規 太郎"))
         .andExpect(jsonPath("$.enabled").value(true))
         .andRespond(withCreatedEntity(URI.create(BASE + "/admin/realms/tasks/users/99")));
     // ③ reset-password → ④ emailVerified を新規 id に対して実施
@@ -100,7 +103,7 @@ class KeycloakAdminCredentialAdapterTest {
         .andExpect(method(HttpMethod.PUT))
         .andRespond(withSuccess());
 
-    adapter.provisionCredential("new@example.com", "raw-password");
+    adapter.provisionCredential("new@example.com", "新規 太郎", "raw-password");
 
     server.verify();
   }
@@ -134,7 +137,7 @@ class KeycloakAdminCredentialAdapterTest {
         .andExpect(method(HttpMethod.PUT))
         .andRespond(withSuccess());
 
-    adapter.provisionCredential("race@example.com", "raw-password");
+    adapter.provisionCredential("race@example.com", "競合 太郎", "raw-password");
 
     server.verify();
   }
@@ -158,7 +161,7 @@ class KeycloakAdminCredentialAdapterTest {
         .andExpect(method(HttpMethod.GET))
         .andRespond(withSuccess("[]", MediaType.APPLICATION_JSON));
 
-    assertThatThrownBy(() -> adapter.provisionCredential("missing@example.com", "pw"))
+    assertThatThrownBy(() -> adapter.provisionCredential("missing@example.com", "欠番 太郎", "pw"))
         .isInstanceOf(CredentialProvisioningException.class);
   }
 
@@ -168,7 +171,7 @@ class KeycloakAdminCredentialAdapterTest {
         .expect(requestTo(BASE + "/realms/tasks/protocol/openid-connect/token"))
         .andRespond(withSuccess("{}", MediaType.APPLICATION_JSON));
 
-    assertThatThrownBy(() -> adapter.provisionCredential("a@example.com", "pw"))
+    assertThatThrownBy(() -> adapter.provisionCredential("a@example.com", "太郎", "pw"))
         .isInstanceOf(CredentialProvisioningException.class);
   }
 }

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/user/adapter/external/LoggingCredentialProvisioningAdapterTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/user/adapter/external/LoggingCredentialProvisioningAdapterTest.java
@@ -11,7 +11,7 @@ class LoggingCredentialProvisioningAdapterTest {
 
   @Test
   void provisionCredentialDoesNotThrow() {
-    assertThatCode(() -> adapter.provisionCredential("user@example.com", "raw-password"))
+    assertThatCode(() -> adapter.provisionCredential("user@example.com", "表示 名", "raw-password"))
         .doesNotThrowAnyException();
   }
 }

--- a/webapi/src/test/java/xyz/dgz48/tasks/webapi/user/usecase/RegisterMemberUseCaseTest.java
+++ b/webapi/src/test/java/xyz/dgz48/tasks/webapi/user/usecase/RegisterMemberUseCaseTest.java
@@ -34,7 +34,7 @@ class RegisterMemberUseCaseTest {
     assertThat(id).isEqualTo(42L);
     InOrder ordered = inOrder(userRegistrationPort, credentialProvisioningPort);
     ordered.verify(userRegistrationPort).upsertPendingMember("a@example.com", "氏名", "シメイ", null);
-    ordered.verify(credentialProvisioningPort).provisionCredential("a@example.com", "pw");
+    ordered.verify(credentialProvisioningPort).provisionCredential("a@example.com", "氏名", "pw");
   }
 
   @Test
@@ -43,7 +43,7 @@ class RegisterMemberUseCaseTest {
     when(userRegistrationPort.upsertPendingMember(any(), any(), any(), any())).thenReturn(1L);
     doThrow(new CredentialProvisioningException("keycloak down"))
         .when(credentialProvisioningPort)
-        .provisionCredential(any(), any());
+        .provisionCredential(any(), any(), any());
 
     assertThatThrownBy(() -> useCase.register(cmd))
         .isInstanceOf(CredentialProvisioningException.class);


### PR DESCRIPTION
## 背景

#858(find-or-create)適用後、dev-smoke `signup-email` を再実行したところ、**complete まで成功**(ユーザー作成 + パスワード + emailVerified)したが、続く**新規ユーザーでのログインが失敗**した。

dev 実機のログイン画面スナップショットで原因を特定:

```
heading "Update Account Information"
  First name * — Please specify this field.
  Last name  * — Please specify this field.
```

find-or-create で作成したローカル Keycloak ユーザーは `firstName`/`lastName` 未設定であり、realm の user profile がこれらを必須とするため、初回ログインで「Update Account Information」に遮られ `/dashboard.html` へ到達できなかった。

## 変更

`CredentialProvisioningPort.provisionCredential` に `displayName`(app の `full_name`)を追加し、ユーザー新規作成時に `firstName`/`lastName` へ設定して必須制約を満たす。

- app は表示名を**単一の `full_name`** で保持し、Keycloak の first/last は SoT ではない(profile SoT は tasks-webapi の `users.full_name`)。SPI federation 経路でも `UserAdapter` が `firstName=full_name` を返す(`keycloak/.../UserAdapter.java:60`)。この整合を踏まえ、両フィールドに `full_name` を設定する。
- **既存ユーザーには反映しない**(検索ヒット時は作成しないため、profile の上書きは発生しない)。
- `UserCreateRequest` に `firstName`/`lastName` を追加、`RegisterMemberUseCase` が `cmd.fullName()` を渡す、`LoggingCredentialProvisioningAdapter` と各テストを更新。
- 作成 contract テストで POST body の `firstName`/`lastName=displayName` を assert。

## 検証

- `:webapi:test`(adapter contract / hints / logging / usecase)green
- merge → 通常デプロイ(native → ECS)後、dev-smoke `signup-email` の **complete → 新規ユーザーでログイン → dashboard 到達**まで green を確認する

Refs #843

🤖 Generated with [Claude Code](https://claude.com/claude-code)