### PR TITLE
docs(infra): EICE DBA トンネル手順を修正(3306 不可 → SSM バスチオン)

### DIFF
--- a/docs/architecture/parameter-store.md
+++ b/docs/architecture/parameter-store.md
@@ -64,7 +64,7 @@
 | `/tasks/dev/app/jwt-issuer` | `https://auth-dev.dgz48.xyz/realms/tasks` |
 | `/tasks/dev/app/tenant-default-id` | `1` |
 | `/tasks/dev/db/keycloak-spi-read-username` | `keycloak_spi_read`（既定値、terraform 管理）|
-| `/tasks/dev/db/keycloak-spi-read-password` | DB ユーザー作成時に SSM コンソール/CLI で実値設定（EICE 経由で作成する MySQL ユーザーと一致させる）|
+| `/tasks/dev/db/keycloak-spi-read-password` | DB ユーザー作成時に SSM コンソール/CLI で実値設定（一時 SSM バスチオン経由で作成する MySQL ユーザーと一致させる。手順は `infra/environments/dev/rds.tf`）|
 | `/tasks/dev/db/spi-jdbc-url` | `jdbc:mysql://<rds-endpoint>:3306/tasks?...`（terraform が RDS エンドポイントから自動設定）|
 
 ---

--- a/infra/environments/dev/rds.tf
+++ b/infra/environments/dev/rds.tf
@@ -57,7 +57,7 @@ output "eice_id" {
 #     rds_ingress_cidr_blocks(VPC CIDR)で許可する(security_group.tf)。RDS SG は他 rule も
 #     インライン管理のため、インライン ingress として追加する(aws_security_group_rule 混在を避ける)。
 #   - keycloak_spi_read DB ユーザー(パスワード認証・SELECT のみ)は master 権限が必要なため
-#     EICE トンネル経由で手動作成する(本ファイル冒頭の手順、infrastructure-plan §手動)。
+#     一時 SSM バスチオン経由で手動作成する(本ファイル冒頭の手順、infrastructure-plan §手動)。
 # ---------------------------------------------------------------------------
 
 resource "aws_ssm_parameter" "spi_jdbc_url" {

--- a/infra/environments/dev/rds.tf
+++ b/infra/environments/dev/rds.tf
@@ -14,15 +14,23 @@ module "rds" {
 }
 
 # ---------------------------------------------------------------------------
-# EC2 Instance Connect Endpoint — DBA 用 MySQL トンネル (dev のみ)
+# EC2 Instance Connect Endpoint (dev のみ)
 #
-# ローカルから RDS への接続手順:
-#   aws ec2-instance-connect open-tunnel \
-#     --instance-connect-endpoint-id $(terraform output -raw eice_id) \
-#     --remote-port 3306 --local-port 13306
-#   mysql -h 127.0.0.1 -P 13306 -u admin -p
+# 注意: EICE の open-tunnel は RemotePort が **22(SSH)/ 3389(RDP)のみ**対応で、
+# MySQL :3306 への直接トンネルはできない(AWS 制約)。したがって RDS への DBA アクセスは
+# 「EICE で 3306」ではなく、下記の一時 SSM バスチオン + port-forward を用いる。
+# EICE 自体は将来 SSH bastion へ 22 で繋ぐ用途に残置(現状 RDS 直結には使わない)。
 #
-# 必要 IAM 権限: ec2-instance-connect:OpenTunnel on このリソース ARN
+# RDS への DBA 接続手順(master SQL 実行が必要なとき):
+#   1) private subnet に SSM 管理の使い捨て EC2(AL2023、SSM instance profile)を起動
+#      (private subnet は NAT egress があり SSM 登録可能)。RDS SG は VPC CIDR ingress を許可済み。
+#   2) aws ssm start-session --target <iid> \
+#        --document-name AWS-StartPortForwardingSessionToRemoteHost \
+#        --parameters host=<rds-endpoint>,portNumber=3306,localPortNumber=13306
+#   3) mysql -h 127.0.0.1 -P 13306 -u admin -p   # master password は SSM /tasks/dev/db/password
+#   4) 作業後、EC2 を terminate + 一時 SG/role/instance-profile を削除。
+#
+# 必要 IAM: ssm:StartSession(AWS-StartPortForwardingSessionToRemoteHost)/ ec2 run/terminate 等。
 # ---------------------------------------------------------------------------
 
 resource "aws_ec2_instance_connect_endpoint" "main" {


### PR DESCRIPTION
## 背景

SPI federation の DB ユーザー作成(#862)で `rds.tf` の documented DBA 手順を実行しようとしたところ、EICE の `open-tunnel` は **RemotePort が 22/3389 のみ対応**で MySQL `:3306` への直接トンネルができないことが判明(`InvalidParameter: Specify either 22 or 3389`)。documented 手順は動作しない。

## 変更

- `rds.tf`: EICE コメントを実態に合わせ修正。RDS への DBA アクセスは「EICE で 3306」ではなく **一時 SSM 管理バスチオン + `AWS-StartPortForwardingSessionToRemoteHost`** で行う手順を明記(private subnet は NAT egress あり→SSM 登録可、RDS SG は VPC CIDR ingress 許可済み)。EICE 自体は将来 SSH bastion 用に残置。
- `docs/architecture/parameter-store.md`: `keycloak-spi-read-password` の注記の EICE 参照を更新。

インフラリソース変更なし(コメント/docs のみ)。

Refs #862

🤖 Generated with [Claude Code](https://claude.com/claude-code)