### PR TITLE
docs(keycloak): 連携機能のシーケンス図を追加

### DIFF
--- a/docs/architecture/keycloak-integration-sequences.md
+++ b/docs/architecture/keycloak-integration-sequences.md
@@ -153,7 +153,7 @@ sequenceDiagram
     U->>SPA: 氏名 / パスワード入力 → 参加
     SPA->>API: POST /api/invitations/{token}/accept
     API->>API: AcceptInvitationUseCase
-    API->>DB: RegisterMemberUseCase.upsertPendingMember(users)
+    API->>DB: RegisterMemberUseCase.register → UserRegistrationPort.upsertPendingMember(users)
     API->>KC: provisionCredential(...)(→ 図2 と同じ Keycloak 経路)
     API->>DB: MembershipFinalizer: user_tenants 紐付け + invitation USED(原子化)
     API-->>SPA: 201

--- a/docs/architecture/keycloak-integration-sequences.md
+++ b/docs/architecture/keycloak-integration-sequences.md
@@ -1,57 +1,88 @@
 # Keycloak 連携機能 シーケンス図
 
-Keycloak と連携する主要フローの実装シーケンス。関連 ADR: [ADR-0006](../adr/0006-keycloak-user-storage-spi.md)(User Storage SPI federation)/ [ADR-0040](../adr/0040-onboarding-registration-and-credential-provisioning.md)(オンボーディング + credential provisioning)/ [ADR-0041](../adr/0041-post-deploy-dev-e2e-and-email-verification.md)(dev E2E)。
+Keycloak と連携する主要フローの実装シーケンス。関連 ADR: [ADR-0006](../adr/0006-keycloak-user-storage-spi.md)(User Storage SPI federation)/ [ADR-0040](../adr/0040-onboarding-registration-and-credential-provisioning.md)(オンボーディング + credential provisioning)/ [ADR-0017](../adr/0017-invitation-and-credential-recovery-flows.md)(招待・資格回復)/ [ADR-0041](../adr/0041-post-deploy-dev-e2e-and-email-verification.md)(dev E2E)。
 
 前提となる識別モデル(#862 で全環境に配線):
 
 - **app `users` テーブルが SoT**。Keycloak は **User Storage SPI**(`tasks-webapi-user-storage`)で `users` を read-only federation する(接続は read-only DB ユーザー `keycloak_spi_read`)。
 - **credential(パスワード)は Keycloak が SoT**(ADR-0006 §3.3)。SPI は `CredentialInputValidator` を実装せず、資格情報は Keycloak native store が持つ。
-- federated ユーザーの JWT `sub` は `f:<component-id>:<users.id>` 形式。プロフィール(`firstName`/`lastName`/`email` 等)は SPI が `users.full_name`/`email` から供給する。
+- federated ユーザーの JWT `sub` は `f:{component-id}:{users.id}` 形式。プロフィール(`firstName`/`lastName`/`email`)は SPI が `users.full_name`/`email` から供給する。
 - dev/local のシード4ユーザーは realm-export のローカルユーザーとして共存し、ログインでローカルが優先(shadow)される。
+- ブラウザ SPA(`web`)は **keycloak-js**(`onLoad:'login-required'`, `pkceMethod:'S256'`, flow=standard)で **OIDC Authorization Code フロー + PKCE(S256)** を使う。
+
+図中の `box` は**同一プロセス**を表す(SPI は別サービスではなく Keycloak プロセス内の provider、`Tasks…Converter`/`OidcSubCorrelationService`/`TenantContextFilter` は webapi 内部クラス)。
 
 ---
 
 ## 1. ログイン → JWT 認証 → oidc_sub correlation → ロール解決
 
-SPA が Keycloak で OIDC 認証(PKCE)し、取得した JWT を webapi に提示。webapi は `sub` から app ユーザーを解決し、権限を確定する。
+SPA が Keycloak で **認可コードフロー + PKCE** で認証し、得た JWT を webapi に提示。webapi は **段階A(JWT 認証)**と**段階B(TenantContextFilter)**で app RDS を複数回参照して principal と権限を確定する。
 
 ```mermaid
 sequenceDiagram
     autonumber
     actor U as User (Browser)
-    participant SPA as SPA (web)
-    participant KC as Keycloak (auth-<env>)
-    participant SPI as User Storage SPI
-    participant DB as app RDS (users)
-    participant API as webapi
-    participant JAC as TasksJwtAuthenticationConverter
-    participant COR as OidcSubCorrelationService
+    participant SPA as SPA (web / keycloak-js)
+    box Keycloak (auth-dev)
+        participant KC as Keycloak core
+        participant SPI as User Storage SPI
+    end
+    box webapi (native)
+        participant JAC as Tasks…JwtAuthConverter
+        participant COR as OidcSubCorrelationService
+        participant TCF as TenantContextFilter
+    end
+    participant DB as app RDS
 
+    Note over U,KC: OIDC Authorization Code + PKCE(S256)
     U->>SPA: アクセス
-    SPA->>KC: OIDC Authorization Code + PKCE
-    KC->>SPI: getUserByUsername/Email(email)
+    SPA->>KC: GET /authorize (response_type=code, code_challenge=S256)
+    KC-->>U: ログイン画面
+    U->>KC: 認証情報入力
+    KC->>SPI: getUserByEmail(email)  (詳細は図3)
     SPI->>DB: SELECT ... FROM users WHERE email=?
     DB-->>SPI: users 行
-    SPI-->>KC: UserModel(federated, credentials=KC native)
+    SPI-->>KC: UserModel(federated, credential=KC native)
     KC->>KC: パスワード検証(native store)
-    KC-->>SPA: ID/Access Token (sub, email)
-    SPA->>API: REST + Bearer JWT (X-Tenant-Id)
-    API->>JAC: convert(jwt)
+    KC-->>SPA: 302 redirect_uri?code=... (認可コード)
+    SPA->>KC: POST /token (code + code_verifier)
+    KC-->>SPA: ID / Access / Refresh Token (sub, email)
+
+    Note over SPA,DB: 段階A — JWT 認証(TasksJwtAuthenticationConverter)
+    SPA->>JAC: REST + Bearer JWT (+ X-Tenant-Id)
+    Note over JAC: JWT 署名は JWKS で検証(Keycloak、キャッシュ)
     JAC->>COR: resolve(sub, email)
-    alt findByOidcSub(sub) ヒット
-        COR-->>JAC: users 行(correlation 済)
-    else 未ヒット & email が pending 行に一致
-        COR->>DB: UPDATE users SET oidc_sub=sub WHERE email=? (pending)
-        COR-->>JAC: users 行(初回 correlation)
+    COR->>DB: findByOidcSub(sub)
+    alt 未ヒット & email が pending 行に一致
+        COR->>DB: findByEmail → UPDATE users SET oidc_sub=sub (初回 correlation)
     end
-    JAC->>DB: app_admin_users に sub 存在?
+    COR-->>JAC: users 行(anonymized/inactive なら 401)
+    JAC->>DB: app_admin_users.existsByOidcSub(sub)?
     DB-->>JAC: (存在すれば ROLE_APP_ADMIN)
-    Note over API: テナント別ロール(TENANT_ADMIN/MEMBER)は<br/>X-Tenant-Id + user_tenants から TenantContext で解決
-    JAC-->>API: TasksAuthenticationToken(principal, authorities)
-    API-->>SPA: 認可済みレスポンス
+
+    Note over TCF,DB: 段階B — テナント解決(TenantContextFilter)
+    alt 免除パス(/api/auth・/api/tenants・/api/signup・/api/invitations・/api/platform・/actuator・/api/users/me)
+        TCF-->>SPA: 素通り(テナント検証なし)
+    else X-Tenant-Id 指定あり
+        TCF->>DB: user_tenants.findActiveRole(userId, tenantId)
+        alt ACTIVE メンバー
+            TCF->>TCF: + ROLE_TENANT_ADMIN / ROLE_MEMBER, TenantContext.set(tenantId)
+        else 非メンバー
+            TCF-->>SPA: 403
+        end
+    else X-Tenant-Id なし(非免除)
+        TCF->>DB: userTenantsResolverService.resolveInitial(userId) (ADR-0016)
+        alt 所属あり
+            TCF->>TCF: 初期テナント + role, TenantContext.set
+        else 所属 0 件
+            TCF-->>SPA: 403
+        end
+    end
+    Note over DB: 以降の業務クエリは Hibernate フィルタで WHERE tenant_id=:ctx
+    TCF-->>SPA: 認可済みレスポンス
 ```
 
-`isAnonymized()` / `isInactive()` の場合は認証を拒否する(`UserAnonymizedException` / `UserInactiveException`)。
+参照する app RDS テーブルは **`users`(correlation)/ `app_admin_users`(SaaS Admin)/ `user_tenants`(テナントロール + メンバー検証)** の3つ。
 
 ---
 
@@ -59,66 +90,75 @@ sequenceDiagram
 
 `POST /api/signup/request` → 確認メール → `POST /api/signup/{token}/complete` で users 行 upsert + Keycloak credential provisioning。登録直後はテナント未所属(ADR-0040 §3.5)。
 
+`provisionCredential(...)` は **アプリの1メソッド**(`KeycloakAdminCredentialAdapter`)で、その内部で Keycloak Admin REST を複数回呼ぶ(下図の枠内)。
+
 ```mermaid
 sequenceDiagram
     autonumber
     actor U as User
     participant SPA as SPA (signup.html)
-    participant API as webapi
-    participant DB as app RDS
+    box webapi
+        participant API as Signup/CompleteSignup/RegisterMember
+    end
     participant SES as SES / メール
-    participant KC as Keycloak Admin API
-    participant SPI as User Storage SPI
+    box Keycloak
+        participant KC as Keycloak Admin API
+        participant SPI as User Storage SPI
+    end
+    participant DB as app RDS
 
     U->>SPA: メール入力 → 登録
     SPA->>API: POST /api/signup/request {email}
     API->>DB: INSERT signup_requests(PENDING, token_hash)
-    API->>SES: 確認メール送信(署名リンク: signup-complete.html?token)
+    API->>SES: 確認メール送信(signup-complete.html?token)
     API-->>SPA: 202(列挙耐性: 常に同一応答)
     SES-->>U: 確認メール
     U->>SPA: 確認リンク → signup-complete.html
     SPA->>API: GET /api/signup/{token}(非消費・email エコー)
     U->>SPA: 氏名 / パスワード入力 → 完了
     SPA->>API: POST /api/signup/{token}/complete
-    API->>API: CompleteSignupUseCase(token 検証)
-    API->>DB: upsertPendingMember: INSERT users(oidc_sub="pending:email", full_name,...)
-    API->>KC: provisionCredential(email, fullName, password)
-    Note over API,KC: KeycloakAdminCredentialAdapter<br/>client_credentials(tasks-webapi-admin)
-    API->>KC: GET /admin/realms/tasks/users?email=&exact=true
-    KC->>SPI: searchForUser(email)
-    SPI->>DB: SELECT ... users WHERE email=?
-    DB-->>SPI: 直前に upsert した行
-    SPI-->>KC: federated user (f:<comp>:<id>)
-    KC-->>API: user id
-    Note over API,KC: 見つからなければ POST /users で<br/>ローカル作成(SPI 未活性環境向け find-or-create)
-    API->>KC: PUT /users/{id}/reset-password(パスワード)
-    API->>KC: PUT /users/{id}(emailVerified=true)
+    API->>DB: UserRegistrationPort.upsertPendingMember: INSERT users(oidc_sub="pending:email", full_name,…)
+
+    rect rgb(238,238,238)
+        Note over API,SPI: provisionCredential(email, fullName, password) — KeycloakAdminCredentialAdapter
+        API->>KC: ① POST /token (client_credentials, tasks-webapi-admin)
+        API->>KC: ② GET /users?email=&exact=true
+        KC->>SPI: searchForUser(email) → 直前 upsert した行を federation(図3)
+        KC-->>API: federated user id (f:comp:id)
+        Note over API,KC: 見つからなければ POST /users で作成(find-or-create、SPI 未活性環境向け)
+        API->>KC: ③ PUT /users/{id}/reset-password(パスワード設定)
+        API->>KC: ④ PUT /users/{id}(emailVerified=true)
+    end
+
     API->>DB: signup_requests → USED
     API-->>SPA: 201(登録完了)
     U->>SPA: 作成ユーザーでログイン(→ 図1)
-    Note over U,SPA: 初回ログインで oidc_sub を pending → 実 sub に correlation。<br/>テナント未所属のため「テナント作成」導線へ着地。
+    Note over U,SPA: 初回ログインで oidc_sub を pending → 実 sub に correlation。テナント未所属のため「テナント作成」導線へ着地。
 ```
 
 Keycloak 失敗時は signup トークンを消費しない(再試行で回復、ADR-0040 §3.5)。列挙耐性のためメール送信失敗は握りつぶす。
 
 ---
 
-## 3. User Storage SPI federation(Keycloak → app users 読取経路)
+## 3. User Storage SPI federation(図1・図2 の `KC→SPI` の内部展開)
 
-Keycloak が federated ユーザーを解決する内部経路。`keycloak_spi_read`(SELECT のみ)で app `users` に JDBC 接続する。
+**単独のフローではなく、図1 のログイン認証 / 図2 の Admin ユーザー検索から Keycloak が呼ぶ内部経路のズームイン**(だから利用者は登場しない)。`keycloak_spi_read`(SELECT のみ)で app `users` に JDBC 接続し、`UserModel` を組み立てる。
 
 ```mermaid
 sequenceDiagram
     autonumber
-    participant KC as Keycloak core
-    participant F as ...ProviderFactory
-    participant P as ...UserStorageProvider
-    participant R as UserRepository (JDBC)
+    box Keycloak プロセス(SPI JAR)
+        participant KC as Keycloak core
+        participant F as ...ProviderFactory
+        participant P as ...UserStorageProvider
+        participant R as UserRepository (JDBC)
+        participant A as UserAdapter
+    end
     participant DB as app RDS (users)
-    participant A as UserAdapter
 
+    Note over KC: 図1 のログイン認証 / 図2 の Admin 検索から呼ばれる
     KC->>F: create(session, component)
-    Note over F: 接続情報を component config →<br/>env(SPI_DB_JDBC_URL/USERNAME/PASSWORD)で解決
+    Note over F: 接続情報を component config → env(SPI_DB_JDBC_URL/USERNAME/PASSWORD)で解決
     F->>R: new UserRepository(jdbcUrl, keycloak_spi_read, pw)
     KC->>P: getUserByEmail / searchForUser
     P->>R: findByEmail / search
@@ -126,7 +166,7 @@ sequenceDiagram
     DB-->>R: UserRow
     R-->>P: UserRow
     P->>A: adapt(row)
-    Note over A: full_name → firstName & lastName(必須項目)<br/>status ACTIVE → enabled / emailVerified=true<br/>credential は KC native(SPI は非提供)
+    Note over A: full_name → firstName & lastName(必須項目) / status ACTIVE → enabled / emailVerified=true / credential は KC native(SPI 非提供)
     A-->>KC: UserModel(federated)
 ```
 
@@ -134,27 +174,46 @@ sequenceDiagram
 
 ---
 
-## 4. 招待受諾(テナントへの参加, Flow A)
+## 4. 招待(発行 → 受諾)
 
-`GET /api/invitations/{token}` で内容表示 → `POST` で受諾。新規ユーザーは会員登録プリミティブを共有し、テナント紐付け + トークン消費を原子化する(ADR-0040 §3.5、#831)。
+Tenant Admin が招待を**発行**(`InviteUserUseCase`)し、招待された利用者が**受諾**する(`AcceptInvitationUseCase`)。受諾は会員登録プリミティブを共有し、テナント紐付け + トークン消費を原子化する(ADR-0040 §3.5・ADR-0017、#831)。
 
 ```mermaid
 sequenceDiagram
     autonumber
+    actor Adm as Tenant Admin
     actor U as 招待された User
-    participant SPA as SPA (invitation.html)
-    participant API as webapi
+    participant SPA as SPA
+    box webapi
+        participant API as Invite/AcceptInvitation/RegisterMember
+    end
+    participant SES as SES / メール
+    box Keycloak
+        participant KC as Keycloak Admin API
+    end
     participant DB as app RDS
-    participant KC as Keycloak Admin API
 
+    Note over Adm,DB: 発行(InviteUserUseCase、要 ROLE_TENANT_ADMIN)
+    Adm->>SPA: メンバー招待(email, role)
+    SPA->>API: POST /api/tenant/users/invite {email, role} (X-Tenant-Id)
+    API->>DB: isAlreadyMember(tenantId, email)?  (既メンバーなら 409)
+    API->>DB: revokePending(既存 PENDING を REVOKED)
+    API->>DB: INSERT invitations(token_hash, tenant_id, email, role, TTL 7d, PENDING)
+    API->>SES: 招待メール送信(invitation.html?token)
+    API-->>SPA: 204
+    SES-->>U: 招待メール
+
+    Note over U,DB: 受諾(AcceptInvitationUseCase)
     U->>SPA: 招待リンク → invitation.html?token
     SPA->>API: GET /api/invitations/{token}(非消費)
     API-->>SPA: 招待内容(テナント名 / email)
     U->>SPA: 氏名 / パスワード入力 → 参加
     SPA->>API: POST /api/invitations/{token}/accept
-    API->>API: AcceptInvitationUseCase
     API->>DB: RegisterMemberUseCase.register → UserRegistrationPort.upsertPendingMember(users)
-    API->>KC: provisionCredential(...)(→ 図2 と同じ Keycloak 経路)
+    rect rgb(238,238,238)
+        Note over API,KC: provisionCredential(...) — Keycloak Admin API 群(図2 の ①〜④ と同じ)
+        API->>KC: token → find-or-create → reset-password → emailVerified
+    end
     API->>DB: MembershipFinalizer: user_tenants 紐付け + invitation USED(原子化)
     API-->>SPA: 201
     U->>SPA: ログイン(→ 図1)。所属テナントありのため dashboard へ。
@@ -164,6 +223,6 @@ sequenceDiagram
 
 ## 参考
 
-- [ADR-0006](../adr/0006-keycloak-user-storage-spi.md) / [ADR-0040](../adr/0040-onboarding-registration-and-credential-provisioning.md) / [ADR-0041](../adr/0041-post-deploy-dev-e2e-and-email-verification.md)
-- 実装: `security/adapter/web/TasksJwtAuthenticationConverter` / `security/usecase/OidcSubCorrelationService` / `tenant/adapter/web/SignupController` / `user/usecase/RegisterMemberUseCase` / `user/adapter/external/KeycloakAdminCredentialAdapter` / `keycloak/`(SPI)
+- [ADR-0006](../adr/0006-keycloak-user-storage-spi.md) / [ADR-0040](../adr/0040-onboarding-registration-and-credential-provisioning.md) / [ADR-0017](../adr/0017-invitation-and-credential-recovery-flows.md) / [ADR-0041](../adr/0041-post-deploy-dev-e2e-and-email-verification.md)
+- 実装: `security/adapter/web/TasksJwtAuthenticationConverter` / `security/adapter/web/TenantContextFilter` / `security/usecase/OidcSubCorrelationService` / `tenant/adapter/web/{SignupController,InvitationController,TenantMemberController}` / `tenant/usecase/{InviteUserUseCase,AcceptInvitationUseCase}` / `user/usecase/RegisterMemberUseCase` / `user/adapter/external/KeycloakAdminCredentialAdapter` / `keycloak/`(SPI)
 - dev 配線の詳細(SPI_DB_*、SSM、DB ユーザー、component 追加手順)は `infra/environments/dev/rds.tf` と ADR-0006/0040。

--- a/docs/architecture/keycloak-integration-sequences.md
+++ b/docs/architecture/keycloak-integration-sequences.md
@@ -125,7 +125,7 @@ sequenceDiagram
         API->>KC: ② GET /users?email=&exact=true
         KC->>SPI: searchForUser(email) → 直前 upsert した行を federation(図3)
         KC-->>API: federated user id (f:comp:id)
-        Note over API,KC: 見つからなければ POST /users で作成(find-or-create、SPI 未活性環境向け)
+        Note over API,KC: 見つからなければ POST /users で作成(find-or-create の防御分岐。SPI 有効時は upsert 済み行が federation されるため通常は発火しない)
         API->>KC: ③ PUT /users/{id}/reset-password(パスワード設定)
         API->>KC: ④ PUT /users/{id}(emailVerified=true)
     end

--- a/docs/architecture/keycloak-integration-sequences.md
+++ b/docs/architecture/keycloak-integration-sequences.md
@@ -200,7 +200,7 @@ sequenceDiagram
     API->>DB: revokePending(既存 PENDING を REVOKED)
     API->>DB: INSERT invitations(token_hash, tenant_id, email, role, TTL 7d, PENDING)
     API->>SES: 招待メール送信(invitation.html?token)
-    API-->>SPA: 204
+    API-->>SPA: 201(招待作成・メール送信)
     SES-->>U: 招待メール
 
     Note over U,DB: 受諾(AcceptInvitationUseCase)

--- a/docs/architecture/keycloak-integration-sequences.md
+++ b/docs/architecture/keycloak-integration-sequences.md
@@ -1,0 +1,169 @@
+# Keycloak 連携機能 シーケンス図
+
+Keycloak と連携する主要フローの実装シーケンス。関連 ADR: [ADR-0006](../adr/0006-keycloak-user-storage-spi.md)(User Storage SPI federation)/ [ADR-0040](../adr/0040-onboarding-registration-and-credential-provisioning.md)(オンボーディング + credential provisioning)/ [ADR-0041](../adr/0041-post-deploy-dev-e2e-and-email-verification.md)(dev E2E)。
+
+前提となる識別モデル(#862 で全環境に配線):
+
+- **app `users` テーブルが SoT**。Keycloak は **User Storage SPI**(`tasks-webapi-user-storage`)で `users` を read-only federation する(接続は read-only DB ユーザー `keycloak_spi_read`)。
+- **credential(パスワード)は Keycloak が SoT**(ADR-0006 §3.3)。SPI は `CredentialInputValidator` を実装せず、資格情報は Keycloak native store が持つ。
+- federated ユーザーの JWT `sub` は `f:<component-id>:<users.id>` 形式。プロフィール(`firstName`/`lastName`/`email` 等)は SPI が `users.full_name`/`email` から供給する。
+- dev/local のシード4ユーザーは realm-export のローカルユーザーとして共存し、ログインでローカルが優先(shadow)される。
+
+---
+
+## 1. ログイン → JWT 認証 → oidc_sub correlation → ロール解決
+
+SPA が Keycloak で OIDC 認証(PKCE)し、取得した JWT を webapi に提示。webapi は `sub` から app ユーザーを解決し、権限を確定する。
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor U as User (Browser)
+    participant SPA as SPA (web)
+    participant KC as Keycloak (auth-<env>)
+    participant SPI as User Storage SPI
+    participant DB as app RDS (users)
+    participant API as webapi
+    participant JAC as TasksJwtAuthenticationConverter
+    participant COR as OidcSubCorrelationService
+
+    U->>SPA: アクセス
+    SPA->>KC: OIDC Authorization Code + PKCE
+    KC->>SPI: getUserByUsername/Email(email)
+    SPI->>DB: SELECT ... FROM users WHERE email=?
+    DB-->>SPI: users 行
+    SPI-->>KC: UserModel(federated, credentials=KC native)
+    KC->>KC: パスワード検証(native store)
+    KC-->>SPA: ID/Access Token (sub, email)
+    SPA->>API: REST + Bearer JWT (X-Tenant-Id)
+    API->>JAC: convert(jwt)
+    JAC->>COR: resolve(sub, email)
+    alt findByOidcSub(sub) ヒット
+        COR-->>JAC: users 行(correlation 済)
+    else 未ヒット & email が pending 行に一致
+        COR->>DB: UPDATE users SET oidc_sub=sub WHERE email=? (pending)
+        COR-->>JAC: users 行(初回 correlation)
+    end
+    JAC->>DB: app_admin_users に sub 存在?
+    DB-->>JAC: (存在すれば ROLE_APP_ADMIN)
+    Note over API: テナント別ロール(TENANT_ADMIN/MEMBER)は<br/>X-Tenant-Id + user_tenants から TenantContext で解決
+    JAC-->>API: TasksAuthenticationToken(principal, authorities)
+    API-->>SPA: 認可済みレスポンス
+```
+
+`isAnonymized()` / `isInactive()` の場合は認証を拒否する(`UserAnonymizedException` / `UserInactiveException`)。
+
+---
+
+## 2. 会員登録(セルフサインアップ, double opt-in)
+
+`POST /api/signup/request` → 確認メール → `POST /api/signup/{token}/complete` で users 行 upsert + Keycloak credential provisioning。登録直後はテナント未所属(ADR-0040 §3.5)。
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor U as User
+    participant SPA as SPA (signup.html)
+    participant API as webapi
+    participant DB as app RDS
+    participant SES as SES / メール
+    participant KC as Keycloak Admin API
+    participant SPI as User Storage SPI
+
+    U->>SPA: メール入力 → 登録
+    SPA->>API: POST /api/signup/request {email}
+    API->>DB: INSERT signup_requests(PENDING, token_hash)
+    API->>SES: 確認メール送信(署名リンク: signup-complete.html?token)
+    API-->>SPA: 202(列挙耐性: 常に同一応答)
+    SES-->>U: 確認メール
+    U->>SPA: 確認リンク → signup-complete.html
+    SPA->>API: GET /api/signup/{token}(非消費・email エコー)
+    U->>SPA: 氏名 / パスワード入力 → 完了
+    SPA->>API: POST /api/signup/{token}/complete
+    API->>API: CompleteSignupUseCase(token 検証)
+    API->>DB: upsertPendingMember: INSERT users(oidc_sub="pending:email", full_name,...)
+    API->>KC: provisionCredential(email, fullName, password)
+    Note over API,KC: KeycloakAdminCredentialAdapter<br/>client_credentials(tasks-webapi-admin)
+    API->>KC: GET /admin/realms/tasks/users?email=&exact=true
+    KC->>SPI: searchForUser(email)
+    SPI->>DB: SELECT ... users WHERE email=?
+    DB-->>SPI: 直前に upsert した行
+    SPI-->>KC: federated user (f:<comp>:<id>)
+    KC-->>API: user id
+    Note over API,KC: 見つからなければ POST /users で<br/>ローカル作成(SPI 未活性環境向け find-or-create)
+    API->>KC: PUT /users/{id}/reset-password(パスワード)
+    API->>KC: PUT /users/{id}(emailVerified=true)
+    API->>DB: signup_requests → USED
+    API-->>SPA: 201(登録完了)
+    U->>SPA: 作成ユーザーでログイン(→ 図1)
+    Note over U,SPA: 初回ログインで oidc_sub を pending → 実 sub に correlation。<br/>テナント未所属のため「テナント作成」導線へ着地。
+```
+
+Keycloak 失敗時は signup トークンを消費しない(再試行で回復、ADR-0040 §3.5)。列挙耐性のためメール送信失敗は握りつぶす。
+
+---
+
+## 3. User Storage SPI federation(Keycloak → app users 読取経路)
+
+Keycloak が federated ユーザーを解決する内部経路。`keycloak_spi_read`(SELECT のみ)で app `users` に JDBC 接続する。
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant KC as Keycloak core
+    participant F as ...ProviderFactory
+    participant P as ...UserStorageProvider
+    participant R as UserRepository (JDBC)
+    participant DB as app RDS (users)
+    participant A as UserAdapter
+
+    KC->>F: create(session, component)
+    Note over F: 接続情報を component config →<br/>env(SPI_DB_JDBC_URL/USERNAME/PASSWORD)で解決
+    F->>R: new UserRepository(jdbcUrl, keycloak_spi_read, pw)
+    KC->>P: getUserByEmail / searchForUser
+    P->>R: findByEmail / search
+    R->>DB: SELECT ... FROM users WHERE ... (DriverManager)
+    DB-->>R: UserRow
+    R-->>P: UserRow
+    P->>A: adapt(row)
+    Note over A: full_name → firstName & lastName(必須項目)<br/>status ACTIVE → enabled / emailVerified=true<br/>credential は KC native(SPI は非提供)
+    A-->>KC: UserModel(federated)
+```
+
+`priority=0` / `cachePolicy=NO_CACHE`。realm への component 登録は realm-export に含む(CI/local は fresh import で有効)が、deployed は `--import-realm` IGNORE_EXISTING のため Admin API で登録する。
+
+---
+
+## 4. 招待受諾(テナントへの参加, Flow A)
+
+`GET /api/invitations/{token}` で内容表示 → `POST` で受諾。新規ユーザーは会員登録プリミティブを共有し、テナント紐付け + トークン消費を原子化する(ADR-0040 §3.5、#831)。
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor U as 招待された User
+    participant SPA as SPA (invitation.html)
+    participant API as webapi
+    participant DB as app RDS
+    participant KC as Keycloak Admin API
+
+    U->>SPA: 招待リンク → invitation.html?token
+    SPA->>API: GET /api/invitations/{token}(非消費)
+    API-->>SPA: 招待内容(テナント名 / email)
+    U->>SPA: 氏名 / パスワード入力 → 参加
+    SPA->>API: POST /api/invitations/{token}/accept
+    API->>API: AcceptInvitationUseCase
+    API->>DB: RegisterMemberUseCase.upsertPendingMember(users)
+    API->>KC: provisionCredential(...)(→ 図2 と同じ Keycloak 経路)
+    API->>DB: MembershipFinalizer: user_tenants 紐付け + invitation USED(原子化)
+    API-->>SPA: 201
+    U->>SPA: ログイン(→ 図1)。所属テナントありのため dashboard へ。
+```
+
+---
+
+## 参考
+
+- [ADR-0006](../adr/0006-keycloak-user-storage-spi.md) / [ADR-0040](../adr/0040-onboarding-registration-and-credential-provisioning.md) / [ADR-0041](../adr/0041-post-deploy-dev-e2e-and-email-verification.md)
+- 実装: `security/adapter/web/TasksJwtAuthenticationConverter` / `security/usecase/OidcSubCorrelationService` / `tenant/adapter/web/SignupController` / `user/usecase/RegisterMemberUseCase` / `user/adapter/external/KeycloakAdminCredentialAdapter` / `keycloak/`(SPI)
+- dev 配線の詳細(SPI_DB_*、SSM、DB ユーザー、component 追加手順)は `infra/environments/dev/rds.tf` と ADR-0006/0040。


### PR DESCRIPTION
## 概要

Keycloak と連携する主要フローの実装シーケンスを mermaid で追加(ご依頼)。SPI federation 配線完了(#862)後の実態(app users を SoT とする federation)に沿う。

- **図1** ログイン → JWT 認証(`TasksJwtAuthenticationConverter`)→ `OidcSubCorrelationService` の oidc_sub correlation → APP_ADMIN / テナントロール解決
- **図2** 会員登録 double opt-in(`SignupController` → `CompleteSignupUseCase` → users upsert + `KeycloakAdminCredentialAdapter` の credential provisioning → 初回ログイン correlation)
- **図3** User Storage SPI federation の読取経路(Keycloak → `keycloak_spi_read` JDBC → app `users` → `UserAdapter`)
- **図4** 招待受諾(Flow A)

配置: `docs/architecture/keycloak-integration-sequences.md`。ADR-0006/0040/0041 + 実クラスへリンク。markdownlint 済。

Refs #862

🤖 Generated with [Claude Code](https://claude.com/claude-code)