### PR TITLE
ci(dev-smoke): デプロイ後 dev-smoke E2E ワークフロー + 最小権限 OIDC ロール + runbook

### DIFF
--- a/.github/workflows/dev-smoke.yml
+++ b/.github/workflows/dev-smoke.yml
@@ -1,0 +1,117 @@
+name: "Dev Smoke (post-deploy E2E)"
+
+# ADR-0041 / #843 — dev へデプロイ済みの実体に対するブラウザ主軸 E2E スモーク。
+# 手動トリガ(workflow_dispatch)。デプロイ直後の疎通確認や、native-only 退行の検知に用いる。
+# 実 Keycloak ログイン / native write / SES 実配信メール(S3 受信)まで通しで検証する。
+#
+# 前提:
+#   - dev 環境が稼働中であること(夜間停止中は RDS/ECS を起動してから実行)。
+#   - GitHub Environment "dev-smoke" が存在し、OIDC role `dev-smoke`(S3 e2e-mail 読取)へ紐付くこと。
+#   - Environment secret DEV_SMOKE_KC_ADMIN_CLIENT_SECRET(signup ユーザー後片付け用の
+#     tasks-webapi-admin client_credentials secret)が設定されていること。
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: 'SPA base URL (default: https://tasks-dev.dgz48.xyz)'
+        required: false
+        default: 'https://tasks-dev.dgz48.xyz'
+        type: string
+      grep:
+        description: 'Playwright --grep filter (blank = 全 dev-smoke)'
+        required: false
+        default: ''
+        type: string
+
+env:
+  LANG: ja_JP.UTF-8
+  TZ: Asia/Tokyo
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  AWS_REGION: ap-northeast-1
+  AWS_ACCOUNT_ID: "138285070797"
+
+# 同一環境への多重実行を避ける(実 Keycloak ユーザー作成/削除・実メール送信を伴うため)
+concurrency:
+  group: dev-smoke
+  cancel-in-progress: false
+
+jobs:
+  dev-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment: dev-smoke
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          # <env>-smoke ロール(S3 e2e-mail の inbound/ 読取のみ)。ADR-0041 / iam_oidc。
+          role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/dev-smoke
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Set up Node 24
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: npm
+          cache-dependency-path: e2e/package-lock.json
+
+      - name: Install e2e dependencies
+        working-directory: e2e
+        run: npm ci
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('e2e/package-lock.json') }}
+          restore-keys: |
+            playwright-${{ runner.os }}-
+
+      - name: Install Playwright browsers
+        working-directory: e2e
+        run: |
+          if [ "${{ steps.playwright-cache.outputs.cache-hit }}" = "true" ]; then
+            npx playwright install-deps chromium
+          else
+            npx playwright install --with-deps chromium
+          fi
+
+      - name: Run dev-smoke suite
+        working-directory: e2e
+        env:
+          CI: true
+          BASE_URL: ${{ inputs.base_url }}
+          # SES 受信メール(S3)の場所。既定はワークフロー内で解決されるが上書き可能にしておく。
+          DEV_SMOKE_MAIL_BUCKET: platform-dev-e2e-mail
+          # signup フルフローで作成した Keycloak ユーザーの後片付けに使う。
+          DEV_SMOKE_KC_ADMIN_CLIENT_SECRET: ${{ secrets.DEV_SMOKE_KC_ADMIN_CLIENT_SECRET }}
+        run: |
+          if [ -n "${{ inputs.grep }}" ]; then
+            npx playwright test --config playwright.dev-smoke.config.ts --grep "${{ inputs.grep }}"
+          else
+            npx playwright test --config playwright.dev-smoke.config.ts
+          fi
+
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: dev-smoke-report
+          path: e2e/playwright-report/
+          if-no-files-found: ignore
+
+      - name: Upload test results (trace / video)
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: dev-smoke-results
+          path: e2e/test-results/
+          if-no-files-found: ignore

--- a/docs/runbook/release-checklist.md
+++ b/docs/runbook/release-checklist.md
@@ -47,6 +47,33 @@ curl -s https://api-dev.tasks.dgz48.xyz/actuator/health   # {"status":"UP"}
 - 性能 N+1 回帰(#769): `TaskQueryCountIT` / `DashboardQueryCountIT`
 - 監査ハッシュチェーン B-05([ADR-0038](../adr/0038-audit-log-hash-chain-tamper-evidence.md)): `AuditChainVerificationIT` / `VerifyAuditChainUseCaseTest` / `AuditChainVerificationBatchSchedulerTest`
 
+### 1.2 デプロイ後 dev-smoke E2E(post-deploy、[ADR-0041](../adr/0041-post-deploy-dev-e2e-and-email-verification.md))
+
+§1 の CI ゲートは **pre-deploy**(JVM / ローカルスタック)であり、native image 固有の退行や dev 実体の構成差は捕捉できない。これを補うのが **デプロイ後**に dev 実体へ通すブラウザ主軸スモーク `Dev Smoke (post-deploy E2E)`(`.github/workflows/dev-smoke.yml`、`e2e/tests-dev/*.dev-smoke.spec.ts`)。実行タイミングは **§2 のデプロイ完了後**(下記 §2 の post-deploy 手順から参照)。
+
+カバレッジ(実 Keycloak / native write / 実 SES 配信を通しで検証):
+
+| spec | 検証内容 |
+|---|---|
+| `login-dashboard` | 実 Keycloak ログイン → dashboard(SPI 認証経路) |
+| `task-journey` | タスク作成・ステータス変更・削除(native write + ETag、失敗時 afterEach で後片付け) |
+| `login-theme` | ログイン画面の新規登録導線(`tasks-login` テーマ) |
+| `api-invariants` | 未認証 401 / 非メンバーテナント 403(NIST、認可マトリクス §4.1) |
+| `signup-email` | セルフサインアップ double opt-in **フルフロー**: signup → 実 SES 配信 → S3 受信 → 確認リンク → complete(ユーザー作成 + Keycloak 資格プロビジョニング)→ 新規ユーザーでログイン到達 |
+
+実行(手動 `workflow_dispatch`):
+
+```bash
+gh workflow run dev-smoke.yml                       # 全 dev-smoke(dev 稼働中に限る)
+gh workflow run dev-smoke.yml -f grep='signup email' # 一部のみ
+```
+
+前提・注意:
+
+- **dev が稼働中であること**。夜間停止中(§5.2、02:00 JST〜)は先に RDS/ECS を起動する([dev-operations.md](dev-operations.md))。
+- GitHub Environment **`dev-smoke`**(OIDC role `dev-smoke` = e2e-mail バケット `inbound/` の S3 読取のみ、`infra/shared/modules/iam_oidc`)と Environment secret **`DEV_SMOKE_KC_ADMIN_CLIENT_SECRET`**(signup で作成した Keycloak ユーザーの後片付け用 `tasks-webapi-admin` client secret)が設定済みであること。
+- `signup-email` は **実メール送信 + 実 Keycloak ユーザー作成**を伴う(afterEach で作成ユーザーを削除)。SES は sandbox のため宛先ドメイン `e2e.dgz48.xyz` は検証済み identity。
+
 ## 2. デプロイ 2 段手順(plan → 承認 → apply)
 
 [ADR-0031](../adr/0031-single-product-version-dispatch-deploy.md) の dispatch 駆動。詳細は [dev-operations.md](dev-operations.md#デプロイadr-0031-dispatch) と整合。
@@ -76,6 +103,12 @@ curl -s https://api-dev.tasks.dgz48.xyz/actuator/health   # {"status":"UP"}
 - dev は承認ゲートなし(自動適用)。stg/prd は plan 添付を確認して apply を承認する。
 - 目標 digest と現行 digest が一致する場合、`deploy-webapi` は no-op(無駄な rolling update をしない)。
 - **ロールバック**: 直前の正常バージョンを再デプロイ(`gh workflow run deploy.yml -f version=<prev> -f environment=dev`)。infra も同 ref に戻るため差分に注意([dev-operations.md](dev-operations.md#ロールバック))。
+
+**post-deploy 疎通(dev)**: デプロイ完了後、dev 実体に対して §1.2 の dev-smoke E2E を実行して native / dev 構成差の退行を確認する。
+
+```bash
+gh workflow run dev-smoke.yml   # 完了後 Actions で全 spec green を確認(dev 稼働中に限る)
+```
 
 ## 3. IaC drift ゼロ確認
 
@@ -173,15 +206,21 @@ aws ssm get-parameters-by-path --path /tasks/dev --recursive --region ap-northea
 - **infra レベルの CloudWatch Alarm / SNS / metric filter は未配線**(`infra/modules/logging/main.tf` のコメントで、infra ADR-0005(ログ基盤、`infra/docs/adr/0005-logging-platform.md`。app の [ADR-0005](../adr/0005-task-authorization-three-roles.md) とは番号衝突する別 ADR)の Alarm/SNS 連携として明示的に後回し)。現状のアラートはアプリ側(B-05 バッチ + 構造化ログ)のみ。
 - 対応: MVP のアラート要件を確定し、metric filter → Alarm → SNS 配線を別 Issue 化する(本チェックリストで **既知ギャップ**として記録)。
 
+### 6.4 デプロイ後スモークによる実体確認([ADR-0041](../adr/0041-post-deploy-dev-e2e-and-email-verification.md))
+
+pre-deploy CI(§1)と infra アラート(§6.1–6.3)に加え、**デプロイ済み実体の疎通**は §1.2 の dev-smoke E2E で確認する。native / 実 Keycloak / 実 SES 配信という **CI では捕捉できない層**を通しで検証し、デプロイ後の即時退行検知に用いる(手動 `gh workflow run dev-smoke.yml`)。
+
 チェック:
 
 - [ ] 主要ログ group にログが出力されている(`aws logs tail /tasks/dev/webapi --since 15m`)
 - [ ] B-05 検証バッチが日次で成功している(監査ログに不整合 ERROR が無い)
 - [ ] infra アラート未配線を関係者が認識(別 Issue 追跡)
+- [ ] デプロイ後 dev-smoke E2E(§1.2)が全 spec green(native / 実 Keycloak / 実 SES 配信を通し確認)
 
 ## 7. 最終ゲート サマリ
 
 - [ ] §1 全 CI green(カバレッジ 0.80 / 漏洩・認可・性能・監査の回帰 IT green)
+- [ ] §1.2 デプロイ後 dev-smoke E2E が全 spec green(native / 実 Keycloak / 実 SES 配信)
 - [ ] §2 デプロイ 2 段(plan → 承認 → apply)を runbook どおり実施できる
 - [ ] §3 IaC drift ゼロ(plan が No changes)
 - [ ] §4 Secrets 棚卸し(SecureString 実値設定済み)

--- a/infra/shared/modules/iam_oidc/main.tf
+++ b/infra/shared/modules/iam_oidc/main.tf
@@ -26,8 +26,9 @@ data "aws_iam_policy_document" "trust" {
     tasks_plan      = "tasks-plan"
     tasks_apply     = "tasks-apply"
     release_build   = "release-build"
-    tasks_deploy    = var.env # "dev" → environment:dev OIDC sub (webapi ECS + web S3/CF + artifact verify)
-    platform_deploy = var.env # "dev" → environment:dev OIDC sub (keycloak ECS on platform cluster)
+    tasks_deploy    = var.env            # "dev" → environment:dev OIDC sub (webapi ECS + web S3/CF + artifact verify)
+    platform_deploy = var.env            # "dev" → environment:dev OIDC sub (keycloak ECS on platform cluster)
+    dev_smoke       = "${var.env}-smoke" # "dev" → environment:dev-smoke OIDC sub (post-deploy dev-smoke E2E, ADR-0041)
   }
 
   statement {
@@ -1295,6 +1296,45 @@ resource "aws_iam_role_policy" "release_build" {
   name   = "release-build-policy"
   role   = aws_iam_role.release_build.id
   policy = data.aws_iam_policy_document.release_build.json
+}
+
+# ---------------------------------------------------------------------------
+# <env>-smoke  (read-only; post-deploy dev-smoke E2E — ADR-0041 / #843)
+# Trust: environment:<env>-smoke。dev-smoke.yml が SES 受信メールを S3 から取得して
+# signup フルフローを検証するための最小権限(e2e-mail バケットの inbound/ プレフィックス読取のみ)。
+# Keycloak/SPA へは公開 HTTPS で到達するため AWS 権限は S3 読取だけで足りる。
+# ---------------------------------------------------------------------------
+
+resource "aws_iam_role" "dev_smoke" {
+  name               = "${var.env}-smoke"
+  assume_role_policy = data.aws_iam_policy_document.trust["dev_smoke"].json
+}
+
+data "aws_iam_policy_document" "dev_smoke" {
+  # SES 受信メール本文(MIME)の取得。規約 R2: inbound/ プレフィックスのオブジェクト ARN に限定。
+  statement {
+    sid       = "E2eMailGet"
+    actions   = ["s3:GetObject"]
+    resources = ["arn:aws:s3:::platform-${var.env}-e2e-mail/inbound/*"]
+  }
+
+  # 受信メール一覧(宛先一致ポーリング)。ListBucket は prefix condition で inbound/ に限定。
+  statement {
+    sid       = "E2eMailList"
+    actions   = ["s3:ListBucket"]
+    resources = ["arn:aws:s3:::platform-${var.env}-e2e-mail"]
+    condition {
+      test     = "StringLike"
+      variable = "s3:prefix"
+      values   = ["inbound/*"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy" "dev_smoke" {
+  name   = "${var.env}-smoke-policy"
+  role   = aws_iam_role.dev_smoke.id
+  policy = data.aws_iam_policy_document.dev_smoke.json
 }
 
 # ---------------------------------------------------------------------------

--- a/infra/shared/modules/iam_oidc/outputs.tf
+++ b/infra/shared/modules/iam_oidc/outputs.tf
@@ -37,3 +37,8 @@ output "platform_deploy_role_arn" {
   description = "ARN of the platform-<env>-deploy IAM role (used by deploy.yml: deploy-keycloak)"
   value       = aws_iam_role.platform_deploy.arn
 }
+
+output "dev_smoke_role_arn" {
+  description = "ARN of the <env>-smoke IAM role (used by dev-smoke.yml: post-deploy dev-smoke E2E, S3 mail read)"
+  value       = aws_iam_role.dev_smoke.arn
+}


### PR DESCRIPTION
## 概要

ADR-0041 / #843 の **Phase 4**。デプロイ済みの dev 実体に対してブラウザ主軸スモークを手動実行する `workflow_dispatch` を追加する。pre-deploy CI(JVM / ローカルスタック)では捕捉できない **native / 実 Keycloak / 実 SES 配信** の層を通しで検証し、デプロイ後の即時退行検知に用いる。

先行してマージ済みのフロー(#852 テストスイート本体、#857/#858/#859 の SES・provisioning 修正)を、dev 実機で v0.2.7 として通し **全 spec green を確認済み**。本 PR はその CI 実行系(ワークフロー + 最小権限 IAM + runbook)を追加する。

## 変更

- **`.github/workflows/dev-smoke.yml`**: `workflow_dispatch`(`base_url` / `grep` 入力)。`environment: dev-smoke` で OIDC ロール `dev-smoke` を assume、Node 24 + Playwright chromium で `playwright.dev-smoke.config.ts` を実行。report / trace / video を artifact 化。実 Keycloak ユーザー作成・実メール送信を伴うため `concurrency: dev-smoke`(直列)。
- **`infra/shared/modules/iam_oidc`**: `<env>-smoke` OIDC ロール追加(trust `environment:<env>-smoke`)。権限は **e2e-mail バケットの `inbound/` に対する `s3:GetObject` + prefix 限定 `s3:ListBucket` のみ**(規約 R2、`release-build` の S3 スコープと同方式)。`mail.ts` の `ListObjectsV2(Prefix: inbound/)` + `GetObject(Key: inbound/...)` に一致。`dev_smoke_role_arn` を output。
- **`docs/runbook/release-checklist.md`**: §1.2(post-deploy dev-smoke ゲート・カバレッジ表・実行手順・前提)、§2 に post-deploy 疎通手順、§6.4 + §7 サマリにチェック項目。

## merge 後のセットアップ(#843 クローズ前に実施)

1. `terraform apply`(platform/shared)で `dev-smoke` ロール作成。
2. GitHub Environment **`dev-smoke`** 作成 + Environment secret **`DEV_SMOKE_KC_ADMIN_CLIENT_SECRET`** 設定。
3. `gh workflow run dev-smoke.yml` で全 spec green を確認 → #843 クローズ。

Refs #843

🤖 Generated with [Claude Code](https://claude.com/claude-code)