### PR TITLE
feat(infra): dev Keycloak に SPI federation の DB 接続配線(Stage2)

### DIFF
--- a/docs/architecture/parameter-store.md
+++ b/docs/architecture/parameter-store.md
@@ -49,6 +49,9 @@
 | `/tasks/<env>/keycloak/smtp-password` | SecureString | Keycloak SMTP メール送信用（SES SMTP interface 経由、ADR-0006 派生）。IAM Access Key から生成 | Keycloak ECS Task Role（platform stack 管理） | IAM Access Key ローテーション時に再生成・更新 |
 | `/tasks/<env>/app/jwt-issuer` | String | OAuth2 issuer URI（ECS Task Definition の `OIDC_ISSUER_URI` 注入元）| ECS Task Role（tasks-webapi）| Keycloak ホスト変更時に更新 |
 | `/tasks/<env>/app/tenant-default-id` | String | デフォルト tenant ID | ECS Task Role（tasks-webapi）| テナント構成変更時に手動更新 |
+| `/tasks/<env>/db/keycloak-spi-read-username` | String | Keycloak SPI federation 用 read-only DB ユーザー名（ADR-0006、既定 `keycloak_spi_read`）| Keycloak ECS Task Role（platform stack 管理）| DB ユーザー再作成時に手動更新 |
+| `/tasks/<env>/db/keycloak-spi-read-password` | SecureString | 同上ユーザーのパスワード（SPI が app `users` を read federation する接続）| Keycloak ECS Task Role（platform stack 管理）| 手動（DB ユーザーと連動、四半期目安） |
+| `/tasks/<env>/db/spi-jdbc-url` | String | SPI federation の JDBC URL（tasks RDS エンドポイントから組み立て、KC task-def の `SPI_DB_JDBC_URL` 注入元）| Keycloak ECS Task Role（platform stack 管理）| RDS 再作成時に `terraform apply` |
 
 ### dev 環境の具体値
 
@@ -60,6 +63,9 @@
 | `/tasks/dev/keycloak/smtp-password` | 初回 apply 後に AWS SSM コンソールで設定 |
 | `/tasks/dev/app/jwt-issuer` | `https://auth-dev.dgz48.xyz/realms/tasks` |
 | `/tasks/dev/app/tenant-default-id` | `1` |
+| `/tasks/dev/db/keycloak-spi-read-username` | `keycloak_spi_read`（既定値、terraform 管理）|
+| `/tasks/dev/db/keycloak-spi-read-password` | DB ユーザー作成時に SSM コンソール/CLI で実値設定（EICE 経由で作成する MySQL ユーザーと一致させる）|
+| `/tasks/dev/db/spi-jdbc-url` | `jdbc:mysql://<rds-endpoint>:3306/tasks?...`（terraform が RDS エンドポイントから自動設定）|
 
 ---
 
@@ -223,6 +229,9 @@ aws ssm get-parameter \
 | `keycloak/smtp-password` | 手動（IAM Access Key 連動） | IAM Access Key ローテーション時に SES SMTP パスワードを再生成・更新 |
 | `app/jwt-issuer` | Terraform 管理（String） | Keycloak ホスト・Realm 変更時に `terraform apply` |
 | `app/tenant-default-id` | Terraform 管理（String） | テナント構成変更時に `terraform apply` |
+| `db/keycloak-spi-read-username` | Terraform 管理（String、既定 `keycloak_spi_read`） | DB ユーザー再作成時 |
+| `db/keycloak-spi-read-password` | 手動（DB ユーザー連動） | 四半期ごと、または DB ユーザー再作成時 |
+| `db/spi-jdbc-url` | Terraform 管理（String） | RDS 再作成時に `terraform apply` |
 
 > AWS Secrets Manager の自動ローテーションは **不使用**（確定前提 #9: コスト面で Parameter Store SecureString を採用）。
 
@@ -232,8 +241,6 @@ aws ssm get-parameter \
 
 以下は本 Issue のスコープ外。Sprint 1 以降で追加する際に本 doc に追記する。
 
-| パラメータパス（予定） | 型 | 用途 | 追加タイミング |
-|---|---|---|---|
-| `/tasks/<env>/db/keycloak-spi-read-password` | SecureString | Keycloak SPI federation 用 read-only DB user（`infrastructure-plan.md` §3.6） | S1Infra-1（RDS 構築時） |
+（現時点で予定パラメータなし。SPI federation 用 `db/keycloak-spi-read-*` は §2 に実装済みとして掲載。ADR-0006 / #862。）
 
 > `db/password`（RDS master）は S1Infra-1 で IAM 認証移行後、apps からは参照されなくなるが DBA 業務用として保持する。

--- a/infra/environments/dev/data.tf
+++ b/infra/environments/dev/data.tf
@@ -10,6 +10,12 @@ data "aws_ssm_parameter" "vpc_id" {
   name = "/platform/${var.env}/vpc-id"
 }
 
+# VPC CIDR — Keycloak(platform)からの SPI federation ingress(RDS :3306)許可元に使う。
+# cross-stack のため SG 参照不可 → KC egress と対称に VPC CIDR で許可(ADR-0006 / #862、規約 R2 例外)。
+data "aws_ssm_parameter" "vpc_cidr" {
+  name = "/platform/${var.env}/vpc-cidr"
+}
+
 data "aws_ssm_parameter" "alb_sg_id" {
   name = "/platform/${var.env}/alb-sg-id"
 }

--- a/infra/environments/dev/rds.tf
+++ b/infra/environments/dev/rds.tf
@@ -39,3 +39,34 @@ output "eice_id" {
   description = "EC2 Instance Connect Endpoint ID (use for open-tunnel)"
   value       = aws_ec2_instance_connect_endpoint.main.id
 }
+
+# ---------------------------------------------------------------------------
+# Keycloak SPI federation(ADR-0006 / #862)— platform の Keycloak が app users DB を
+# read federation するための配線。
+#   - spi-jdbc-url: RDS エンドポイントから組み立てた JDBC URL を SSM 公開。KC タスク定義は
+#     valueFrom で ARN 参照し、ECS がコンテナ起動時に解決する(platform→tasks の apply 順に非依存)。
+#   - RDS SG に Keycloak(VPC 内)からの :3306 ingress を追加。cross-stack のため SG 参照不可 →
+#     KC egress(keycloak module、VPC CIDR)と対称に VPC CIDR で許可(規約 R2 例外、既存慣例踏襲)。
+#   - keycloak_spi_read DB ユーザー(パスワード認証・SELECT のみ)は master 権限が必要なため
+#     EICE トンネル経由で手動作成する(本ファイル冒頭の手順、infrastructure-plan §手動)。
+# ---------------------------------------------------------------------------
+
+resource "aws_ssm_parameter" "spi_jdbc_url" {
+  name  = "/tasks/${var.env}/db/spi-jdbc-url"
+  type  = "String"
+  value = "jdbc:mysql://${module.rds.db_instance_address}:3306/tasks?allowPublicKeyRetrieval=true&useSSL=false"
+
+  tags = {
+    Name = "tasks-${var.env}-db-spi-jdbc-url"
+  }
+}
+
+resource "aws_security_group_rule" "rds_from_keycloak_spi" {
+  type              = "ingress"
+  description       = "MySQL from Keycloak SPI federation (VPC CIDR, cross-stack; ADR-0006)"
+  from_port         = 3306
+  to_port           = 3306
+  protocol          = "tcp"
+  security_group_id = module.security_group.rds_sg_id
+  cidr_blocks       = [data.aws_ssm_parameter.vpc_cidr.value]
+}

--- a/infra/environments/dev/rds.tf
+++ b/infra/environments/dev/rds.tf
@@ -45,8 +45,9 @@ output "eice_id" {
 # read federation するための配線。
 #   - spi-jdbc-url: RDS エンドポイントから組み立てた JDBC URL を SSM 公開。KC タスク定義は
 #     valueFrom で ARN 参照し、ECS がコンテナ起動時に解決する(platform→tasks の apply 順に非依存)。
-#   - RDS SG に Keycloak(VPC 内)からの :3306 ingress を追加。cross-stack のため SG 参照不可 →
-#     KC egress(keycloak module、VPC CIDR)と対称に VPC CIDR で許可(規約 R2 例外、既存慣例踏襲)。
+#   - RDS SG への Keycloak(VPC 内)からの :3306 ingress は security_group module の
+#     rds_ingress_cidr_blocks(VPC CIDR)で許可する(security_group.tf)。RDS SG は他 rule も
+#     インライン管理のため、インライン ingress として追加する(aws_security_group_rule 混在を避ける)。
 #   - keycloak_spi_read DB ユーザー(パスワード認証・SELECT のみ)は master 権限が必要なため
 #     EICE トンネル経由で手動作成する(本ファイル冒頭の手順、infrastructure-plan §手動)。
 # ---------------------------------------------------------------------------
@@ -59,14 +60,4 @@ resource "aws_ssm_parameter" "spi_jdbc_url" {
   tags = {
     Name = "tasks-${var.env}-db-spi-jdbc-url"
   }
-}
-
-resource "aws_security_group_rule" "rds_from_keycloak_spi" {
-  type              = "ingress"
-  description       = "MySQL from Keycloak SPI federation (VPC CIDR, cross-stack; ADR-0006)"
-  from_port         = 3306
-  to_port           = 3306
-  protocol          = "tcp"
-  security_group_id = module.security_group.rds_sg_id
-  cidr_blocks       = [data.aws_ssm_parameter.vpc_cidr.value]
 }

--- a/infra/environments/dev/security_group.tf
+++ b/infra/environments/dev/security_group.tf
@@ -9,4 +9,6 @@ module "security_group" {
   env       = var.env
   vpc_id    = data.aws_ssm_parameter.vpc_id.value
   alb_sg_id = data.aws_ssm_parameter.alb_sg_id.value
+  # Keycloak(platform)からの SPI federation :3306 ingress を VPC CIDR で許可(ADR-0006 / #862)。
+  rds_ingress_cidr_blocks = [data.aws_ssm_parameter.vpc_cidr.value]
 }

--- a/infra/modules/security_group/main.tf
+++ b/infra/modules/security_group/main.tf
@@ -62,6 +62,20 @@ resource "aws_security_group" "rds" {
     security_groups = [aws_security_group.eice.id]
   }
 
+  # Keycloak SPI federation(ADR-0006): cross-stack のため SG 参照不可 → VPC CIDR で許可。
+  # インライン ingress として定義する(この SG は他 rule もインライン管理のため、AWS provider が
+  # 禁じる「インライン ingress + aws_security_group_rule の混在」による rule flapping を避ける)。
+  dynamic "ingress" {
+    for_each = var.rds_ingress_cidr_blocks
+    content {
+      description = "MySQL from Keycloak SPI federation (cross-stack VPC CIDR)"
+      from_port   = 3306
+      to_port     = 3306
+      protocol    = "tcp"
+      cidr_blocks = [ingress.value]
+    }
+  }
+
   tags = {
     Name = "tasks-${var.env}-sg-rds"
   }

--- a/infra/modules/security_group/variables.tf
+++ b/infra/modules/security_group/variables.tf
@@ -12,3 +12,9 @@ variable "alb_sg_id" {
   type        = string
   description = "Security Group ID of the shared ALB (SG-ALB); sourced from SSM /platform/{env}/alb-sg-id"
 }
+
+variable "rds_ingress_cidr_blocks" {
+  type        = list(string)
+  default     = []
+  description = "Extra CIDR blocks allowed inbound to RDS on :3306 (Keycloak SPI federation cross-stack; ADR-0006). Empty = none."
+}

--- a/infra/shared/modules/keycloak/main.tf
+++ b/infra/shared/modules/keycloak/main.tf
@@ -91,6 +91,11 @@ resource "aws_iam_role_policy" "exec_ssm" {
         Resource = [
           "arn:aws:ssm:${var.region}:${var.account_id}:parameter/platform/${var.env}/keycloak-db-password",
           "arn:aws:ssm:${var.region}:${var.account_id}:parameter/tasks/${var.env}/keycloak/admin-password",
+          # SPI federation(ADR-0006): app users DB への read 接続情報。値は tasks スタックが publish、
+          # ここは ARN 参照のみ(apply 時に値を読まないため platform→tasks の適用順に依存しない)。
+          "arn:aws:ssm:${var.region}:${var.account_id}:parameter/tasks/${var.env}/db/spi-jdbc-url",
+          "arn:aws:ssm:${var.region}:${var.account_id}:parameter/tasks/${var.env}/db/keycloak-spi-read-username",
+          "arn:aws:ssm:${var.region}:${var.account_id}:parameter/tasks/${var.env}/db/keycloak-spi-read-password",
         ]
       }
     ]
@@ -242,6 +247,21 @@ resource "aws_ecs_task_definition" "keycloak" {
       {
         name      = "KEYCLOAK_ADMIN_PASSWORD"
         valueFrom = "arn:aws:ssm:${var.region}:${var.account_id}:parameter/tasks/${var.env}/keycloak/admin-password"
+      },
+      # User Storage SPI federation の接続情報(ADR-0006)。realm-export のコンポーネントは有効化のみで、
+      # 接続情報は SPI_DB_* 環境変数へフォールバック解決される(TasksWebApiUserStorageProviderFactory)。
+      # ECS がコンテナ起動時に SSM から解決するため apply 時の cross-stack 値依存は無い。
+      {
+        name      = "SPI_DB_JDBC_URL"
+        valueFrom = "arn:aws:ssm:${var.region}:${var.account_id}:parameter/tasks/${var.env}/db/spi-jdbc-url"
+      },
+      {
+        name      = "SPI_DB_USERNAME"
+        valueFrom = "arn:aws:ssm:${var.region}:${var.account_id}:parameter/tasks/${var.env}/db/keycloak-spi-read-username"
+      },
+      {
+        name      = "SPI_DB_PASSWORD"
+        valueFrom = "arn:aws:ssm:${var.region}:${var.account_id}:parameter/tasks/${var.env}/db/keycloak-spi-read-password"
       },
     ]
 


### PR DESCRIPTION
## 概要

ADR-0006 SPI federation を **deployed dev** で有効化するためのインフラ配線(Stage 2)。Stage 1(#863、compose/CI)に続き、デプロイ済み Keycloak が app `users` テーブルを federation できるよう配線する。realm へのコンポーネント追加(Admin API)と `keycloak_spi_read` DB ユーザー作成(EICE 手動)は **apply 後の runtime 手順**で、本 PR はインフラのみ。

## 変更

**platform(keycloak module)**
- exec-role に SPI 接続情報 SSM の read を追加(`/tasks/dev/db/spi-jdbc-url` / `keycloak-spi-read-username` / `-password`)。
- task-def に `SPI_DB_JDBC_URL` / `SPI_DB_USERNAME` / `SPI_DB_PASSWORD` を `secrets`(valueFrom ARN)で注入。**ECS がコンテナ起動時に SSM 解決するため、platform→tasks の apply 順に非依存**(terraform は apply 時に値を読まない)。realm-export のコンポーネント(Stage 1)は接続情報を `SPI_DB_*` 環境変数へフォールバックする。

**tasks env**
- `/tasks/dev/db/spi-jdbc-url` を RDS エンドポイントから組み立て SSM 公開。
- RDS SG に Keycloak からの `:3306` ingress を追加。cross-stack のため SG 参照不可 → **KC→RDS egress(keycloak module、VPC CIDR)と対称に VPC CIDR で許可**(規約 R2 例外の既存慣例踏襲)。

## デプロイ安全性

deployed KC は `--import-realm` **IGNORE_EXISTING** のため、稼働中 realm にコンポーネントは自動追加されない。SPI 未活性の間は `SPI_DB_*` が未解決値でも SPI が instantiate されず**無害**(既存 dev ログインに影響なし)。

## apply 後の runtime 手順(このPRだけでは SPI は有効化されない)

1. `keycloak_spi_read` MySQL ユーザー作成 + `GRANT SELECT`(EICE トンネル・master、`rds.tf` 冒頭手順)。
2. SSM `/tasks/dev/db/keycloak-spi-read-password` を実値に(username は既定 `keycloak_spi_read`)。
3. KC 強制再デプロイ(起動時に実 `SPI_DB_*` を解決)。
4. 稼働中 dev realm に `UserStorageProvider` コンポーネントを Admin API で追加。
5. 検証: Admin search で federated user 表示 / dev ログイン / signup フル動作。

Refs #862

🤖 Generated with [Claude Code](https://claude.com/claude-code)