### PR TITLE
fix(iam): dev-smoke ロールを platform-<env>-smoke に改名(apply ロール管理スコープ整合)

### DIFF
--- a/.github/workflows/dev-smoke.yml
+++ b/.github/workflows/dev-smoke.yml
@@ -51,8 +51,8 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:
-          # <env>-smoke ロール(S3 e2e-mail の inbound/ 読取のみ)。ADR-0041 / iam_oidc。
-          role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/dev-smoke
+          # platform-<env>-smoke ロール(S3 e2e-mail の inbound/ 読取のみ)。ADR-0041 / iam_oidc。
+          role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/platform-dev-smoke
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Set up Node 24

--- a/docs/runbook/release-checklist.md
+++ b/docs/runbook/release-checklist.md
@@ -71,7 +71,7 @@ gh workflow run dev-smoke.yml -f grep='signup email' # 一部のみ
 前提・注意:
 
 - **dev が稼働中であること**。夜間停止中(§5.2、02:00 JST〜)は先に RDS/ECS を起動する([dev-operations.md](dev-operations.md))。
-- GitHub Environment **`dev-smoke`**(OIDC role `dev-smoke` = e2e-mail バケット `inbound/` の S3 読取のみ、`infra/shared/modules/iam_oidc`)と Environment secret **`DEV_SMOKE_KC_ADMIN_CLIENT_SECRET`**(signup で作成した Keycloak ユーザーの後片付け用 `tasks-webapi-admin` client secret)が設定済みであること。
+- GitHub Environment **`dev-smoke`**(OIDC role `platform-dev-smoke` = e2e-mail バケット `inbound/` の S3 読取のみ、`infra/shared/modules/iam_oidc`)と Environment secret **`DEV_SMOKE_KC_ADMIN_CLIENT_SECRET`**(signup で作成した Keycloak ユーザーの後片付け用 `tasks-webapi-admin` client secret)が設定済みであること。
 - `signup-email` は **実メール送信 + 実 Keycloak ユーザー作成**を伴う(afterEach で作成ユーザーを削除)。SES は sandbox のため宛先ドメイン `e2e.dgz48.xyz` は検証済み identity。
 
 ## 2. デプロイ 2 段手順(plan → 承認 → apply)

--- a/infra/shared/modules/iam_oidc/main.tf
+++ b/infra/shared/modules/iam_oidc/main.tf
@@ -1299,14 +1299,16 @@ resource "aws_iam_role_policy" "release_build" {
 }
 
 # ---------------------------------------------------------------------------
-# <env>-smoke  (read-only; post-deploy dev-smoke E2E — ADR-0041 / #843)
-# Trust: environment:<env>-smoke。dev-smoke.yml が SES 受信メールを S3 から取得して
-# signup フルフローを検証するための最小権限(e2e-mail バケットの inbound/ プレフィックス読取のみ)。
-# Keycloak/SPA へは公開 HTTPS で到達するため AWS 権限は S3 読取だけで足りる。
+# platform-<env>-smoke  (read-only; post-deploy dev-smoke E2E — ADR-0041 / #843)
+# Trust: environment:<env>-smoke(GitHub Environment 名は "<env>-smoke")。dev-smoke.yml が
+# SES 受信メールを S3 から取得して signup フルフローを検証するための最小権限(e2e-mail バケットの
+# inbound/ プレフィックス読取のみ)。Keycloak/SPA へは公開 HTTPS で到達するため AWS 権限は S3 読取だけで足りる。
+# ロール名は platform-* とする: platform_apply の IAM 管理スコープ(role/platform-* + role/tasks-*)で
+# 作成でき、かつ platform 所有の e2e-mail バケットを読むため。GitHub Environment 名(<env>-smoke)とは別。
 # ---------------------------------------------------------------------------
 
 resource "aws_iam_role" "dev_smoke" {
-  name               = "${var.env}-smoke"
+  name               = "platform-${var.env}-smoke"
   assume_role_policy = data.aws_iam_policy_document.trust["dev_smoke"].json
 }
 
@@ -1332,7 +1334,7 @@ data "aws_iam_policy_document" "dev_smoke" {
 }
 
 resource "aws_iam_role_policy" "dev_smoke" {
-  name   = "${var.env}-smoke-policy"
+  name   = "platform-${var.env}-smoke-policy"
   role   = aws_iam_role.dev_smoke.id
   policy = data.aws_iam_policy_document.dev_smoke.json
 }

--- a/infra/shared/modules/iam_oidc/outputs.tf
+++ b/infra/shared/modules/iam_oidc/outputs.tf
@@ -39,6 +39,6 @@ output "platform_deploy_role_arn" {
 }
 
 output "dev_smoke_role_arn" {
-  description = "ARN of the <env>-smoke IAM role (used by dev-smoke.yml: post-deploy dev-smoke E2E, S3 mail read)"
+  description = "ARN of the platform-<env>-smoke IAM role (used by dev-smoke.yml: post-deploy dev-smoke E2E, S3 mail read)"
   value       = aws_iam_role.dev_smoke.arn
 }


### PR DESCRIPTION
## 背景

#860 で追加した post-deploy dev-smoke 用 OIDC ロール名 `dev-smoke` は、`platform_apply` の IAM 管理スコープ(`role/platform-*` + `role/tasks-*`、`infra/shared/modules/iam_oidc` L259-261)に**一致しない**。このまま terraform apply すると `iam:CreateRole` が AccessDenied になる(self-managed IAM の 2-pass を避けるべき箇所)。

## 変更

ロール名を `role/platform-*` に一致する **`platform-<env>-smoke`** へ改名(= `platform-dev-smoke`)。platform 所有の e2e-mail バケットを読むロールであり platform 管理下が妥当。

- **GitHub Environment 名は `dev-smoke` のまま**(trust の `environment:` sub は role 名と独立)。
- `dev-smoke.yml` の `role-to-assume` を `role/platform-dev-smoke` に。
- outputs / runbook の参照を更新。

権限内容(inbound/ の GetObject + prefix 限定 ListBucket)は不変。`terraform fmt`/`validate`、markdownlint 済。

Refs #843

🤖 Generated with [Claude Code](https://claude.com/claude-code)