### PR TITLE
feat(keycloak): SPI federation を有効化(Stage1: compose/CI)

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -23,6 +23,8 @@ services:
       context: .
       dockerfile: keycloak/Dockerfile
     # Override production CMD for local development: use start-dev (H2 embedded) with realm import.
+    # KC 自身のストアは H2 のまま。User Storage SPI(ADR-0006)は下記 SPI_DB_* で compose の MySQL
+    # (app の users テーブル)へ別途 JDBC 接続して federation する。
     command: start-dev --import-realm
     environment:
       KEYCLOAK_ADMIN: admin
@@ -31,11 +33,18 @@ services:
       # matching what the browser sees. Without this, start-dev derives the URL from the incoming
       # Host header, which would differ between browser and webapi backchannel calls.
       KC_HOSTNAME: "http://localhost:18080"
+      # User Storage SPI の接続先(realm-export のコンポーネントは有効化のみ、接続情報は env で与える)。
+      SPI_DB_JDBC_URL: "jdbc:mysql://mysql:3306/tasks?allowPublicKeyRetrieval=true&useSSL=false"
+      SPI_DB_USERNAME: tasks_webapi
+      SPI_DB_PASSWORD: tasks_webapi
     ports:
       - "18080:8080"
     volumes:
       - ./keycloak/realm-export:/opt/keycloak/data/import
-    # start-dev は H2 embedded を使用するため mysql への depends_on は不要
+    # SPI が起動直後から MySQL(app users)を参照できるよう mysql の healthy を待つ。
+    depends_on:
+      mysql:
+        condition: service_healthy
     healthcheck:
       # curl は Keycloak 26 の slim イメージに含まれないため bash /dev/tcp で代用する。
       # /realms/tasks が 200 を返す = サーバ起動 + realm import 完了の両方を同時に確認できる。

--- a/keycloak/Dockerfile
+++ b/keycloak/Dockerfile
@@ -13,15 +13,16 @@ COPY keycloak/ keycloak/
 
 RUN printf 'rootProject.name = "tasks-monorepo"\ninclude("keycloak")\n' > settings.gradle.kts && \
     chmod +x ./gradlew && \
-    ./gradlew :keycloak:jar --no-daemon -x test
+    ./gradlew :keycloak:stageProviders --no-daemon -x test
 
 # ─── Stage 2: Keycloak optimized build (kc.sh build) ───────────────────────
-# Installs the SPI JAR into Keycloak's providers/ directory and runs kc.sh build
-# to produce an optimized Quarkus augmentation for MySQL. No DB connection is
+# Installs the SPI JAR + MySQL JDBC driver into Keycloak's providers/ directory and runs
+# kc.sh build to produce an optimized Quarkus augmentation for MySQL. No DB connection is
 # needed at this stage — kc.sh build only sets compile-time configuration.
+# ドライバは SPI(User Storage federation)が app users テーブルへ DriverManager 接続するのに必要(ADR-0006)。
 FROM quay.io/keycloak/keycloak:26.6.4 AS kc-builder
 
-COPY --from=spi-builder /workspace/keycloak/build/libs/*.jar /opt/keycloak/providers/
+COPY --from=spi-builder /workspace/keycloak/build/providers/*.jar /opt/keycloak/providers/
 
 ENV KC_DB=mysql
 ENV KC_HEALTH_ENABLED=true

--- a/keycloak/build.gradle.kts
+++ b/keycloak/build.gradle.kts
@@ -75,6 +75,17 @@ dependencies {
     errorprone("com.uber.nullaway:nullaway:0.13.7")
 }
 
+// Keycloak イメージの providers/ へ配備する JAR(SPI 本体 + MySQL JDBC ドライバ)を build/providers/ に集める。
+// Dockerfile の spi-builder ステージがこのタスクを実行し、build/providers/ を /opt/keycloak/providers/ へ COPY する。
+// SPI は User Storage federation で app の users テーブルへ DriverManager で JDBC 接続するため、driver を
+// SPI の provider classloader から解決可能にする必要がある(Keycloak 内蔵ストア用の MySQL driver は別 classloader
+// のため SPI からは見えない)。ADR-0006 / #862。
+val stageProviders by tasks.registering(Copy::class) {
+    from(tasks.named("jar"))
+    from(mysqlDriver)
+    into(layout.buildDirectory.dir("providers"))
+}
+
 tasks.named<JavaCompile>("compileJava") {
     options.errorprone {
         error("NullAway")

--- a/keycloak/realm-export/tasks-realm.json
+++ b/keycloak/realm-export/tasks-realm.json
@@ -195,6 +195,18 @@
   "adminTheme": "tasks-admin",
   "loginTheme": "tasks-login",
   "components": {
+    "org.keycloak.storage.UserStorageProvider": [
+      {
+        "name": "tasks-webapi-users",
+        "providerId": "tasks-webapi-user-storage",
+        "subComponents": {},
+        "config": {
+          "cachePolicy": ["NO_CACHE"],
+          "enabled": ["true"],
+          "priority": ["0"]
+        }
+      }
+    ],
     "org.keycloak.userprofile.UserProfileProvider": [
       {
         "providerId": "declarative-user-profile",

--- a/keycloak/src/main/java/xyz/dgz48/tasks/keycloak/TasksWebApiUserStorageProviderFactory.java
+++ b/keycloak/src/main/java/xyz/dgz48/tasks/keycloak/TasksWebApiUserStorageProviderFactory.java
@@ -69,11 +69,7 @@ public class TasksWebApiUserStorageProviderFactory
     }
     if (value == null || value.isBlank()) {
       throw new ModelException(
-          "tasks-webapi user store: config '"
-              + configKey
-              + "' (or env "
-              + envKey
-              + ") is not set");
+          "tasks-webapi user store: config '" + configKey + "' (or env " + envKey + ") is not set");
     }
     return value;
   }

--- a/keycloak/src/main/java/xyz/dgz48/tasks/keycloak/TasksWebApiUserStorageProviderFactory.java
+++ b/keycloak/src/main/java/xyz/dgz48/tasks/keycloak/TasksWebApiUserStorageProviderFactory.java
@@ -27,6 +27,14 @@ public class TasksWebApiUserStorageProviderFactory
   static final String CONFIG_DB_USERNAME = "dbUsername";
   static final String CONFIG_DB_PASSWORD = "dbPassword";
 
+  // コンポーネント config が空の場合のフォールバック環境変数。realm-export ではコンポーネントで provider を
+  // 有効化するだけとし、接続情報は環境ごと(compose / dev / stg / prd)に下記の環境変数で与える。realm JSON は
+  // import 時に ${ENV} 置換されない(UserProfile の ${username} 等テーマキーと衝突するため有効化できない)ので、
+  // 環境差のある接続情報はここで解決する。IT は config を明示設定するため従来通り動作する。ADR-0006 / #862。
+  static final String ENV_JDBC_URL = "SPI_DB_JDBC_URL";
+  static final String ENV_DB_USERNAME = "SPI_DB_USERNAME";
+  static final String ENV_DB_PASSWORD = "SPI_DB_PASSWORD";
+
   // Admin Console は getHelpText / 各 config プロパティの label・helpText を i18n メッセージキーとして解決する。
   // 対応する翻訳はカスタム admin テーマ tasks-admin の message bundle(messages_ja/en.properties、#729)で定義する。
   static final String MSG_PREFIX = PROVIDER_ID + ".";
@@ -35,16 +43,28 @@ public class TasksWebApiUserStorageProviderFactory
   public TasksWebApiUserStorageProvider create(KeycloakSession session, ComponentModel model) {
     UserRepository repository =
         new UserRepository(
-            requireConfig(model, CONFIG_JDBC_URL),
-            requireConfig(model, CONFIG_DB_USERNAME),
-            requireConfig(model, CONFIG_DB_PASSWORD));
+            resolveConfig(model, CONFIG_JDBC_URL, ENV_JDBC_URL),
+            resolveConfig(model, CONFIG_DB_USERNAME, ENV_DB_USERNAME),
+            resolveConfig(model, CONFIG_DB_PASSWORD, ENV_DB_PASSWORD));
     return new TasksWebApiUserStorageProvider(session, model, repository);
   }
 
-  private static String requireConfig(ComponentModel model, String key) {
-    String value = model.get(key);
+  /**
+   * コンポーネント config を優先し、未設定(null/空)なら環境変数へフォールバックして解決する。両方とも未設定なら
+   * {@link ModelException} を投げる。
+   */
+  private static String resolveConfig(ComponentModel model, String configKey, String envKey) {
+    String value = model.get(configKey);
     if (value == null || value.isBlank()) {
-      throw new ModelException("tasks-webapi user store: required config '" + key + "' is not set");
+      value = System.getenv(envKey);
+    }
+    if (value == null || value.isBlank()) {
+      throw new ModelException(
+          "tasks-webapi user store: config '"
+              + configKey
+              + "' (or env "
+              + envKey
+              + ") is not set");
     }
     return value;
   }

--- a/keycloak/src/main/java/xyz/dgz48/tasks/keycloak/TasksWebApiUserStorageProviderFactory.java
+++ b/keycloak/src/main/java/xyz/dgz48/tasks/keycloak/TasksWebApiUserStorageProviderFactory.java
@@ -49,10 +49,7 @@ public class TasksWebApiUserStorageProviderFactory
     return new TasksWebApiUserStorageProvider(session, model, repository);
   }
 
-  /**
-   * コンポーネント config を優先し、未設定(null/空)なら環境変数へフォールバックして解決する。両方とも未設定なら
-   * {@link ModelException} を投げる。
-   */
+  /** コンポーネント config を優先し、未設定(null/空)なら環境変数へフォールバックして解決する。両方とも未設定なら {@link ModelException} を投げる。 */
   private static String resolveConfig(ComponentModel model, String configKey, String envKey) {
     String value = model.get(configKey);
     if (value == null || value.isBlank()) {

--- a/keycloak/src/main/java/xyz/dgz48/tasks/keycloak/TasksWebApiUserStorageProviderFactory.java
+++ b/keycloak/src/main/java/xyz/dgz48/tasks/keycloak/TasksWebApiUserStorageProviderFactory.java
@@ -1,6 +1,8 @@
 package xyz.dgz48.tasks.keycloak;
 
 import java.util.List;
+import java.util.function.Function;
+import org.jspecify.annotations.Nullable;
 import org.keycloak.Config;
 import org.keycloak.component.ComponentModel;
 import org.keycloak.models.KeycloakSession;
@@ -41,19 +43,29 @@ public class TasksWebApiUserStorageProviderFactory
 
   @Override
   public TasksWebApiUserStorageProvider create(KeycloakSession session, ComponentModel model) {
+    return create(session, model, System::getenv);
+  }
+
+  /** env 解決を注入可能にした {@link #create} 本体(env フォールバックのテスト用に package-private)。 */
+  TasksWebApiUserStorageProvider create(
+      KeycloakSession session, ComponentModel model, Function<String, @Nullable String> env) {
     UserRepository repository =
         new UserRepository(
-            resolveConfig(model, CONFIG_JDBC_URL, ENV_JDBC_URL),
-            resolveConfig(model, CONFIG_DB_USERNAME, ENV_DB_USERNAME),
-            resolveConfig(model, CONFIG_DB_PASSWORD, ENV_DB_PASSWORD));
+            resolveConfig(model, CONFIG_JDBC_URL, ENV_JDBC_URL, env),
+            resolveConfig(model, CONFIG_DB_USERNAME, ENV_DB_USERNAME, env),
+            resolveConfig(model, CONFIG_DB_PASSWORD, ENV_DB_PASSWORD, env));
     return new TasksWebApiUserStorageProvider(session, model, repository);
   }
 
-  /** コンポーネント config を優先し、未設定(null/空)なら環境変数へフォールバックして解決する。両方とも未設定なら {@link ModelException} を投げる。 */
-  private static String resolveConfig(ComponentModel model, String configKey, String envKey) {
+  /** コンポーネント config を優先し、未設定(null/空)なら env へフォールバックして解決する。両方とも未設定なら {@link ModelException} を投げる。 */
+  private static String resolveConfig(
+      ComponentModel model,
+      String configKey,
+      String envKey,
+      Function<String, @Nullable String> env) {
     String value = model.get(configKey);
     if (value == null || value.isBlank()) {
-      value = System.getenv(envKey);
+      value = env.apply(envKey);
     }
     if (value == null || value.isBlank()) {
       throw new ModelException(

--- a/keycloak/src/test/java/xyz/dgz48/tasks/keycloak/TasksWebApiUserStorageProviderFactoryTest.java
+++ b/keycloak/src/test/java/xyz/dgz48/tasks/keycloak/TasksWebApiUserStorageProviderFactoryTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.util.Map;
 import java.util.ServiceLoader;
 import org.junit.jupiter.api.Test;
 import org.keycloak.component.ComponentModel;
@@ -57,7 +58,32 @@ class TasksWebApiUserStorageProviderFactoryTest {
     KeycloakSession session = mock(KeycloakSession.class);
     ComponentModel model = mock(ComponentModel.class);
     when(model.get(TasksWebApiUserStorageProviderFactory.CONFIG_JDBC_URL)).thenReturn("  ");
-    assertThrows(ModelException.class, () -> factory.create(session, model));
+    // config も env も未設定 → 例外(env は常に null を返すダミー)。
+    assertThrows(ModelException.class, () -> factory.create(session, model, envKey -> null));
+  }
+
+  @Test
+  void create_buildsProvider_fromEnvFallback_whenConfigBlank() {
+    var factory = new TasksWebApiUserStorageProviderFactory();
+    KeycloakSession session = mock(KeycloakSession.class);
+    ComponentModel model = mock(ComponentModel.class);
+    // コンポーネント config は空(未設定)。realm-export で provider を有効化しただけの状態を模す。
+    when(model.get(TasksWebApiUserStorageProviderFactory.CONFIG_JDBC_URL)).thenReturn("");
+    when(model.get(TasksWebApiUserStorageProviderFactory.CONFIG_DB_USERNAME)).thenReturn(null);
+    when(model.get(TasksWebApiUserStorageProviderFactory.CONFIG_DB_PASSWORD)).thenReturn("  ");
+    // 接続情報は環境変数から解決される(env キー名の typo 回帰も検知する)。
+    var env =
+        Map.of(
+            TasksWebApiUserStorageProviderFactory.ENV_JDBC_URL,
+            "jdbc:mysql://mysql:3306/tasks",
+            TasksWebApiUserStorageProviderFactory.ENV_DB_USERNAME,
+            "tasks_webapi",
+            TasksWebApiUserStorageProviderFactory.ENV_DB_PASSWORD,
+            "tasks_webapi");
+    // JDBC 接続は遅延生成のため create 自体は DB へ接続しない。
+    var provider = factory.create(session, model, env::get);
+    assertNotNull(provider);
+    provider.close();
   }
 
   @Test


### PR DESCRIPTION
## 概要

ADR-0006 の User Storage SPI federation を **Keycloak を使う全コンテキストで有効化**する取り組みの **Stage 1(CI e2e / ローカル compose)**。SPI は実装済み・IT では配線済みだが、shipped realm には `UserStorageProvider` コンポーネントが無く dead code だった。本 PR で compose/CI の Keycloak が app `users` テーブルを federation するようにする。

## 変更

- **Dockerfile / build.gradle.kts**: MySQL JDBC ドライバを `providers/` に同梱(`stageProviders` タスクで SPI JAR + driver を集約)。SPI は `DriverManager` で app DB へ接続するため、provider classloader にドライバが必要(KC 内蔵ストア用ドライバは別 classloader)。
- **`TasksWebApiUserStorageProviderFactory`**: 接続情報を「コンポーネント config → 環境変数(`SPI_DB_JDBC_URL`/`SPI_DB_USERNAME`/`SPI_DB_PASSWORD`)」フォールバックで解決。realm JSON は import 時に `${ENV}` 置換されない(UserProfile 設定内の `${username}` 等テーマキーと衝突するため有効化不可)ので、環境差のある接続情報は env で与える。IT は config を明示設定するため従来通り動作(env 未設定+config 空なら従来どおり `ModelException`)。
- **realm-export**: `UserStorageProvider` コンポーネント追加(provider 有効化のみ、接続は env)。
- **docker-compose.local.yml**: KC に `SPI_DB_*`(compose MySQL、user `tasks_webapi`)+ `depends_on: mysql`。KC 自身のストアは H2 のまま、SPI は別接続で app users を federation。

## 検証(ローカル実機)

- realm import 成功・重複エラー無し、SPI が app DB へ接続成功(federated user `f:<comp>:<users.id>` を確認)。
- シードユーザー(realm-export ローカル)はログインでローカル優先 shadow され `sub=UUID` で app correlation 維持。実 signup ユーザー(ローカル無し)は federation 経路。
- **e2e 全 25 spec green**(login / tasks / admin / tenant-users / invitation / signup)。`e2e-test.yml` は同 compose を使うため CI e2e も自動的に SPI 有効下で回る。

## デプロイ安全性

deployed KC は `--import-realm` **IGNORE_EXISTING** のため、本 PR の realm 変更は稼働中 dev realm を変更しない。deployed 環境での SPI 配線(env 注入・SG・DB ユーザー・realm へのコンポーネント追加)は **Stage 2(インフラ)** で行う。

Refs #862

🤖 Generated with [Claude Code](https://claude.com/claude-code)