### PR TITLE
fix(keycloak): federated user に lastName を設定(初回ログイン遮断を解消)

### DIFF
--- a/keycloak/src/main/java/xyz/dgz48/tasks/keycloak/UserAdapter.java
+++ b/keycloak/src/main/java/xyz/dgz48/tasks/keycloak/UserAdapter.java
@@ -56,7 +56,11 @@ public final class UserAdapter extends AbstractInMemoryUserAdapter {
     setEnabled(STATUS_ACTIVE.equals(row.status()));
     setEmailVerified(true);
     super.setEmail(row.email());
+    // app は表示名を単一の full_name で保持する。Keycloak の firstName/lastName は realm の user profile
+    // 必須項目であり、未設定だと初回ログインで「Update Account Information」に遮られ dashboard へ到達できない。
+    // first/last は本アプリでは vestigial(SoT は users.full_name)のため、両方に full_name を設定して必須制約を満たす。
     setSingleAttribute(FIRST_NAME, row.fullName());
+    setSingleAttribute(LAST_NAME, row.fullName());
     setSingleAttribute(FULL_NAME, row.fullName());
     setSingleAttribute(FULL_NAME_KANA, row.fullNameKana());
     if (row.departmentName() != null) {

--- a/keycloak/src/test/java/xyz/dgz48/tasks/keycloak/UserAdapterComponentTest.java
+++ b/keycloak/src/test/java/xyz/dgz48/tasks/keycloak/UserAdapterComponentTest.java
@@ -41,6 +41,10 @@ class UserAdapterComponentTest extends AbstractMySqlContainerTest {
       assertThat(a.getEmail()).isEqualTo(email);
       assertThat(a.isEnabled()).isTrue();
       assertThat(a.isEmailVerified()).isTrue();
+      // realm profile 必須項目の firstName/lastName は full_name から供給する(未設定だと初回ログインが
+      // 「Update Account Information」で遮られるため。#862)。
+      assertThat(a.getFirstName()).isEqualTo("氏名 太郎");
+      assertThat(a.getLastName()).isEqualTo("氏名 太郎");
       assertThat(a.getFirstAttribute(UserAdapter.FULL_NAME)).isEqualTo("氏名 太郎");
       assertThat(a.getFirstAttribute(UserAdapter.FULL_NAME_KANA)).isEqualTo("シメイ タロウ");
       assertThat(a.getFirstAttribute(UserAdapter.DEPARTMENT_NAME)).isEqualTo("営業部");


### PR DESCRIPTION
## 背景

SPI federation を dev で有効化(#862)して signup フルフローを通したところ、federated な新規ユーザーが初回ログインで Keycloak の「Update Account Information」に遮られ dashboard へ到達できなかった。原因: `UserAdapter` は `firstName` を `full_name` から供給するが **`lastName` を未設定**にしており、realm の user profile は first/last 両方を必須とするため。

これは #859(find-or-create のローカル作成ユーザー)と同じ事象の **federated 版**で、SPI を有効化して初めて表面化した。

## 変更

`UserAdapter` の hydration で `lastName` も `full_name` から供給する。app は表示名を単一の `full_name` で保持し、Keycloak の first/last は vestigial(SoT は `users.full_name`)なので、両フィールドに `full_name` を設定して必須制約を満たす(#859 と一貫)。

- `setSingleAttribute(LAST_NAME, row.fullName())` を追加
- `UserAdapterComponentTest`: `getFirstName()`/`getLastName()` が `full_name` を返すことを assert

## 検証

- `:keycloak:test --tests *UserAdapterComponentTest`(Testcontainers)green。
- merge → KC イメージ再ビルド + dev デプロイ後、dev-smoke の signup-email(complete → 新規 federated ユーザーでログイン)まで green を確認する。

Refs #862

🤖 Generated with [Claude Code](https://claude.com/claude-code)